### PR TITLE
Restore relay work for draft-18 and port missing session layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1271,7 +1271,7 @@ dependencies = [
 
 [[package]]
 name = "moq-clock-ietf"
-version = "0.6.18"
+version = "0.6.20"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "moq-native-ietf"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "moq-pub"
-version = "0.9.1"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1329,7 +1329,7 @@ dependencies = [
 
 [[package]]
 name = "moq-relay-ietf"
-version = "0.7.18"
+version = "0.7.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1358,7 +1358,7 @@ dependencies = [
 
 [[package]]
 name = "moq-sub"
-version = "0.4.12"
+version = "0.4.14"
 dependencies = [
  "anyhow",
  "clap",
@@ -1375,7 +1375,7 @@ dependencies = [
 
 [[package]]
 name = "moq-test-client"
-version = "0.1.10"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "bytes",

--- a/moq-clock-ietf/CHANGELOG.md
+++ b/moq-clock-ietf/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.20](https://github.com/cloudflare/moq-rs/compare/moq-clock-ietf-v0.6.19...moq-clock-ietf-v0.6.20) - 2026-07-31
+
+### Fixed
+
+- send log output to stderr instead of stdout
+
+## [0.6.19](https://github.com/cloudflare/moq-rs/compare/moq-clock-ietf-v0.6.18...moq-clock-ietf-v0.6.19) - 2026-07-20
+
+### Other
+
+- updated the following local packages: moq-native-ietf
+
 ## [0.6.18](https://github.com/cloudflare/moq-rs/compare/moq-clock-ietf-v0.6.17...moq-clock-ietf-v0.6.18) - 2026-07-19
 
 ### Other

--- a/moq-clock-ietf/Cargo.toml
+++ b/moq-clock-ietf/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/englishm/moq-rs"
 license = "MIT OR Apache-2.0"
 
-version = "0.6.18"
+version = "0.6.20"
 edition = "2021"
 
 keywords = ["quic", "http3", "webtransport", "media", "live"]
@@ -17,7 +17,7 @@ categories = ["multimedia", "network-programming", "web-programming"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-moq-native-ietf = { path = "../moq-native-ietf", version = "0.9" }
+moq-native-ietf = { path = "../moq-native-ietf", version = "0.10" }
 moq-transport = { path = "../moq-transport", version = "0.16" }
 
 # QUIC

--- a/moq-clock-ietf/src/main.rs
+++ b/moq-clock-ietf/src/main.rs
@@ -22,7 +22,11 @@ use moq_transport::{
 async fn main() -> anyhow::Result<()> {
     // Initialize tracing with env filter (respects RUST_LOG environment variable)
     // Default to info level, but suppress quinn's verbose output
+    //
+    // Logs go to stderr so they stay separate from the clock values this
+    // binary prints to stdout.
     tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info,quinn=warn")),

--- a/moq-native-ietf/CHANGELOG.md
+++ b/moq-native-ietf/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/cloudflare/moq-rs/compare/moq-native-ietf-v0.9.3...moq-native-ietf-v0.10.0) - 2026-07-20
+
+### Added
+
+- forward local accept IP to the connection tagger
+
 ## [0.9.3](https://github.com/cloudflare/moq-rs/compare/moq-native-ietf-v0.9.2...moq-native-ietf-v0.9.3) - 2026-07-19
 
 ### Added

--- a/moq-native-ietf/Cargo.toml
+++ b/moq-native-ietf/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/englishm/moq-rs"
 license = "MIT OR Apache-2.0"
 
-version = "0.9.3"
+version = "0.10.0"
 edition = "2021"
 
 keywords = ["quic", "http3", "webtransport", "media", "live"]

--- a/moq-native-ietf/src/quic.rs
+++ b/moq-native-ietf/src/quic.rs
@@ -386,6 +386,17 @@ pub struct ConnInfo {
     /// Peer socket address.
     pub remote_address: net::SocketAddr,
 
+    /// Local IP the peer connected to: the destination IP the peer's packets
+    /// targeted (the port is always our fixed listening port, so it is omitted).
+    ///
+    /// On a wildcard bind (`0.0.0.0` / `[::]`) this identifies which local
+    /// address/interface (e.g. an anycast VIP) actually received the
+    /// connection — something neither [`remote_address`](Self::remote_address)
+    /// nor the wildcard [`Server::local_addr`] can tell you. `None` when the
+    /// platform does not expose the destination address (see
+    /// `quinn::Connection::local_ip`).
+    pub local_ip: Option<IpAddr>,
+
     /// TLS SNI server name sent by the peer, if any.
     pub server_name: Option<String>,
 }
@@ -490,11 +501,17 @@ impl Server {
         // the connection interface (public client vs internal relay peer).
         let remote_address = conn.remote_address();
 
+        // The destination IP the peer targeted, which differs from the wildcard
+        // bind address on multi-homed / anycast hosts. `None` if the platform
+        // does not expose it.
+        let local_ip = conn.local_ip();
+
         tracing::debug!(
-            "established QUIC connection: cid={} stable_id={} ip={} alpn={} server={}",
+            "established QUIC connection: cid={} stable_id={} ip={} local_ip={:?} alpn={} server={}",
             connection_id_hex,
             conn.stable_id(),
             remote_address,
+            local_ip,
             alpn,
             server_name,
         );
@@ -506,8 +523,9 @@ impl Server {
                 .await
                 .context("failed to receive WebTransport request")?;
 
-            // Negotiate the MoQT version from the clients offered protocols.
-            // Reject if no mutually-supported version exists.
+            // Negotiate the MoQT version from the client's offered protocols. Rejecting here
+            // rather than accepting without a protocol keeps a non-MoQT WebTransport client
+            // from getting a successful CONNECT only to fail later at MoQT SETUP.
             let selected = moq_transport::setup::negotiate_version(&request.protocols)
                 .context("no mutually supported MoQT version in WT-Available-Protocols")?;
             let response =
@@ -539,6 +557,7 @@ impl Server {
             id: connection_id_hex,
             transport,
             remote_address,
+            local_ip,
             // An empty SNI means the peer sent no server name.
             server_name: (!server_name.is_empty()).then_some(server_name),
         };
@@ -651,7 +670,8 @@ impl Client {
 
         let (session, transport) = match url.scheme() {
             "https" => {
-                // Offer all supported MoQT versions via WT-Available-Protocols.
+                // Offer all supported MoQT versions via WT-Available-Protocols so the server
+                // can pick by its own preference order.
                 let mut request = web_transport_quinn::proto::ConnectRequest::new(url.clone());
                 for alpn in moq_transport::setup::SUPPORTED_ALPNS {
                     request = request.with_protocol(alpn.to_string());

--- a/moq-pub/CHANGELOG.md
+++ b/moq-pub/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.3](https://github.com/cloudflare/moq-rs/compare/moq-pub-v0.9.2...moq-pub-v0.9.3) - 2026-07-31
+
+### Fixed
+
+- send log output to stderr instead of stdout
+
+## [0.9.2](https://github.com/cloudflare/moq-rs/compare/moq-pub-v0.9.1...moq-pub-v0.9.2) - 2026-07-20
+
+### Other
+
+- updated the following local packages: moq-native-ietf
+
 ## [0.9.1](https://github.com/cloudflare/moq-rs/compare/moq-pub-v0.9.0...moq-pub-v0.9.1) - 2026-07-19
 
 ### Other

--- a/moq-pub/Cargo.toml
+++ b/moq-pub/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["moq-rs contributors"]
 repository = "https://github.com/cloudflare/moq-rs"
 license = "MIT OR Apache-2.0"
 
-version = "0.9.1"
+version = "0.9.3"
 edition = "2021"
 
 keywords = ["quic", "http3", "webtransport", "media", "live"]
@@ -18,7 +18,7 @@ categories = ["multimedia", "network-programming", "web-programming"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-moq-native-ietf = { path = "../moq-native-ietf", version = "0.9" }
+moq-native-ietf = { path = "../moq-native-ietf", version = "0.10" }
 moq-transport = { path = "../moq-transport", version = "0.16" }
 moq-catalog = { path = "../moq-catalog", version = "0.2" }
 

--- a/moq-pub/src/main.rs
+++ b/moq-pub/src/main.rs
@@ -9,10 +9,16 @@ use url::Url;
 use anyhow::Context;
 use clap::Parser;
 use tokio::io::AsyncReadExt;
+use tokio::sync::mpsc;
+use tokio::task::JoinSet;
 
 use moq_native_ietf::quic;
 use moq_pub::Media;
-use moq_transport::{coding::TrackNamespace, serve, session::Publisher};
+use moq_transport::{
+    coding::{KeyValuePairs, TrackName, TrackNamespace},
+    serve,
+    session::Publisher,
+};
 
 #[derive(Parser, Clone)]
 pub struct Cli {
@@ -41,13 +47,20 @@ pub struct Cli {
     /// The TLS configuration.
     #[command(flatten)]
     pub tls: moq_native_ietf::tls::Args,
+
+    /// Push tracks with PUBLISH after sending PUBLISH_NAMESPACE.
+    #[arg(long)]
+    pub publish: bool,
 }
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     // Initialize tracing with env filter (respects RUST_LOG environment variable)
     // Default to info level, but suppress quinn's verbose output
+    //
+    // Logs go to stderr, per convention and to keep stdout clean.
     tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info,quinn=warn")),
@@ -58,7 +71,14 @@ async fn main() -> anyhow::Result<()> {
 
     let (writer, _, reader) =
         serve::Tracks::new(TrackNamespace::from_utf8_path(&cli.name)).produce();
-    let media = Media::new(writer)?;
+
+    let (track_tx, track_rx) = if cli.publish {
+        let (tx, rx) = mpsc::unbounded_channel();
+        (Some(tx), Some(rx))
+    } else {
+        (None, None)
+    };
+    let media = Media::new(writer, track_tx)?;
 
     let tls = cli.tls.load()?;
 
@@ -76,19 +96,92 @@ async fn main() -> anyhow::Result<()> {
         connection_id
     );
 
-    let (session, mut publisher) = Publisher::connect(session, transport)
+    let (session, publisher) = Publisher::connect(session, transport)
         .await
         .context("failed to create MoQ Transport publisher")?;
+
+    let mut namespace_publisher = publisher.clone();
+    let publish_publisher = publisher;
+    let namespace_reader = reader.clone();
+    let publish_reader = reader.clone();
 
     tokio::select! {
         res = session.run() => res.context("session error")?,
         res = run_media(media) => {
             res.context("media error")?
         },
-        res = publisher.publish_namespace(reader) => res.context("publisher error")?,
+        res = namespace_publisher.publish_namespace(namespace_reader) => res.context("publisher error")?,
+        res = async {
+            if let Some(track_rx) = track_rx {
+                publish_created_tracks(publish_publisher, publish_reader, track_rx).await?;
+            }
+            Ok::<_, anyhow::Error>(())
+        }, if cli.publish => res.context("publish tracks error")?,
     }
 
     Ok(())
+}
+
+async fn publish_created_tracks(
+    mut publisher: Publisher,
+    mut tracks: serve::TracksReader,
+    mut track_rx: mpsc::UnboundedReceiver<TrackName>,
+) -> anyhow::Result<()> {
+    let mut tasks = JoinSet::new();
+
+    loop {
+        tokio::select! {
+            Some(track_name) = track_rx.recv() => {
+                let namespace = tracks.namespace.clone();
+                let Some(track) = tracks.get_track_reader(&namespace, track_name.clone()) else {
+                    tracing::warn!(namespace = %namespace, track = %track_name, "created track was not found in TracksReader");
+                    continue;
+                };
+
+                tracing::info!(namespace = %namespace, track = %track_name, "sending PUBLISH for track");
+                let published = publisher
+                    .publish(track, KeyValuePairs::default())
+                    .await
+                    .with_context(|| format!("failed to send PUBLISH for track {}/{}", namespace, track_name))?;
+
+                tasks.spawn(async move {
+                    published
+                        .serve()
+                        .await
+                        .context("failed serving PUBLISH track")
+                });
+            },
+            Some(res) = tasks.join_next(), if !tasks.is_empty() => {
+                res.context("PUBLISH track task panicked")??;
+            },
+            else => return Ok(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn publish_flag_defaults_false() {
+        let cli = Cli::try_parse_from(["moq-pub", "https://example.com/watch", "--name", "test"])
+            .unwrap();
+        assert!(!cli.publish);
+    }
+
+    #[test]
+    fn publish_flag_sets_true() {
+        let cli = Cli::try_parse_from([
+            "moq-pub",
+            "https://example.com/watch",
+            "--name",
+            "test",
+            "--publish",
+        ])
+        .unwrap();
+        assert!(cli.publish);
+    }
 }
 
 async fn run_media(mut media: Media) -> anyhow::Result<()> {

--- a/moq-pub/src/media.rs
+++ b/moq-pub/src/media.rs
@@ -4,12 +4,16 @@
 
 use anyhow::{self, Context};
 use bytes::{Buf, BufMut, Bytes, BytesMut};
-use moq_transport::serve::{SubgroupWriter, SubgroupsWriter, TrackWriter, TracksWriter};
+use moq_transport::{
+    coding::TrackName,
+    serve::{SubgroupWriter, SubgroupsWriter, TrackWriter, TracksWriter},
+};
 use mp4::{self, ReadBox, TrackType};
 use std::cmp::max;
 use std::collections::HashMap;
 use std::io::Cursor;
 use std::time;
+use tokio::sync::mpsc;
 
 pub struct Media {
     // Tracks based on their track ID.
@@ -28,10 +32,16 @@ pub struct Media {
 
     // The current track name
     current: Option<u32>,
+
+    // Optional notification for tracks as they become available.
+    track_tx: Option<mpsc::UnboundedSender<TrackName>>,
 }
 
 impl Media {
-    pub fn new(mut broadcast: TracksWriter) -> anyhow::Result<Self> {
+    pub fn new(
+        mut broadcast: TracksWriter,
+        track_tx: Option<mpsc::UnboundedSender<TrackName>>,
+    ) -> anyhow::Result<Self> {
         let catalog = broadcast
             .create(".catalog")
             .context("broadcast closed")?
@@ -41,6 +51,11 @@ impl Media {
             .context("broadcast closed")?
             .subgroups()?;
 
+        if let Some(tx) = &track_tx {
+            let _ = tx.send(TrackName::from(".catalog"));
+            let _ = tx.send(TrackName::from("0.mp4"));
+        }
+
         Ok(Media {
             tracks: Default::default(),
             broadcast,
@@ -49,6 +64,7 @@ impl Media {
             ftyp: None,
             moov: None,
             current: None,
+            track_tx,
         })
     }
 
@@ -251,6 +267,9 @@ impl Media {
 
             // Store the track publisher in a map so we can update it later.
             let track = self.broadcast.create(&name).context("broadcast closed")?;
+            if let Some(tx) = &self.track_tx {
+                let _ = tx.send(TrackName::from(name.clone()));
+            }
             let track = Track::new(track, handler, timescale);
             self.tracks.insert(id, track);
         }

--- a/moq-relay-ietf/CHANGELOG.md
+++ b/moq-relay-ietf/CHANGELOG.md
@@ -6,6 +6,107 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.25](https://github.com/cloudflare/moq-rs/compare/moq-relay-ietf-v0.7.24...moq-relay-ietf-v0.7.25) - 2026-07-31
+
+### Added
+
+- add metrics for lock poisoning and broadcast lag
+
+### Fixed
+
+- decide upstream wait outcome by branch, not error variant
+- label cancelled subscribes distinctly from upstream failures
+- wait for upstream subscription before sending SUBSCRIBE_OK
+- release upstream subscriptions for idle cached tracks
+- send log output to stderr instead of stdout
+
+### Other
+
+- stream namespace paths into the formatter
+
+## [0.7.24](https://github.com/cloudflare/moq-rs/compare/moq-relay-ietf-v0.7.23...moq-relay-ietf-v0.7.24) - 2026-07-20
+
+### Added
+
+- forward local accept IP to the connection tagger
+
+## [0.7.23](https://github.com/cloudflare/moq-rs/compare/moq-relay-ietf-v0.7.22...moq-relay-ietf-v0.7.23) - 2026-07-19
+
+### Added
+
+- *(moq-relay-ietf)* coalesce upstream subscribe-namespace prefixes
+- *(moq-relay-ietf)* track local and remote namespace sources
+- *(moq-relay-ietf)* pull upstream namespaces for subscribe_namespace
+- *(moq-relay-ietf)* return no upstream relays for internal subscribe_namespace
+- *(moq-relay-ietf)* return upstream relays from coordinator subscribe_namespace
+- *(moq-relay-ietf)* fan out publish namespaces to subscribers
+- *(moq-relay-ietf)* make relay-to-relay sessions full bidirectional peers
+- *(moq-relay-ietf)* pass connection interface and peer source to coordinator
+- *(moq-relay-ietf)* classify inbound connections as public or internal
+
+### Fixed
+
+- *(moq-relay-ietf)* isolate best-effort namespace fan-out failures
+- *(moq-relay-ietf)* share reserved reader for concurrent pull-through requests
+
+### Other
+
+- *(moq-relay-ietf)* align subscribe-namespace connection bindings
+- *(moq-relay-ietf)* build resync_publish_tracks set in one pass
+- *(moq-relay-ietf)* read-mostly RwLock for track and namespace registries
+- *(moq-relay-ietf)* name namespace/track broadcast channel capacities
+- *(moq-relay-ietf)* prune and match tracks in a single locked pass
+- *(moq-relay-ietf)* serve subscribe-namespace from local state only
+- *(moq-relay-ietf)* cover cross-relay subscribe-namespace choreography
+- honor subscribe namespace prefixes
+- register namespace subscription interest
+- persist file coordinator namespace interest
+- return file coordinator namespace matches
+- filter namespace fanout to published tracks
+- fan out publish tracks for namespace subscriptions
+- serve namespace subscriptions
+- track namespace changes in locals
+
+## [0.7.22](https://github.com/cloudflare/moq-rs/compare/moq-relay-ietf-v0.7.21...moq-relay-ietf-v0.7.22) - 2026-07-09
+
+### Fixed
+
+- *(moq-transport)* send publish done after serve completion
+
+### Other
+
+- address PUBLISH review feedback
+- track pending request responses
+- route PUBLISH tracks by full track name
+
+## [0.7.21](https://github.com/cloudflare/moq-rs/compare/moq-relay-ietf-v0.7.20...moq-relay-ietf-v0.7.21) - 2026-07-08
+
+### Added
+
+- *(moq-relay-ietf)* expose relay session config
+
+### Other
+
+- *(moq-relay-ietf)* remove redundant session config binding
+- *(moq-relay-ietf)* remove manual changelog entry
+
+## [0.7.20](https://github.com/cloudflare/moq-rs/compare/moq-relay-ietf-v0.7.19...moq-relay-ietf-v0.7.20) - 2026-07-08
+
+### Added
+
+- route track-level PUBLISH registrations so relays can serve exact pushed tracks before falling back to namespace routing
+
+### Other
+
+- Merge pull request #170 from itzmanish/draft-16-rewrite
+- Update relay dependencies for the draft-16 transport/native stack.
+
+## [0.7.19](https://github.com/cloudflare/moq-rs/compare/moq-relay-ietf-v0.7.18...moq-relay-ietf-v0.7.19) - 2026-06-10
+
+### Other
+
+- updated the following local packages: moq-native-ietf
+
 ## [0.7.18](https://github.com/cloudflare/moq-rs/compare/moq-relay-ietf-v0.7.17...moq-relay-ietf-v0.7.18) - 2026-05-20
 
 ### Fixed

--- a/moq-relay-ietf/Cargo.toml
+++ b/moq-relay-ietf/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["moq-rs contributors"]
 repository = "https://github.com/cloudflare/moq-rs"
 license = "MIT OR Apache-2.0"
 
-version = "0.7.18"
+version = "0.7.25"
 edition = "2021"
 
 keywords = ["quic", "http3", "webtransport", "media", "live"]
@@ -24,7 +24,7 @@ path = "src/bin/moq-relay-ietf/main.rs"
 
 [dependencies]
 moq-transport = { path = "../moq-transport", version = "0.16" }
-moq-native-ietf = { path = "../moq-native-ietf", version = "0.9" }
+moq-native-ietf = { path = "../moq-native-ietf", version = "0.10" }
 moq-api = { path = "../moq-api", version = "0.2" }
 web-transport = { workspace = true }
 
@@ -69,6 +69,11 @@ thiserror = "2.0.17"
 # The metrics-prometheus feature adds the optional Prometheus exporter.
 metrics = "0.24"
 metrics-exporter-prometheus = { version = "0.16", optional = true }
+
+[dev-dependencies]
+# test-util provides the paused-clock runtime used to test idle timeouts without
+# sleeping for real.
+tokio = { version = "1", features = ["full", "test-util"] }
 
 [features]
 default = []

--- a/moq-relay-ietf/src/bin/moq-relay-ietf/api_coordinator.rs
+++ b/moq-relay-ietf/src/bin/moq-relay-ietf/api_coordinator.rs
@@ -21,7 +21,8 @@ use moq_transport::coding::TrackNamespace;
 use url::Url;
 
 use moq_relay_ietf::{
-    Coordinator, CoordinatorError, CoordinatorResult, NamespaceOrigin, NamespaceRegistration,
+    Coordinator, CoordinatorContext, CoordinatorError, CoordinatorResult, NamespaceOrigin,
+    NamespaceRegistration,
 };
 
 /// Default TTL for namespace registrations (in seconds)
@@ -214,6 +215,7 @@ impl Coordinator for ApiCoordinator {
         &self,
         scope: Option<&str>,
         namespace: &TrackNamespace,
+        _context: &CoordinatorContext,
     ) -> CoordinatorResult<NamespaceRegistration> {
         let namespace_str = Self::registry_key(scope, namespace);
         let origin = Origin {

--- a/moq-relay-ietf/src/bin/moq-relay-ietf/file_coordinator.rs
+++ b/moq-relay-ietf/src/bin/moq-relay-ietf/file_coordinator.rs
@@ -7,7 +7,7 @@
 //! namespace registration across multiple relay instances. No separate
 //! server process is required.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
@@ -16,19 +16,29 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use fs2::FileExt;
 use moq_native_ietf::quic::Client;
-use moq_transport::coding::TrackNamespace;
+use moq_transport::coding::{TrackNamespace, TrackNamespacePrefix, TupleField};
 use serde::{Deserialize, Serialize};
 use url::Url;
 
 use moq_relay_ietf::{
-    Coordinator, CoordinatorError, CoordinatorResult, NamespaceOrigin, NamespaceRegistration,
+    Coordinator, CoordinatorContext, CoordinatorError, CoordinatorResult, NamespaceOrigin,
+    NamespaceRegistration, NamespaceSubscription, RelayInfo, SessionInterface, TrackRegistration,
 };
 
 /// Data stored in the shared file
 #[derive(Debug, Default, Serialize, Deserialize)]
 struct CoordinatorData {
     /// Maps connection scope to namespace map
+    #[serde(default)]
     namespaces: HashMap<String, HashMap<String, String>>,
+    /// Maps connection scope to exact full-track map.
+    /// Key format: `<namespace utf8 byte len>:<namespace utf8 path><track utf8/lossy>`.
+    #[serde(default)]
+    tracks: HashMap<String, HashMap<String, String>>,
+    /// Maps connection scope to namespace-prefix interest map.
+    /// Inner map: prefix key -> relay URL -> reference count.
+    #[serde(default)]
+    namespace_subscribers: HashMap<String, HashMap<String, HashMap<String, u64>>>,
 }
 
 impl CoordinatorData {
@@ -37,7 +47,16 @@ impl CoordinatorData {
     }
 
     fn namespace_key(namespace: &TrackNamespace) -> String {
-        namespace.to_utf8_path()
+        tuple_key(&namespace.fields)
+    }
+
+    fn prefix_key(prefix: &TrackNamespacePrefix) -> String {
+        tuple_key(&prefix.fields)
+    }
+
+    fn track_key(namespace: &TrackNamespace, track: &str) -> String {
+        let namespace = namespace.to_utf8_path();
+        format!("{}:{}{}", namespace.len(), namespace, track)
     }
 }
 
@@ -46,6 +65,42 @@ struct NamespaceUnregisterHandle {
     scope_key: String,
     namespace_key: String,
     file_path: PathBuf,
+}
+
+/// Handle that unregisters a track when dropped.
+struct TrackUnregisterHandle {
+    scope_key: String,
+    track_key: String,
+    file_path: PathBuf,
+}
+
+/// Handle that unregisters namespace interest when dropped.
+struct NamespaceSubscriptionHandle {
+    scope_key: String,
+    prefix_key: String,
+    relay_url: String,
+    file_path: PathBuf,
+}
+
+impl Drop for NamespaceSubscriptionHandle {
+    fn drop(&mut self) {
+        if let Err(err) = unregister_namespace_subscription_sync(
+            &self.file_path,
+            &self.scope_key,
+            &self.prefix_key,
+            &self.relay_url,
+        ) {
+            tracing::warn!(prefix = %self.prefix_key, relay_url = %self.relay_url, error = %err, "failed to unregister namespace subscription on drop: {}", err);
+        }
+    }
+}
+
+impl Drop for TrackUnregisterHandle {
+    fn drop(&mut self) {
+        if let Err(err) = unregister_track_sync(&self.file_path, &self.scope_key, &self.track_key) {
+            tracing::warn!(track = %self.track_key, error = %err, "failed to unregister track on drop: {}", err);
+        }
+    }
 }
 
 impl Drop for NamespaceUnregisterHandle {
@@ -75,6 +130,73 @@ fn unregister_namespace_sync(file_path: &Path, scope_key: &str, namespace_key: &
         bucket.remove(namespace_key);
         if bucket.is_empty() {
             data.namespaces.remove(scope_key);
+        }
+    }
+
+    write_data(&file, &data)?;
+    file.unlock()?;
+
+    Ok(())
+}
+
+fn unregister_track_sync(file_path: &Path, scope_key: &str, track_key: &str) -> Result<()> {
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(file_path)?;
+
+    file.lock_exclusive()?;
+
+    let mut data = read_data(&file)?;
+    tracing::debug!(track = %track_key, scope = %scope_key, "unregistering track: {}", track_key);
+    if let Some(bucket) = data.tracks.get_mut(scope_key) {
+        bucket.remove(track_key);
+        if bucket.is_empty() {
+            data.tracks.remove(scope_key);
+        }
+    }
+
+    write_data(&file, &data)?;
+    file.unlock()?;
+
+    Ok(())
+}
+
+fn unregister_namespace_subscription_sync(
+    file_path: &Path,
+    scope_key: &str,
+    prefix_key: &str,
+    relay_url: &str,
+) -> Result<()> {
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(file_path)?;
+
+    file.lock_exclusive()?;
+
+    let mut data = read_data(&file)?;
+    if let Some(scope_bucket) = data.namespace_subscribers.get_mut(scope_key) {
+        if let Some(prefix_bucket) = scope_bucket.get_mut(prefix_key) {
+            match prefix_bucket.get_mut(relay_url) {
+                Some(count) if *count > 1 => *count -= 1,
+                Some(_) => {
+                    prefix_bucket.remove(relay_url);
+                }
+                None => {}
+            }
+
+            if prefix_bucket.is_empty() {
+                scope_bucket.remove(prefix_key);
+            }
+        }
+
+        if scope_bucket.is_empty() {
+            data.namespace_subscribers.remove(scope_key);
         }
     }
 
@@ -114,6 +236,49 @@ fn write_data(file: &File, data: &CoordinatorData) -> Result<()> {
     Ok(())
 }
 
+fn namespace_key_has_prefix(namespace_key: &str, prefix_key: &str) -> bool {
+    let namespace_fields = key_fields(namespace_key);
+    let prefix_fields = key_fields(prefix_key);
+    prefix_fields.len() <= namespace_fields.len()
+        && prefix_fields
+            .iter()
+            .zip(namespace_fields.iter())
+            .all(|(prefix, namespace)| prefix == namespace)
+}
+
+fn tuple_key(fields: &[TupleField]) -> String {
+    fields
+        .iter()
+        .map(|field| hex::encode(&field.value))
+        .collect::<Vec<_>>()
+        .join(".")
+}
+
+fn key_fields(key: &str) -> Vec<&str> {
+    if key.is_empty() {
+        Vec::new()
+    } else {
+        key.split('.').collect()
+    }
+}
+
+fn key_field_count(key: &str) -> usize {
+    key_fields(key).len()
+}
+
+fn decode_namespace_key(key: &str) -> Result<TrackNamespace> {
+    let fields = key_fields(key)
+        .into_iter()
+        .map(|field| {
+            hex::decode(field)
+                .map(|value| TupleField { value })
+                .context("failed to decode namespace key field")
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    TrackNamespace::try_from(fields).context("failed to decode namespace key")
+}
+
 /// A coordinator that uses a shared file for state storage.
 ///
 /// Multiple relay instances can use the same file to share namespace/track
@@ -145,6 +310,7 @@ impl Coordinator for FileCoordinator {
         &self,
         scope: Option<&str>,
         namespace: &TrackNamespace,
+        _context: &CoordinatorContext,
     ) -> CoordinatorResult<NamespaceRegistration> {
         let scope_key = CoordinatorData::scope_key(scope);
         let namespace_key = CoordinatorData::namespace_key(namespace);
@@ -246,14 +412,11 @@ impl Coordinator for FileCoordinator {
                 // Try prefix matching (find longest matching prefix)
                 let mut best_match: Option<(String, String)> = None;
                 for (registered_key, url) in bucket {
-                    // FIXME(itzmanish): it would be much better to compare on TupleField
-                    // instead of working on strings
-                    let is_prefix = registered_key
-                        .split('/')
-                        .zip(namespace_key.split('/'))
-                        .all(|(a, b)| a == b);
+                    let is_prefix = namespace_key_has_prefix(&namespace_key, registered_key);
                     match best_match {
-                        Some((ns, _)) if is_prefix && ns.len() < registered_key.len() => {
+                        Some((ns, _))
+                            if is_prefix && key_field_count(&ns) < key_field_count(registered_key) =>
+                        {
                             best_match = Some((registered_key.clone(), url.clone()));
                         }
                         None if is_prefix => {
@@ -266,7 +429,297 @@ impl Coordinator for FileCoordinator {
                 file.unlock()?;
 
                 if let Some((matched_key, relay_url)) = best_match {
-                    let matched_ns = TrackNamespace::from_utf8_path(&matched_key);
+                    let matched_ns = decode_namespace_key(&matched_key)?;
+                    let url = Url::parse(&relay_url)?;
+                    return Ok(Some((NamespaceOrigin::new(matched_ns, url, None), None)));
+                }
+
+                Ok(None)
+            },
+        )
+        .await??;
+
+        result.ok_or(CoordinatorError::NamespaceNotFound)
+    }
+
+    async fn subscribe_namespace(
+        &self,
+        scope: Option<&str>,
+        prefix: &TrackNamespacePrefix,
+        context: &CoordinatorContext,
+    ) -> CoordinatorResult<NamespaceSubscription> {
+        let scope_key = CoordinatorData::scope_key(scope);
+        let prefix_key = CoordinatorData::prefix_key(prefix);
+        let relay_url = self.relay_url.to_string();
+        let file_path = self.file_path.clone();
+
+        // Exclude the caller (this relay) and the inbound source peer so we
+        // never return ourselves or the relay the SUBSCRIBE_NAMESPACE arrived
+        // from as an upstream pull target. The caller string matches the value
+        // format written by register_namespace (self.relay_url.to_string()).
+        let caller = relay_url.clone();
+        let source = context.source.as_ref().map(|relay| relay.url.to_string());
+        let is_public = context.interface == SessionInterface::Public;
+
+        let upstream_relays = tokio::task::spawn_blocking({
+            let scope_key = scope_key.clone();
+            let prefix_key = prefix_key.clone();
+            let relay_url = relay_url.clone();
+            move || -> Result<Vec<RelayInfo>> {
+                let file = OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .create(true)
+                    .truncate(false)
+                    .open(&file_path)?;
+
+                file.lock_exclusive()?;
+
+                let mut data = read_data(&file)?;
+
+                // The distinct relays hosting a currently-matching namespace are
+                // the upstream pull targets. Only public sessions fan out: an
+                // internal (relay-to-relay) pull must not recurse, so it is
+                // served from local state alone (empty upstream_relays breaks the
+                // loop). Exclude ourselves and the inbound source peer so we
+                // never pull from the caller or the relay the SUBSCRIBE_NAMESPACE
+                // arrived from. Interest is still recorded below for the push
+                // path regardless of interface.
+                let mut upstream_relays = Vec::new();
+                if is_public {
+                    let mut seen_relays = HashSet::new();
+                    if let Some(bucket) = data.namespaces.get(&scope_key) {
+                        for (namespace_key, hosting_relay) in bucket {
+                            if !namespace_key_has_prefix(namespace_key, &prefix_key) {
+                                continue;
+                            }
+                            if hosting_relay == &caller || Some(hosting_relay) == source.as_ref() {
+                                continue;
+                            }
+                            if seen_relays.insert(hosting_relay.clone()) {
+                                upstream_relays.push(RelayInfo::new(Url::parse(hosting_relay)?));
+                            }
+                        }
+                    }
+                }
+
+                let count = data
+                    .namespace_subscribers
+                    .entry(scope_key)
+                    .or_default()
+                    .entry(prefix_key)
+                    .or_default()
+                    .entry(relay_url)
+                    .or_default();
+                *count = count.saturating_add(1);
+
+                write_data(&file, &data)?;
+
+                file.unlock()?;
+
+                Ok(upstream_relays)
+            }
+        })
+        .await??;
+
+        Ok(NamespaceSubscription::new(
+            upstream_relays,
+            NamespaceSubscriptionHandle {
+                scope_key,
+                prefix_key,
+                relay_url,
+                file_path: self.file_path.clone(),
+            },
+        ))
+    }
+
+    async fn lookup_namespace_subscribers(
+        &self,
+        scope: Option<&str>,
+        namespace: &TrackNamespace,
+        context: &CoordinatorContext,
+    ) -> CoordinatorResult<Vec<RelayInfo>> {
+        let scope_key = CoordinatorData::scope_key(scope);
+        let namespace_key = CoordinatorData::namespace_key(namespace);
+        let file_path = self.file_path.clone();
+
+        // Exclude the caller (this relay) and the inbound source peer so a
+        // forwarded PUBLISH_NAMESPACE is never sent to ourselves or echoed back
+        // to the relay it just arrived from. The caller string matches the key
+        // format written by subscribe_namespace (self.relay_url.to_string()).
+        let caller = self.relay_url.to_string();
+        let source = context.source.as_ref().map(|relay| relay.url.to_string());
+
+        let subscribers = tokio::task::spawn_blocking(move || -> Result<Vec<RelayInfo>> {
+            let file = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .truncate(false)
+                .open(&file_path)?;
+
+            file.lock_shared()?;
+
+            let data = read_data(&file)?;
+            let mut urls = HashSet::new();
+            let mut subscribers = Vec::new();
+            if let Some(bucket) = data.namespace_subscribers.get(&scope_key) {
+                for (prefix_key, relays) in bucket {
+                    if !namespace_key_has_prefix(&namespace_key, prefix_key) {
+                        continue;
+                    }
+
+                    for relay_url in relays.keys() {
+                        if relay_url == &caller || Some(relay_url) == source.as_ref() {
+                            continue;
+                        }
+                        if urls.insert(relay_url.clone()) {
+                            subscribers.push(RelayInfo::new(Url::parse(relay_url)?));
+                        }
+                    }
+                }
+            }
+
+            file.unlock()?;
+
+            Ok(subscribers)
+        })
+        .await??;
+
+        Ok(subscribers)
+    }
+
+    async fn register_track(
+        &self,
+        scope: Option<&str>,
+        namespace: &TrackNamespace,
+        track: &str,
+    ) -> CoordinatorResult<TrackRegistration> {
+        let scope_key = CoordinatorData::scope_key(scope);
+        let track_key = CoordinatorData::track_key(namespace, track);
+        let relay_url = self.relay_url.to_string();
+        let file_path = self.file_path.clone();
+
+        let scope_clone = scope_key.clone();
+        let key_clone = track_key.clone();
+        tokio::task::spawn_blocking(move || {
+            let file = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .truncate(false)
+                .open(&file_path)?;
+
+            file.lock_exclusive()?;
+
+            let mut data = read_data(&file)?;
+            tracing::info!(track = %key_clone, scope = %scope_clone, relay_url = %relay_url, "registering track: {} -> {}", key_clone, relay_url);
+            data.tracks
+                .entry(scope_clone)
+                .or_default()
+                .insert(key_clone, relay_url);
+
+            write_data(&file, &data)?;
+            file.unlock()?;
+
+            Ok::<_, anyhow::Error>(())
+        })
+        .await??;
+
+        let handle = TrackUnregisterHandle {
+            scope_key,
+            track_key,
+            file_path: self.file_path.clone(),
+        };
+
+        Ok(TrackRegistration::new(handle))
+    }
+
+    async fn unregister_track(
+        &self,
+        scope: Option<&str>,
+        namespace: &TrackNamespace,
+        track: &str,
+    ) -> CoordinatorResult<()> {
+        let scope_key = CoordinatorData::scope_key(scope);
+        let track_key = CoordinatorData::track_key(namespace, track);
+        let file_path = self.file_path.clone();
+
+        tokio::task::spawn_blocking(move || {
+            unregister_track_sync(&file_path, &scope_key, &track_key)
+        })
+        .await??;
+
+        Ok(())
+    }
+
+    async fn lookup_track(
+        &self,
+        scope: Option<&str>,
+        namespace: &TrackNamespace,
+        track: &str,
+    ) -> CoordinatorResult<(NamespaceOrigin, Option<Client>)> {
+        let namespace = namespace.clone();
+        let scope_key = CoordinatorData::scope_key(scope);
+        let namespace_key = CoordinatorData::namespace_key(&namespace);
+        let track_key = CoordinatorData::track_key(&namespace, track);
+        let file_path = self.file_path.clone();
+
+        let result = tokio::task::spawn_blocking(
+            move || -> Result<Option<(NamespaceOrigin, Option<Client>)>> {
+                let file = OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .create(true)
+                    .truncate(false)
+                    .open(&file_path)?;
+
+                file.lock_shared()?;
+
+                let data = read_data(&file)?;
+                tracing::debug!(track = %track_key, scope = %scope_key, "looking up track: {}", track_key);
+
+                if let Some(relay_url) = data
+                    .tracks
+                    .get(&scope_key)
+                    .and_then(|bucket| bucket.get(&track_key))
+                {
+                    let url = Url::parse(relay_url)?;
+                    file.unlock()?;
+                    return Ok(Some((NamespaceOrigin::new(namespace.clone(), url, None), None)));
+                }
+
+                let Some(bucket) = data.namespaces.get(&scope_key) else {
+                    file.unlock()?;
+                    return Ok(None);
+                };
+
+                if let Some(relay_url) = bucket.get(&namespace_key) {
+                    let url = Url::parse(relay_url)?;
+                    file.unlock()?;
+                    return Ok(Some((NamespaceOrigin::new(namespace.clone(), url, None), None)));
+                }
+
+                let mut best_match: Option<(String, String)> = None;
+                for (registered_key, url) in bucket {
+                    let is_prefix = namespace_key_has_prefix(&namespace_key, registered_key);
+                    match best_match {
+                        Some((ns, _))
+                            if is_prefix && key_field_count(&ns) < key_field_count(registered_key) =>
+                        {
+                            best_match = Some((registered_key.clone(), url.clone()));
+                        }
+                        None if is_prefix => {
+                            best_match = Some((registered_key.clone(), url.clone()));
+                        }
+                        _ => {}
+                    }
+                }
+
+                file.unlock()?;
+
+                if let Some((matched_key, relay_url)) = best_match {
+                    let matched_ns = decode_namespace_key(&matched_key)?;
                     let url = Url::parse(&relay_url)?;
                     return Ok(Some((NamespaceOrigin::new(matched_ns, url, None), None)));
                 }
@@ -282,5 +735,678 @@ impl Coordinator for FileCoordinator {
     async fn shutdown(&self) -> CoordinatorResult<()> {
         // Nothing to clean up - file will be unlocked automatically
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_file_path(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("moq-file-coordinator-{name}-{nanos}.json"))
+    }
+
+    fn prefix(path: &str) -> TrackNamespacePrefix {
+        TrackNamespacePrefix::from_utf8_path(path)
+    }
+
+    fn namespace_from_fields(fields: &[&str]) -> TrackNamespace {
+        TrackNamespace::try_from(
+            fields
+                .iter()
+                .map(|field| TupleField::from_utf8(field))
+                .collect::<Vec<_>>(),
+        )
+        .expect("test namespace should be valid")
+    }
+
+    #[tokio::test]
+    async fn lookup_track_finds_registered_track() {
+        let file = temp_file_path("track-lookup");
+        let relay_url = Url::parse("https://relay.example.com").unwrap();
+        let coordinator = FileCoordinator::new(&file, relay_url.clone());
+        let namespace = TrackNamespace::from_utf8_path("room/123");
+
+        let _track = coordinator
+            .register_track(Some("scope-a"), &namespace, "audio")
+            .await
+            .expect("track should register");
+
+        let (origin, client) = coordinator
+            .lookup_track(Some("scope-a"), &namespace, "audio")
+            .await
+            .expect("track lookup should find registration");
+
+        assert_eq!(origin.namespace(), &namespace);
+        assert_eq!(origin.url(), relay_url);
+        assert!(client.is_none());
+
+        let _ = std::fs::remove_file(file);
+    }
+
+    #[tokio::test]
+    async fn lookup_track_distinguishes_separator_text_in_namespace_and_track() {
+        let file = temp_file_path("track-key-collision");
+        let relay_a = Url::parse("https://relay-a.example.com").unwrap();
+        let relay_b = Url::parse("https://relay-b.example.com").unwrap();
+        let coordinator_a = FileCoordinator::new(&file, relay_a.clone());
+        let coordinator_b = FileCoordinator::new(&file, relay_b.clone());
+        let namespace_a = TrackNamespace::from_utf8_path("room--audio");
+        let namespace_b = TrackNamespace::from_utf8_path("room");
+
+        let _track_a = coordinator_a
+            .register_track(Some("scope-a"), &namespace_a, "main")
+            .await
+            .expect("first track should register");
+        let _track_b = coordinator_b
+            .register_track(Some("scope-a"), &namespace_b, "audio--main")
+            .await
+            .expect("second track should register");
+
+        let (origin_a, _) = coordinator_a
+            .lookup_track(Some("scope-a"), &namespace_a, "main")
+            .await
+            .expect("first track lookup should find original relay");
+        let (origin_b, _) = coordinator_a
+            .lookup_track(Some("scope-a"), &namespace_b, "audio--main")
+            .await
+            .expect("second track lookup should find original relay");
+
+        assert_eq!(origin_a.url(), relay_a);
+        assert_eq!(origin_b.url(), relay_b);
+
+        let _ = std::fs::remove_file(file);
+    }
+
+    #[tokio::test]
+    async fn lookup_track_falls_back_to_namespace() {
+        let file = temp_file_path("track-namespace-fallback");
+        let relay_url = Url::parse("https://relay.example.com").unwrap();
+        let coordinator = FileCoordinator::new(&file, relay_url.clone());
+        let namespace = TrackNamespace::from_utf8_path("room/123");
+
+        let _namespace = coordinator
+            .register_namespace(Some("scope-a"), &namespace, &CoordinatorContext::public())
+            .await
+            .expect("namespace should register");
+
+        let (origin, client) = coordinator
+            .lookup_track(Some("scope-a"), &namespace, "audio")
+            .await
+            .expect("track lookup should fall back to namespace");
+
+        assert_eq!(origin.namespace(), &namespace);
+        assert_eq!(origin.url(), relay_url);
+        assert!(client.is_none());
+
+        let _ = std::fs::remove_file(file);
+    }
+
+    #[tokio::test]
+    async fn subscribe_namespace_returns_hosting_relays_for_matching_prefix() {
+        let file = temp_file_path("subscribe-namespace-existing");
+        let edge = FileCoordinator::new(&file, Url::parse("https://edge.example.com").unwrap());
+
+        // The origin hosts two namespaces under the prefix; a third relay hosts
+        // a non-matching namespace that must be filtered out.
+        let origin = FileCoordinator::new(&file, Url::parse("https://origin.example.com").unwrap());
+        let other_origin = FileCoordinator::new(
+            &file,
+            Url::parse("https://other-origin.example.com").unwrap(),
+        );
+
+        let _room = origin
+            .register_namespace(
+                Some("scope-a"),
+                &TrackNamespace::from_utf8_path("room/123"),
+                &CoordinatorContext::public(),
+            )
+            .await
+            .expect("room should register");
+        let _camera = origin
+            .register_namespace(
+                Some("scope-a"),
+                &TrackNamespace::from_utf8_path("room/123/camera"),
+                &CoordinatorContext::public(),
+            )
+            .await
+            .expect("camera should register");
+        let _other = other_origin
+            .register_namespace(
+                Some("scope-a"),
+                &TrackNamespace::from_utf8_path("other/123"),
+                &CoordinatorContext::public(),
+            )
+            .await
+            .expect("other should register");
+
+        // Subscribing to the prefix returns the distinct relays hosting a
+        // matching namespace. The origin hosts two matches but is deduplicated
+        // to a single entry; other-origin hosts only a non-matching namespace
+        // and is excluded.
+        let subscription = edge
+            .subscribe_namespace(
+                Some("scope-a"),
+                &prefix("room/123"),
+                &CoordinatorContext::public(),
+            )
+            .await
+            .expect("namespace subscription should succeed");
+        let upstream: Vec<String> = subscription
+            .upstream_relays
+            .iter()
+            .map(|relay| relay.url.to_string())
+            .collect();
+
+        assert_eq!(upstream, vec!["https://origin.example.com/".to_string()]);
+
+        let _ = std::fs::remove_file(file);
+    }
+
+    #[tokio::test]
+    async fn subscribe_namespace_keeps_scopes_isolated() {
+        let file = temp_file_path("subscribe-namespace-scopes");
+        let edge = FileCoordinator::new(&file, Url::parse("https://edge.example.com").unwrap());
+
+        // Each scope's namespace is hosted by a different origin relay, so scope
+        // isolation is observable through which relay is returned as an upstream
+        // pull target.
+        let origin_global = FileCoordinator::new(
+            &file,
+            Url::parse("https://origin-global.example.com").unwrap(),
+        );
+        let origin_scoped = FileCoordinator::new(
+            &file,
+            Url::parse("https://origin-scoped.example.com").unwrap(),
+        );
+
+        let _global = origin_global
+            .register_namespace(
+                None,
+                &TrackNamespace::from_utf8_path("room/global"),
+                &CoordinatorContext::public(),
+            )
+            .await
+            .expect("global should register");
+        let _scoped = origin_scoped
+            .register_namespace(
+                Some("scope-a"),
+                &TrackNamespace::from_utf8_path("room/scoped"),
+                &CoordinatorContext::public(),
+            )
+            .await
+            .expect("scoped should register");
+
+        // The global (unscoped) subscription only sees the global origin.
+        let global = edge
+            .subscribe_namespace(None, &prefix("room"), &CoordinatorContext::public())
+            .await
+            .expect("global namespace subscription should succeed");
+        let global_upstream: Vec<String> = global
+            .upstream_relays
+            .iter()
+            .map(|relay| relay.url.to_string())
+            .collect();
+        assert_eq!(
+            global_upstream,
+            vec!["https://origin-global.example.com/".to_string()]
+        );
+
+        // The scope-a subscription only sees the scoped origin.
+        let scoped = edge
+            .subscribe_namespace(
+                Some("scope-a"),
+                &prefix("room"),
+                &CoordinatorContext::public(),
+            )
+            .await
+            .expect("scoped namespace subscription should succeed");
+        let scoped_upstream: Vec<String> = scoped
+            .upstream_relays
+            .iter()
+            .map(|relay| relay.url.to_string())
+            .collect();
+        assert_eq!(
+            scoped_upstream,
+            vec!["https://origin-scoped.example.com/".to_string()]
+        );
+
+        let _ = std::fs::remove_file(file);
+    }
+
+    #[tokio::test]
+    async fn lookup_namespace_subscribers_finds_matching_prefixes() {
+        let file = temp_file_path("namespace-subscribers");
+        let relay_url = Url::parse("https://relay.example.com").unwrap();
+        let coordinator = FileCoordinator::new(&file, relay_url.clone());
+
+        let _subscription = coordinator
+            .subscribe_namespace(
+                Some("scope-a"),
+                &prefix("room/123"),
+                &CoordinatorContext::public(),
+            )
+            .await
+            .expect("namespace subscription should register");
+
+        // A second relay (the origin) shares the same coordinator file and
+        // performs the lookups, so the subscribing relay is returned rather
+        // than filtered out as the caller.
+        let looker = FileCoordinator::new(&file, Url::parse("https://origin.example.com").unwrap());
+
+        let subscribers = looker
+            .lookup_namespace_subscribers(
+                Some("scope-a"),
+                &TrackNamespace::from_utf8_path("room/123/camera"),
+                &CoordinatorContext::public(),
+            )
+            .await
+            .expect("subscriber lookup should succeed");
+
+        assert_eq!(subscribers.len(), 1);
+        assert_eq!(subscribers[0].url, relay_url);
+
+        let no_match = looker
+            .lookup_namespace_subscribers(
+                Some("scope-a"),
+                &TrackNamespace::from_utf8_path("room/456"),
+                &CoordinatorContext::public(),
+            )
+            .await
+            .expect("subscriber lookup should succeed");
+        assert!(no_match.is_empty());
+
+        let _ = std::fs::remove_file(file);
+    }
+
+    #[tokio::test]
+    async fn namespace_subscription_drop_unregisters_with_refcount() {
+        let file = temp_file_path("namespace-subscriber-refcount");
+        let relay_url = Url::parse("https://relay.example.com").unwrap();
+        let coordinator = FileCoordinator::new(&file, relay_url.clone());
+        let namespace_prefix = prefix("room/123");
+        let namespace = TrackNamespace::from_utf8_path("room/123/camera");
+
+        let first = coordinator
+            .subscribe_namespace(
+                Some("scope-a"),
+                &namespace_prefix,
+                &CoordinatorContext::public(),
+            )
+            .await
+            .expect("first subscription should register");
+        let second = coordinator
+            .subscribe_namespace(
+                Some("scope-a"),
+                &namespace_prefix,
+                &CoordinatorContext::public(),
+            )
+            .await
+            .expect("second subscription should register");
+
+        drop(first);
+
+        // A second relay (the origin) shares the coordinator file and performs
+        // the lookups, so the subscribing relay is visible while its refcount
+        // is positive and disappears once it hits zero.
+        let looker = FileCoordinator::new(&file, Url::parse("https://origin.example.com").unwrap());
+
+        let subscribers = looker
+            .lookup_namespace_subscribers(
+                Some("scope-a"),
+                &namespace,
+                &CoordinatorContext::public(),
+            )
+            .await
+            .expect("subscriber lookup should succeed");
+        assert_eq!(subscribers.len(), 1);
+        assert_eq!(subscribers[0].url, relay_url);
+
+        drop(second);
+
+        let subscribers = looker
+            .lookup_namespace_subscribers(
+                Some("scope-a"),
+                &namespace,
+                &CoordinatorContext::public(),
+            )
+            .await
+            .expect("subscriber lookup should succeed");
+        assert!(subscribers.is_empty());
+
+        let _ = std::fs::remove_file(file);
+    }
+
+    #[tokio::test]
+    async fn subscribe_namespace_empty_prefix_matches_all_namespaces() {
+        let file = temp_file_path("subscribe-namespace-empty-prefix");
+        let edge_url = Url::parse("https://edge.example.com").unwrap();
+        let edge = FileCoordinator::new(&file, edge_url.clone());
+
+        // Two different origin relays each host a namespace under the scope.
+        let origin_a =
+            FileCoordinator::new(&file, Url::parse("https://origin-a.example.com").unwrap());
+        let origin_b =
+            FileCoordinator::new(&file, Url::parse("https://origin-b.example.com").unwrap());
+
+        let _room = origin_a
+            .register_namespace(
+                Some("scope-a"),
+                &TrackNamespace::from_utf8_path("room/123"),
+                &CoordinatorContext::public(),
+            )
+            .await
+            .expect("room should register");
+        let _other = origin_b
+            .register_namespace(
+                Some("scope-a"),
+                &TrackNamespace::from_utf8_path("other/123"),
+                &CoordinatorContext::public(),
+            )
+            .await
+            .expect("other should register");
+
+        // An empty prefix matches every namespace in the scope, so both hosting
+        // relays are returned as upstream pull targets.
+        let subscription = edge
+            .subscribe_namespace(
+                Some("scope-a"),
+                &TrackNamespacePrefix::new(),
+                &CoordinatorContext::public(),
+            )
+            .await
+            .expect("empty prefix namespace subscription should succeed");
+        let mut upstream: Vec<String> = subscription
+            .upstream_relays
+            .iter()
+            .map(|relay| relay.url.to_string())
+            .collect();
+        upstream.sort();
+
+        assert_eq!(
+            upstream,
+            vec![
+                "https://origin-a.example.com/".to_string(),
+                "https://origin-b.example.com/".to_string(),
+            ]
+        );
+
+        // An origin performing the reverse lookup discovers the subscribing
+        // edge; the origin (caller) is excluded, leaving the edge.
+        let subscribers = origin_a
+            .lookup_namespace_subscribers(
+                Some("scope-a"),
+                &TrackNamespace::from_utf8_path("room/123/camera"),
+                &CoordinatorContext::public(),
+            )
+            .await
+            .expect("subscriber lookup should succeed");
+
+        assert_eq!(subscribers.len(), 1);
+        assert_eq!(subscribers[0].url, edge_url);
+
+        let _ = std::fs::remove_file(file);
+    }
+
+    #[tokio::test]
+    async fn subscribe_namespace_matches_tuple_fields_not_slash_strings() {
+        let file = temp_file_path("subscribe-namespace-tuple-prefix");
+        let edge = FileCoordinator::new(&file, Url::parse("https://edge.example.com").unwrap());
+
+        let single_field_namespace = namespace_from_fields(&["room/123"]);
+        let two_field_namespace = namespace_from_fields(&["room", "123"]);
+
+        // Host each namespace on a distinct origin so the matched namespace is
+        // identifiable by which relay is returned as an upstream pull target.
+        let origin_single = FileCoordinator::new(
+            &file,
+            Url::parse("https://origin-single.example.com").unwrap(),
+        );
+        let origin_two =
+            FileCoordinator::new(&file, Url::parse("https://origin-two.example.com").unwrap());
+
+        let _single = origin_single
+            .register_namespace(
+                Some("scope-a"),
+                &single_field_namespace,
+                &CoordinatorContext::public(),
+            )
+            .await
+            .expect("single-field namespace should register");
+        let _two = origin_two
+            .register_namespace(
+                Some("scope-a"),
+                &two_field_namespace,
+                &CoordinatorContext::public(),
+            )
+            .await
+            .expect("two-field namespace should register");
+
+        // The prefix has a single field "room". It matches the two-field
+        // namespace ["room", "123"] but NOT the single-field namespace
+        // ["room/123"], so only the two-field namespace's origin is returned
+        // (tuple-aware matching, not slash-string matching).
+        let subscription = edge
+            .subscribe_namespace(
+                Some("scope-a"),
+                &prefix("room"),
+                &CoordinatorContext::public(),
+            )
+            .await
+            .expect("namespace subscription should succeed");
+
+        let upstream: Vec<String> = subscription
+            .upstream_relays
+            .iter()
+            .map(|relay| relay.url.to_string())
+            .collect();
+
+        assert_eq!(
+            upstream,
+            vec!["https://origin-two.example.com/".to_string()]
+        );
+
+        let _ = std::fs::remove_file(file);
+    }
+
+    #[tokio::test]
+    async fn internal_subscribe_namespace_returns_no_upstream_relays() {
+        // A pull opened on another relay's behalf arrives as an internal
+        // session, so the coordinator returns no upstream relays even though a
+        // peer hosts a matching namespace: the pull is served from local state
+        // and does not recurse (the loop-breaker). The source is a *third* relay
+        // that does not host the namespace, so only the interface -- not
+        // caller/source exclusion -- can explain the empty result.
+        let file = temp_file_path("subscribe-namespace-internal");
+        let edge = FileCoordinator::new(&file, Url::parse("https://edge.example.com").unwrap());
+        let origin = FileCoordinator::new(&file, Url::parse("https://origin.example.com").unwrap());
+
+        let _registration = origin
+            .register_namespace(
+                Some("scope-a"),
+                &TrackNamespace::from_utf8_path("room/123"),
+                &CoordinatorContext::public(),
+            )
+            .await
+            .expect("origin should register");
+
+        // A public subscribe is told to pull from the origin...
+        let public_sub = edge
+            .subscribe_namespace(
+                Some("scope-a"),
+                &prefix("room"),
+                &CoordinatorContext::public(),
+            )
+            .await
+            .expect("public subscription should succeed");
+        assert_eq!(
+            public_sub.upstream_relays.len(),
+            1,
+            "public sessions fan out to hosting relays"
+        );
+
+        // ...but an internal subscribe is given nothing to pull.
+        let internal_sub = edge
+            .subscribe_namespace(
+                Some("scope-a"),
+                &prefix("room"),
+                &CoordinatorContext::internal(Some(RelayInfo::new(
+                    Url::parse("https://other.example.com").unwrap(),
+                ))),
+            )
+            .await
+            .expect("internal subscription should succeed");
+        assert!(
+            internal_sub.upstream_relays.is_empty(),
+            "internal sessions are served from local state, breaking the pull loop"
+        );
+
+        let _ = std::fs::remove_file(file);
+    }
+
+    #[tokio::test]
+    async fn lookup_namespace_subscribers_keeps_scopes_isolated() {
+        let file = temp_file_path("namespace-subscriber-scopes");
+        let relay_url = Url::parse("https://relay.example.com").unwrap();
+        let coordinator = FileCoordinator::new(&file, relay_url);
+
+        let _global = coordinator
+            .subscribe_namespace(None, &prefix("room/global"), &CoordinatorContext::public())
+            .await
+            .expect("global subscription should register");
+        let _scoped = coordinator
+            .subscribe_namespace(
+                Some("scope-a"),
+                &prefix("room/scoped"),
+                &CoordinatorContext::public(),
+            )
+            .await
+            .expect("scoped subscription should register");
+
+        // A second relay (the origin) shares the coordinator file and performs
+        // the lookups, so the subscribing relay is returned rather than filtered
+        // out as the caller.
+        let looker = FileCoordinator::new(&file, Url::parse("https://origin.example.com").unwrap());
+
+        let global = looker
+            .lookup_namespace_subscribers(
+                None,
+                &TrackNamespace::from_utf8_path("room/global/cam"),
+                &CoordinatorContext::public(),
+            )
+            .await
+            .expect("global lookup should succeed");
+        assert_eq!(global.len(), 1);
+
+        let scoped = looker
+            .lookup_namespace_subscribers(
+                Some("scope-a"),
+                &TrackNamespace::from_utf8_path("room/scoped/cam"),
+                &CoordinatorContext::public(),
+            )
+            .await
+            .expect("scoped lookup should succeed");
+        assert_eq!(scoped.len(), 1);
+
+        let no_cross_scope = looker
+            .lookup_namespace_subscribers(
+                Some("scope-a"),
+                &TrackNamespace::from_utf8_path("room/global/cam"),
+                &CoordinatorContext::public(),
+            )
+            .await
+            .expect("scoped lookup should succeed");
+        assert!(no_cross_scope.is_empty());
+
+        let _ = std::fs::remove_file(file);
+    }
+
+    #[tokio::test]
+    async fn lookup_namespace_subscribers_excludes_caller() {
+        // A relay that subscribed and then performs the lookup itself must not
+        // be returned to itself; otherwise it would forward PUBLISH_NAMESPACE to
+        // its own endpoint and loop forever.
+        let file = temp_file_path("namespace-subscribers-exclude-caller");
+        let relay_url = Url::parse("https://relay.example.com").unwrap();
+        let coordinator = FileCoordinator::new(&file, relay_url);
+
+        let _subscription = coordinator
+            .subscribe_namespace(
+                Some("scope-a"),
+                &prefix("room/123"),
+                &CoordinatorContext::public(),
+            )
+            .await
+            .expect("namespace subscription should register");
+
+        let subscribers = coordinator
+            .lookup_namespace_subscribers(
+                Some("scope-a"),
+                &TrackNamespace::from_utf8_path("room/123/camera"),
+                &CoordinatorContext::public(),
+            )
+            .await
+            .expect("subscriber lookup should succeed");
+
+        assert!(
+            subscribers.is_empty(),
+            "caller relay must be excluded from its own lookup results"
+        );
+
+        let _ = std::fs::remove_file(file);
+    }
+
+    #[tokio::test]
+    async fn lookup_namespace_subscribers_excludes_source() {
+        // A PUBLISH_NAMESPACE that arrived from a peer relay must not be echoed
+        // back to that same peer.
+        let file = temp_file_path("namespace-subscribers-exclude-source");
+        let edge_url = Url::parse("https://edge.example.com").unwrap();
+        let edge = FileCoordinator::new(&file, edge_url.clone());
+        let origin = FileCoordinator::new(&file, Url::parse("https://origin.example.com").unwrap());
+
+        let _subscription = edge
+            .subscribe_namespace(
+                Some("scope-a"),
+                &prefix("room/123"),
+                &CoordinatorContext::public(),
+            )
+            .await
+            .expect("namespace subscription should register");
+
+        // Without a source, the origin sees the edge subscriber.
+        let subscribers = origin
+            .lookup_namespace_subscribers(
+                Some("scope-a"),
+                &TrackNamespace::from_utf8_path("room/123/camera"),
+                &CoordinatorContext::public(),
+            )
+            .await
+            .expect("subscriber lookup should succeed");
+        assert_eq!(subscribers.len(), 1);
+        assert_eq!(subscribers[0].url, edge_url);
+
+        // When the PUBLISH_NAMESPACE arrived *from* the edge relay, it must be
+        // excluded so it is not echoed back.
+        let from_edge = CoordinatorContext::internal(Some(RelayInfo::new(edge_url.clone())));
+        let subscribers = origin
+            .lookup_namespace_subscribers(
+                Some("scope-a"),
+                &TrackNamespace::from_utf8_path("room/123/camera"),
+                &from_edge,
+            )
+            .await
+            .expect("subscriber lookup should succeed");
+        assert!(
+            subscribers.is_empty(),
+            "source relay must be excluded to avoid echoing PUBLISH_NAMESPACE back"
+        );
+
+        let _ = std::fs::remove_file(file);
     }
 }

--- a/moq-relay-ietf/src/bin/moq-relay-ietf/main.rs
+++ b/moq-relay-ietf/src/bin/moq-relay-ietf/main.rs
@@ -12,7 +12,8 @@ use url::Url;
 
 use api_coordinator::{ApiCoordinator, ApiCoordinatorConfig};
 use file_coordinator::FileCoordinator;
-use moq_relay_ietf::{Coordinator, Relay, RelayConfig, Web, WebConfig};
+use moq_relay_ietf::{Coordinator, Relay, RelayConfig, SessionConfig, Web, WebConfig};
+use std::time::Duration;
 
 #[derive(Parser, Clone)]
 pub struct Cli {
@@ -31,6 +32,20 @@ pub struct Cli {
     /// Directory to write mlog files (one per connection)
     #[arg(long)]
     pub mlog_dir: Option<PathBuf>,
+
+    /// Accepted for compatibility; ignored.
+    ///
+    /// Draft-18 removed MAX_REQUEST_ID, so there is no request budget to
+    /// advertise in SETUP. The flag remains so existing invocations keep
+    /// working.
+    #[arg(long, default_value_t = 100)]
+    pub max_request_id: u64,
+
+    /// Seconds to keep a cached track with no subscribers before releasing its
+    /// upstream subscription. 0 disables eviction, holding upstream
+    /// subscriptions for the lifetime of the upstream session.
+    #[arg(long, default_value_t = 30)]
+    pub cache_idle_timeout: u64,
 
     /// Forward all PUBLISH_NAMESPACE messages to the provided server for auth/routing.
     /// If not provided, the relay accepts every unique namespace publish.
@@ -93,7 +108,10 @@ pub struct Cli {
 async fn main() -> anyhow::Result<()> {
     // Initialize tracing with env filter (respects RUST_LOG environment variable)
     // Default to info level, but suppress quinn's verbose output
+    //
+    // Logs go to stderr, per convention and to keep stdout clean.
     tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info,quinn=warn")),
@@ -181,16 +199,26 @@ async fn main() -> anyhow::Result<()> {
     };
 
     // Create a QUIC server for media.
-    let relay = Relay::new(RelayConfig {
-        tls: tls.clone(),
-        bind: Some(cli.bind),
-        endpoints: vec![],
-        qlog_dir: qlog_dir_for_relay,
-        mlog_dir: mlog_dir_for_relay,
-        node: cli.node,
-        announce: cli.announce,
-        coordinator,
-    })?;
+    let relay = Relay::new_with_cache_idle_timeout(
+        RelayConfig {
+            tls: tls.clone(),
+            bind: Some(cli.bind),
+            endpoints: vec![],
+            qlog_dir: qlog_dir_for_relay,
+            mlog_dir: mlog_dir_for_relay,
+            node: cli.node,
+            announce: cli.announce,
+            coordinator,
+            session: SessionConfig {
+                max_request_id: cli.max_request_id,
+            },
+            // No connection tagger: the default binary treats every inbound
+            // connection as a public client. Embedders that run relay-to-relay
+            // meshes supply a tagger to mark internal peers.
+            connection_tagger: None,
+        },
+        Duration::from_secs(cli.cache_idle_timeout),
+    )?;
 
     if cli.dev {
         // Create a web server too.
@@ -208,4 +236,16 @@ async fn main() -> anyhow::Result<()> {
     }
 
     relay.run().await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn max_request_id_flag_overrides_default() {
+        let cli = Cli::try_parse_from(["moq-relay-ietf", "--max-request-id", "7"]).unwrap();
+
+        assert_eq!(cli.max_request_id, 7);
+    }
 }

--- a/moq-relay-ietf/src/consumer.rs
+++ b/moq-relay-ietf/src/consumer.rs
@@ -6,11 +6,17 @@ use std::sync::Arc;
 use anyhow::Context;
 use futures::{stream::FuturesUnordered, FutureExt, StreamExt};
 use moq_transport::{
-    serve::Tracks,
-    session::{PublishedNamespace, SessionError, Subscriber},
+    message::RequestErrorCode,
+    serve::{ServeError, Tracks},
+    session::{PublishReceived, PublishedNamespace, SessionError, Subscriber},
+};
+use tokio::sync::Semaphore;
+
+use crate::{
+    metrics::GaugeGuard, Coordinator, Locals, Producer, RemoteManager, SessionContext, TrackRequest,
 };
 
-use crate::{metrics::GaugeGuard, Coordinator, Locals, Producer};
+const MAX_INBOUND_PUBLISH_TRACKS_PER_SESSION: usize = 1024;
 
 /// Consumer of tracks from a remote Publisher
 #[derive(Clone)]
@@ -18,11 +24,13 @@ pub struct Consumer {
     subscriber: Subscriber,
     locals: Locals,
     coordinator: Arc<dyn Coordinator>,
+    /// Relay-to-relay session pool, used to forward PUBLISH_NAMESPACE to peer
+    /// relays that the coordinator oracle reports as interested subscribers.
+    remotes: RemoteManager,
     forward: Option<Producer>, // Forward all announcements to this subscriber
-    /// The resolved scope identity for this session, if any.
-    /// Produced by `Coordinator::resolve_scope()` from the connection path.
-    /// Passed to coordinator register/lookup calls to isolate namespaces.
-    scope: Option<String>,
+    /// Relay-level context for this MoQT session.
+    context: SessionContext,
+    publish_track_permits: Arc<Semaphore>,
 }
 
 impl Consumer {
@@ -30,25 +38,31 @@ impl Consumer {
         subscriber: Subscriber,
         locals: Locals,
         coordinator: Arc<dyn Coordinator>,
+        remotes: RemoteManager,
         forward: Option<Producer>,
-        scope: Option<String>,
+        context: SessionContext,
     ) -> Self {
         Self {
             subscriber,
             locals,
             coordinator,
+            remotes,
             forward,
-            scope,
+            context,
+            publish_track_permits: Arc::new(Semaphore::new(MAX_INBOUND_PUBLISH_TRACKS_PER_SESSION)),
         }
     }
 
-    /// Run the consumer to handle inbound PUBLISH_NAMESPACE requests.
-    pub async fn run(mut self) -> Result<(), SessionError> {
-        let mut tasks = FuturesUnordered::new();
+    /// Run the consumer to handle inbound PUBLISH_NAMESPACE and PUBLISH requests.
+    pub async fn run(self) -> Result<(), SessionError> {
+        let mut tasks: FuturesUnordered<futures::future::BoxFuture<'static, ()>> =
+            FuturesUnordered::new();
+        let mut namespace_subscriber = self.subscriber.clone();
+        let mut publish_subscriber = self.subscriber.clone();
 
         loop {
             tokio::select! {
-                Some(published_ns) = self.subscriber.published_namespace() => {
+                Some(published_ns) = namespace_subscriber.published_namespace() => {
                     metrics::counter!("moq_relay_publishers_total").increment(1);
 
                     let this = self.clone();
@@ -68,7 +82,21 @@ impl Consumer {
                                 "failed serving PUBLISH_NAMESPACE: {:?}", info
                             );
                         }
-                    });
+                    }.boxed());
+                },
+                Some(publish) = publish_subscriber.publish_received() => {
+                    metrics::counter!("moq_relay_published_tracks_total").increment(1);
+
+                    let this = self.clone();
+                    tasks.push(async move {
+                        let namespace = publish.namespace().to_utf8_path();
+                        let track_name = publish.name().clone();
+                        tracing::info!(namespace = %namespace, track = %track_name, "serving PUBLISH");
+
+                        if let Err(err) = this.serve_track(publish).await {
+                            tracing::warn!(namespace = %namespace, track = %track_name, error = %err, "failed serving PUBLISH");
+                        }
+                    }.boxed());
                 },
                 _ = tasks.next(), if !tasks.is_empty() => {},
                 else => return Ok(()),
@@ -81,17 +109,18 @@ impl Consumer {
         // Track active publishers - decrements when this function returns.
         let _publisher_guard = GaugeGuard::new("moq_relay_active_publishers");
 
-        let mut tasks = FuturesUnordered::new();
+        let mut tasks: FuturesUnordered<
+            futures::future::BoxFuture<'static, Result<(), anyhow::Error>>,
+        > = FuturesUnordered::new();
+        let ns = published_ns.namespace.to_utf8_path();
 
-        let (_, mut request, reader) = Tracks::new(published_ns.namespace.clone()).produce();
-
-        let ns = reader.namespace.to_utf8_path();
-
-        // Register the namespace locally so downstream subscribers can be served.
-        tracing::debug!(namespace = %ns, "registering namespace in locals");
-        let _register = match self
+        // Register namespace routing metadata locally. This does not register
+        // any media tracks; it only creates a request queue used when a
+        // downstream SUBSCRIBE asks for a missing track under this namespace.
+        tracing::debug!(namespace = %ns, "registering namespace route source in locals");
+        let (_register, mut requests) = match self
             .locals
-            .register(self.scope.as_deref(), reader.clone())
+            .register_namespace(self.context.scope(), published_ns.namespace.clone())
             .await
         {
             Ok(reg) => reg,
@@ -101,13 +130,18 @@ impl Consumer {
                 return Err(err);
             }
         };
-        tracing::debug!(namespace = %ns, "namespace registered in locals");
+        tracing::debug!(namespace = %ns, "namespace route source registered in locals");
 
         // Register namespace with the coordinator so other relay nodes can route to us.
         tracing::debug!(namespace = %ns, "registering namespace with coordinator");
+        let coordinator_context = self.context.coordinator_context();
         let _namespace_registration = match self
             .coordinator
-            .register_namespace(self.scope.as_deref(), &reader.namespace)
+            .register_namespace(
+                self.context.scope(),
+                &published_ns.namespace,
+                &coordinator_context,
+            )
             .await
         {
             Ok(reg) => reg,
@@ -129,17 +163,86 @@ impl Consumer {
 
         // Forward the namespace upstream, if configured.
         if let Some(mut forward) = self.forward {
+            // The forwarding API still uses the moq-transport Tracks helper.
+            // This helper is not the relay-local registry; it is only an
+            // adapter for the outgoing publish_namespace API.
+            let (_, _forward_request, forward_reader) =
+                Tracks::new(published_ns.namespace.clone()).produce();
+            tasks.push(
+                async move {
+                    let namespace = forward_reader.namespace.to_utf8_path();
+                    tracing::info!(
+                        namespace = %namespace,
+                        "forwarding PUBLISH_NAMESPACE: {:?}", forward_reader.info
+                    );
+                    // Best-effort upstream propagation: a forwarding failure must not
+                    // tear down the local PUBLISH_NAMESPACE registration for other peers.
+                    if let Err(err) = forward
+                        .publish_namespace(forward_reader)
+                        .await
+                        .context("failed forwarding PUBLISH_NAMESPACE")
+                    {
+                        metrics::counter!("moq_relay_announce_errors_total", "phase" => "forward")
+                            .increment(1);
+                        tracing::warn!(namespace = %namespace, error = %err, "failed forwarding PUBLISH_NAMESPACE upstream");
+                    }
+                    Ok(())
+                }
+                .boxed(),
+            );
+        }
+
+        // Fan out the PUBLISH_NAMESPACE to peer relays that the coordinator
+        // oracle reports as having matching SUBSCRIBE_NAMESPACE interest. The
+        // coordinator already excludes this relay (the caller) and the inbound
+        // source peer, so every returned relay is a distinct downstream peer and
+        // we can push to all of them without creating a forwarding loop.
+        let subscriber_relays = match self
+            .coordinator
+            .lookup_namespace_subscribers(
+                self.context.scope(),
+                &published_ns.namespace,
+                &coordinator_context,
+            )
+            .await
+        {
+            Ok(relays) => relays,
+            Err(err) => {
+                metrics::counter!("moq_relay_announce_errors_total", "phase" => "coordinator_lookup")
+                    .increment(1);
+                return Err(err.into());
+            }
+        };
+
+        for relay in subscriber_relays {
+            let remotes = self.remotes.clone();
+            // The forwarding API uses the moq-transport Tracks helper as an
+            // adapter for the outgoing publish_namespace call; it is not the
+            // relay-local registry.
+            let (_, _request, reader) = Tracks::new(published_ns.namespace.clone()).produce();
             tasks.push(
                 async move {
                     let namespace = reader.namespace.to_utf8_path();
                     tracing::info!(
                         namespace = %namespace,
-                        "forwarding PUBLISH_NAMESPACE: {:?}", reader.info
+                        remote = %relay.url,
+                        "forwarding PUBLISH_NAMESPACE to peer relay"
                     );
-                    forward
-                        .publish_namespace(reader)
+                    // Best-effort fan-out: one downstream relay failing must not tear
+                    // down the PUBLISH_NAMESPACE registration for the publisher or the
+                    // other peer relays.
+                    if let Err(err) = remotes
+                        .publish_namespace(&relay, reader)
                         .await
-                        .context("failed forwarding PUBLISH_NAMESPACE")
+                        .with_context(|| {
+                            format!("failed forwarding PUBLISH_NAMESPACE to {}", relay.url)
+                        })
+                    {
+                        metrics::counter!("moq_relay_announce_errors_total", "phase" => "peer_fanout")
+                            .increment(1);
+                        tracing::warn!(namespace = %namespace, remote = %relay.url, error = %err, "failed forwarding PUBLISH_NAMESPACE to peer relay");
+                    }
+                    Ok(())
                 }
                 .boxed(),
             );
@@ -153,11 +256,11 @@ impl Consumer {
                     tracing::info!(namespace = %ns, "PUBLISH_NAMESPACE closed");
                     return Ok(());
                 },
-                Some(track) = request.next() => {
+                Some(TrackRequest { writer, lease, upstream }) = requests.recv() => {
                     let mut subscriber = self.subscriber.clone();
 
                     tasks.push(async move {
-                        let info = track.clone();
+                        let info = writer.info.clone();
                         let namespace = info.namespace.to_utf8_path();
                         let track_name = info.name.clone();
                         tracing::info!(
@@ -166,14 +269,57 @@ impl Consumer {
                             "forwarding subscribe: {:?}", info
                         );
 
-                        if let Err(err) = subscriber.subscribe(track).await {
-                            tracing::warn!(
-                                namespace = %namespace,
-                                track = %track_name,
-                                error = %err,
-                                "failed forwarding subscribe: {:?}", info
-                            )
+                        // Hold the subscription explicitly rather than using
+                        // `subscribe()`, so it can be dropped — sending
+                        // UNSUBSCRIBE — once downstream interest goes away.
+                        //
+                        // `subscribe_open` resolves once the upstream publisher
+                        // answers, so its outcome is exactly what downstream
+                        // subscribers are waiting on to satisfy draft-16 §8.4.
+                        let subscribe = match subscriber.subscribe_open(writer).await {
+                            Ok(subscribe) => {
+                                upstream.established();
+                                subscribe
+                            }
+                            Err(err) => {
+                                tracing::warn!(
+                                    namespace = %namespace,
+                                    track = %track_name,
+                                    error = %err,
+                                    "failed forwarding subscribe: {:?}", info
+                                );
+                                // Release waiting downstream subscribers with the
+                                // upstream reason so they get a REQUEST_ERROR that
+                                // matches it, rather than a premature accept.
+                                upstream.failed(err);
+                                return Ok(());
+                            }
+                        };
+
+                        tokio::select! {
+                            res = subscribe.closed() => {
+                                if let Err(err) = res {
+                                    tracing::warn!(
+                                        namespace = %namespace,
+                                        track = %track_name,
+                                        error = %err,
+                                        "failed forwarding subscribe: {:?}", info
+                                    )
+                                }
+                            }
+                            // The cached track went unwatched long enough to be
+                            // evicted, so stop pulling it. Dropping `subscribe`
+                            // below sends UNSUBSCRIBE upstream.
+                            _ = lease.released() => {
+                                tracing::info!(
+                                    namespace = %namespace,
+                                    track = %track_name,
+                                    "releasing upstream subscription for idle cached track"
+                                );
+                            }
                         }
+
+                        drop(subscribe);
 
                         Ok(())
                     }.boxed());
@@ -182,5 +328,83 @@ impl Consumer {
                 else => return Ok(()),
             }
         }
+    }
+
+    /// Serve an inbound PUBLISH for one exact track.
+    async fn serve_track(mut self, mut publish: PublishReceived) -> Result<(), anyhow::Error> {
+        let _publish_permit = match self.publish_track_permits.clone().try_acquire_owned() {
+            Ok(permit) => permit,
+            Err(_) => {
+                metrics::counter!("moq_relay_publish_errors_total", "phase" => "session_limit")
+                    .increment(1);
+                publish.close(ServeError::Closed(RequestErrorCode::InternalError as u64));
+                return Err(ServeError::Cancel.into());
+            }
+        };
+
+        let namespace = publish.namespace().clone();
+        let track_name = publish.name().clone();
+
+        // Take the reader first, then follow the same order as PUBLISH_NAMESPACE:
+        // local registration → coordinator registration → PUBLISH_OK.
+        let reader = match publish.take_reader() {
+            Ok(reader) => reader,
+            Err(err) => {
+                metrics::counter!("moq_relay_publish_errors_total", "phase" => "take_reader")
+                    .increment(1);
+                return Err(err.into());
+            }
+        };
+
+        let _registration = match self
+            .locals
+            .register_track(self.context.scope(), reader)
+            .await
+        {
+            Ok(registration) => registration,
+            Err(err) => {
+                metrics::counter!("moq_relay_publish_errors_total", "phase" => "local_register")
+                    .increment(1);
+                if err
+                    .downcast_ref::<ServeError>()
+                    .is_some_and(|err| matches!(err, ServeError::Duplicate))
+                {
+                    publish.close(ServeError::Duplicate);
+                    return Err(ServeError::Duplicate.into());
+                }
+                return Err(err);
+            }
+        };
+
+        let track_string = track_name.to_string();
+        let _track_registration = match self
+            .coordinator
+            .register_track(self.context.scope(), &namespace, &track_string)
+            .await
+        {
+            Ok(registration) => registration,
+            Err(err) => {
+                metrics::counter!("moq_relay_publish_errors_total", "phase" => "coordinator_register")
+                    .increment(1);
+                publish.close(ServeError::Closed(RequestErrorCode::InternalError as u64));
+                return Err(err.into());
+            }
+        };
+
+        if let Err(err) = publish.accept(true) {
+            metrics::counter!("moq_relay_publish_errors_total", "phase" => "send_ok").increment(1);
+            return Err(err.into());
+        }
+
+        tracing::debug!(
+            namespace = %namespace,
+            track = %track_name,
+            "PUBLISH registered as exact local track"
+        );
+
+        publish.closed().await?;
+        tracing::info!(namespace = %namespace, track = %track_name, "PUBLISH closed");
+
+        Ok(())
     }
 }

--- a/moq-relay-ietf/src/coordinator.rs
+++ b/moq-relay-ietf/src/coordinator.rs
@@ -5,8 +5,10 @@ use std::net::SocketAddr;
 
 use async_trait::async_trait;
 use moq_native_ietf::quic;
-use moq_transport::coding::TrackNamespace;
+use moq_transport::coding::{TrackNamespace, TrackNamespacePrefix};
 use url::Url;
+
+use crate::session::SessionInterface;
 
 #[derive(Debug, thiserror::Error)]
 pub enum CoordinatorError {
@@ -211,9 +213,17 @@ pub struct ScopeConfig {
 /// The subscription remains active until this handle is dropped.
 /// On drop, cleanup is performed (e.g., unregistering from the coordinator).
 pub struct NamespaceSubscription {
-    /// Namespaces that currently match the subscribed prefix.
-    /// The relay should send PUBLISH_NAMESPACE for each of these.
-    pub existing_namespaces: Vec<NamespaceInfo>,
+    /// Peer relays that currently host namespaces matching the subscribed
+    /// prefix. The subscribing relay opens upstream SUBSCRIBE_NAMESPACE
+    /// sessions to these to receive live NAMESPACE / NAMESPACE_DONE updates.
+    /// The coordinator excludes the caller and the inbound source peer, so
+    /// every entry is a distinct upstream that is safe to pull from.
+    ///
+    /// The matching namespaces themselves are not returned here: they are
+    /// delivered live over the upstream pull sessions (cross-relay) and served
+    /// from relay-local state (same-relay), so a static snapshot would be both
+    /// redundant and unable to reflect later withdrawals.
+    pub upstream_relays: Vec<RelayInfo>,
 
     /// RAII handle — drop triggers unsubscription cleanup.
     _registration: Box<dyn Send + Sync>,
@@ -222,37 +232,19 @@ pub struct NamespaceSubscription {
 impl Default for NamespaceSubscription {
     fn default() -> Self {
         Self {
-            existing_namespaces: vec![],
+            upstream_relays: vec![],
             _registration: Box::new(()),
         }
     }
 }
 
 impl NamespaceSubscription {
-    /// Create a new subscription with existing namespaces and a cleanup handle.
-    pub fn new<T: Send + Sync + 'static>(existing: Vec<NamespaceInfo>, inner: T) -> Self {
+    /// Create a new subscription with upstream relays and a cleanup handle.
+    pub fn new<T: Send + Sync + 'static>(upstream_relays: Vec<RelayInfo>, inner: T) -> Self {
         Self {
-            existing_namespaces: existing,
+            upstream_relays,
             _registration: Box::new(inner),
         }
-    }
-}
-
-/// Information about a registered namespace.
-///
-/// Returned in [`NamespaceSubscription`] to describe namespaces matching
-/// a SUBSCRIBE_NAMESPACE prefix.
-#[derive(Debug, Clone)]
-#[non_exhaustive]
-pub struct NamespaceInfo {
-    /// The namespace identity.
-    pub namespace: TrackNamespace,
-}
-
-impl NamespaceInfo {
-    /// Create a new NamespaceInfo.
-    pub fn new(namespace: TrackNamespace) -> Self {
-        Self { namespace }
     }
 }
 
@@ -282,6 +274,68 @@ impl RelayInfo {
         Self {
             url,
             addr: Some(addr),
+        }
+    }
+
+    /// Create a `RelayInfo` identity from an inbound peer's socket address.
+    ///
+    /// Used when a relay accepts an internal connection and only knows the
+    /// peer by its transport-level source address — it trusts the incoming
+    /// socket address rather than asking the coordinator to resolve the
+    /// peer's canonical URL. The [`url`](Self::url) is a synthetic
+    /// `https://{addr}` identity; callers should treat [`addr`](Self::addr)
+    /// as the authoritative field and must not assume the URL is dialable.
+    pub fn from_socket_addr(addr: SocketAddr) -> Self {
+        // A `SocketAddr` always renders as a valid `host:port` authority
+        // (IPv6 is bracketed by its `Display`), so this parse is infallible.
+        let url = Url::parse(&format!("https://{addr}"))
+            .expect("socket address forms a valid https authority");
+        Self {
+            url,
+            addr: Some(addr),
+        }
+    }
+}
+
+/// Per-call context describing how a coordinator operation reached this relay.
+///
+/// Passed alongside `scope` to routing/registration methods so a coordinator
+/// can distinguish public client traffic from internal relay-to-relay traffic
+/// and, for the latter, know which peer relay it came from.
+///
+/// The relay's own URL (the "caller") is intentionally **not** part of this
+/// context: each coordinator instance is constructed knowing its own relay
+/// URL, so it does not need to be told on every call.
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct CoordinatorContext {
+    /// Whether the originating session is public client-facing or internal
+    /// relay-to-relay. Defaults to [`SessionInterface::Public`].
+    pub interface: SessionInterface,
+
+    /// The peer relay this operation was received from, for internal
+    /// sessions. `None` for public client sessions.
+    ///
+    /// Derived by the relay from the inbound socket address (see
+    /// [`RelayInfo::from_socket_addr`]); the coordinator is not asked to
+    /// resolve peer identity.
+    pub source: Option<RelayInfo>,
+}
+
+impl CoordinatorContext {
+    /// A public, client-facing context with no peer relay.
+    pub fn public() -> Self {
+        Self {
+            interface: SessionInterface::Public,
+            source: None,
+        }
+    }
+
+    /// An internal, relay-to-relay context originating from `source`.
+    pub fn internal(source: Option<RelayInfo>) -> Self {
+        Self {
+            interface: SessionInterface::Internal,
+            source,
         }
     }
 }
@@ -448,6 +502,10 @@ pub trait Coordinator: Send + Sync {
     ///   registrations — the same namespace in different scopes may
     ///   route independently.
     /// * `namespace` - The namespace being registered
+    /// * `context` - Whether the registering session is a public client or an
+    ///   internal relay peer (and which peer). Coordinators may use this to
+    ///   avoid, for example, re-advertising registrations that arrived from
+    ///   another relay.
     ///
     /// # Returns
     ///
@@ -459,6 +517,7 @@ pub trait Coordinator: Send + Sync {
         &self,
         scope: Option<&str>,
         namespace: &TrackNamespace,
+        context: &CoordinatorContext,
     ) -> CoordinatorResult<NamespaceRegistration>;
 
     /// Unregister a namespace.
@@ -501,6 +560,27 @@ pub trait Coordinator: Send + Sync {
         scope: Option<&str>,
         namespace: &TrackNamespace,
     ) -> CoordinatorResult<(NamespaceOrigin, Option<quic::Client>)>;
+
+    /// Lookup where a specific track is served from.
+    ///
+    /// Called when a subscriber requests a full track name. Implementations
+    /// should prefer exact track registrations created by PUBLISH, then fall
+    /// back to namespace routing created by PUBLISH_NAMESPACE. This keeps the
+    /// common caller ergonomic while still allowing a single PUBLISH track to be
+    /// routed without pretending the whole namespace was published.
+    ///
+    /// # Default Implementation
+    ///
+    /// Falls back to [`lookup`], so existing coordinators that only implement
+    /// namespace-level routing retain their current behavior.
+    async fn lookup_track(
+        &self,
+        scope: Option<&str>,
+        namespace: &TrackNamespace,
+        _track: &str,
+    ) -> CoordinatorResult<(NamespaceOrigin, Option<quic::Client>)> {
+        self.lookup(scope, namespace).await
+    }
 
     /// Graceful shutdown of the coordinator.
     ///
@@ -546,27 +626,55 @@ pub trait Coordinator: Send + Sync {
     /// Called when a subscriber sends SUBSCRIBE_NAMESPACE. The coordinator
     /// should:
     /// 1. Record that this relay is interested in the prefix
-    /// 2. Return currently-matching namespaces
+    /// 2. Return the peer relays that host currently-matching namespaces (the
+    ///    upstream pull targets)
     /// 3. Return an RAII handle for cleanup on disconnect
     ///
-    /// When publishers later register namespaces matching this prefix, the
-    /// relay uses [`lookup_namespace_subscribers()`] to find interested relays
-    /// and forward PUBLISH_NAMESPACE to them.
+    /// The subscribing relay opens upstream SUBSCRIBE_NAMESPACE sessions to the
+    /// returned [`NamespaceSubscription::upstream_relays`] to receive live
+    /// NAMESPACE / NAMESPACE_DONE updates for namespaces that already exist
+    /// (the publish-before-subscribe case). Separately, when publishers *later*
+    /// register namespaces matching this prefix, the origin relay uses
+    /// [`lookup_namespace_subscribers()`] to find interested relays and push
+    /// PUBLISH_NAMESPACE to them (the subscribe-before-publish case).
+    ///
+    /// The subscribing relay applies **no** routing or topology policy of its
+    /// own and does not interpret the session interface: it simply opens an
+    /// upstream pull to each relay in `upstream_relays`, and an empty list means
+    /// "serve from local state only, do not connect upstream". All routing
+    /// policy therefore lives in the coordinator.
+    ///
+    /// To decide what to return, the coordinator MAY use the informational
+    /// [`CoordinatorContext`] — in particular the session
+    /// [`interface`][CoordinatorContext::interface] (public client vs. internal
+    /// relay peer) and the [`source`][CoordinatorContext::source] peer. For
+    /// example, the built-in implementations exclude both the caller (this
+    /// relay's own endpoint) and the source peer, so a relay is never told to
+    /// pull from itself or from the peer the SUBSCRIBE_NAMESPACE just arrived
+    /// from; and they return an empty list for internal sessions, so a pull
+    /// opened on another relay's behalf does not itself fan out upstream (which
+    /// would otherwise make relays recurse — and, in a mesh, cycle). Those are
+    /// policy choices of the built-in implementations, not requirements of this
+    /// trait. Interest is still recorded for the push path regardless of
+    /// interface.
     ///
     /// # Arguments
     ///
     /// * `scope` - The resolved scope identity, or `None` for unscoped sessions.
     /// * `prefix` - The namespace prefix to subscribe to.
+    /// * `context` - Whether the subscribing session is a public client or an
+    ///   internal relay peer (and which peer).
     ///
     /// # Default Implementation
     ///
-    /// Returns an empty subscription (no existing namespaces, no-op cleanup).
+    /// Returns an empty subscription (no upstream relays, no-op cleanup).
     ///
     /// [`lookup_namespace_subscribers()`]: Coordinator::lookup_namespace_subscribers
     async fn subscribe_namespace(
         &self,
         _scope: Option<&str>,
-        _prefix: &TrackNamespace,
+        _prefix: &TrackNamespacePrefix,
+        _context: &CoordinatorContext,
     ) -> CoordinatorResult<NamespaceSubscription> {
         Ok(NamespaceSubscription::default())
     }
@@ -588,7 +696,7 @@ pub trait Coordinator: Send + Sync {
     async fn unsubscribe_namespace(
         &self,
         _scope: Option<&str>,
-        _prefix: &TrackNamespace,
+        _prefix: &TrackNamespacePrefix,
     ) -> CoordinatorResult<()> {
         Ok(())
     }
@@ -603,10 +711,18 @@ pub trait Coordinator: Send + Sync {
     ///
     /// * `scope` - The resolved scope identity, or `None` for unscoped sessions.
     /// * `namespace` - The newly-registered namespace.
+    /// * `context` - Origin of the PUBLISH_NAMESPACE that triggered this lookup.
+    ///   Implementations MUST use this (together with their own relay identity)
+    ///   to exclude relays that would create forwarding loops:
+    ///   - the **caller** (this relay's own endpoint), so a relay never forwards
+    ///     PUBLISH_NAMESPACE to itself; and
+    ///   - the **source** ([`CoordinatorContext::source`]), so a PUBLISH_NAMESPACE
+    ///     is never echoed back to the peer relay it just arrived from.
     ///
     /// # Returns
     ///
-    /// List of relay endpoints to forward PUBLISH_NAMESPACE to.
+    /// List of peer relay endpoints to forward PUBLISH_NAMESPACE to, with the
+    /// caller and source excluded.
     ///
     /// # Default Implementation
     ///
@@ -615,6 +731,7 @@ pub trait Coordinator: Send + Sync {
         &self,
         _scope: Option<&str>,
         _namespace: &TrackNamespace,
+        _context: &CoordinatorContext,
     ) -> CoordinatorResult<Vec<RelayInfo>> {
         Ok(vec![])
     }
@@ -812,8 +929,16 @@ mod tests {
         TrackNamespace::from_utf8_path(path)
     }
 
+    fn prefix(path: &str) -> TrackNamespacePrefix {
+        TrackNamespacePrefix::from_utf8_path(path)
+    }
+
     /// Returns true if `namespace` starts with all the fields in `prefix`.
-    fn ns_has_prefix(namespace: &TrackNamespace, prefix: &TrackNamespace) -> bool {
+    fn ns_has_prefix(namespace: &TrackNamespace, prefix: &TrackNamespacePrefix) -> bool {
+        prefix.is_prefix_of(namespace)
+    }
+
+    fn ns_has_namespace_prefix(namespace: &TrackNamespace, prefix: &TrackNamespace) -> bool {
         namespace.fields.len() >= prefix.fields.len()
             && prefix
                 .fields
@@ -860,7 +985,7 @@ mod tests {
         tracks: HashMap<String, HashMap<(TrackNamespace, String), String>>,
 
         /// Maps scope → SUBSCRIBE_NAMESPACE prefixes → list of relay URLs
-        namespace_subscribers: HashMap<String, HashMap<TrackNamespace, Vec<String>>>,
+        namespace_subscribers: HashMap<String, HashMap<TrackNamespacePrefix, Vec<String>>>,
 
         /// Maps scope → subscribed tracks → list of relay URLs
         /// Key: (namespace, track_name)
@@ -919,7 +1044,7 @@ mod tests {
     struct MockNamespaceSubHandle {
         state: std::sync::Arc<Mutex<MockState>>,
         scope_key: String,
-        prefix: TrackNamespace,
+        prefix: TrackNamespacePrefix,
         relay_url: String,
     }
 
@@ -979,6 +1104,19 @@ mod tests {
             }
         }
 
+        /// Create another relay's view of the *same* shared oracle state.
+        ///
+        /// The returned coordinator shares this instance's registry but reports
+        /// a different `relay_url`, modelling a distinct relay talking to the
+        /// same coordinator (as separate relay processes do with a shared
+        /// [`FileCoordinator`] file).
+        fn peer(&self, relay_url: &str) -> Self {
+            Self {
+                state: self.state.clone(),
+                relay_url: Url::parse(relay_url).unwrap(),
+            }
+        }
+
         /// Configure scope resolution: connection path → ScopeInfo.
         fn add_path_mapping(&self, path: &str, scope_id: &str, permissions: ScopePermissions) {
             let mut state = self.state.lock().unwrap();
@@ -1025,6 +1163,7 @@ mod tests {
             &self,
             scope: Option<&str>,
             namespace: &TrackNamespace,
+            _context: &CoordinatorContext,
         ) -> CoordinatorResult<NamespaceRegistration> {
             let scope_key = MockState::scope_key(scope);
             let relay_url = self.relay_url.to_string();
@@ -1081,7 +1220,7 @@ mod tests {
             // Prefix match (longest wins)
             let mut best: Option<(&TrackNamespace, &String)> = None;
             for (registered, url) in bucket {
-                if ns_has_prefix(namespace, registered) {
+                if ns_has_namespace_prefix(namespace, registered) {
                     match &best {
                         Some((prev, _)) if registered.fields.len() > prev.fields.len() => {
                             best = Some((registered, url));
@@ -1103,6 +1242,30 @@ mod tests {
             }
         }
 
+        async fn lookup_track(
+            &self,
+            scope: Option<&str>,
+            namespace: &TrackNamespace,
+            track: &str,
+        ) -> CoordinatorResult<(NamespaceOrigin, Option<quic::Client>)> {
+            let scope_key = MockState::scope_key(scope);
+            let track_key = MockState::track_key(namespace, track);
+
+            {
+                let state = self.state.lock().unwrap();
+                if let Some(relay_url) = state
+                    .tracks
+                    .get(&scope_key)
+                    .and_then(|bucket| bucket.get(&track_key))
+                {
+                    let url = Url::parse(relay_url).unwrap();
+                    return Ok((NamespaceOrigin::new(namespace.clone(), url, None), None));
+                }
+            }
+
+            self.lookup(scope, namespace).await
+        }
+
         async fn get_scope_config(&self, scope: Option<&str>) -> CoordinatorResult<ScopeConfig> {
             let state = self.state.lock().unwrap();
             let scope_key = MockState::scope_key(scope);
@@ -1116,25 +1279,44 @@ mod tests {
         async fn subscribe_namespace(
             &self,
             scope: Option<&str>,
-            prefix: &TrackNamespace,
+            prefix: &TrackNamespacePrefix,
+            context: &CoordinatorContext,
         ) -> CoordinatorResult<NamespaceSubscription> {
             let scope_key = MockState::scope_key(scope);
             let relay_url = self.relay_url.to_string();
 
+            // Exclude the caller (this relay) and the inbound source peer so we
+            // never return ourselves or the relay the SUBSCRIBE_NAMESPACE
+            // arrived from as an upstream to pull from.
+            let caller = relay_url.clone();
+            let source = context.source.as_ref().map(|relay| relay.url.to_string());
+
             let mut state = self.state.lock().unwrap();
 
-            // Find currently-registered namespaces that match the prefix
-            let existing: Vec<NamespaceInfo> = state
-                .namespaces
-                .get(&scope_key)
-                .map(|bucket| {
-                    bucket
-                        .keys()
-                        .filter(|ns| ns_has_prefix(ns, prefix))
-                        .map(|ns| NamespaceInfo::new(ns.clone()))
-                        .collect()
-                })
-                .unwrap_or_default();
+            // Find the distinct relays hosting namespaces that match the prefix
+            // (the upstream pull targets), excluding the caller and source. Only
+            // public sessions fan out: an internal (relay-to-relay) pull must
+            // not recurse, so it is served from local state alone (empty
+            // upstream_relays breaks the loop). Interest is still recorded below
+            // for the push path regardless of interface.
+            let mut upstream_relays = Vec::new();
+            if context.interface == SessionInterface::Public {
+                let mut seen_relays = std::collections::HashSet::new();
+                if let Some(bucket) = state.namespaces.get(&scope_key) {
+                    for (ns, hosting_relay) in bucket {
+                        if !ns_has_prefix(ns, prefix) {
+                            continue;
+                        }
+                        if hosting_relay == &caller || Some(hosting_relay) == source.as_ref() {
+                            continue;
+                        }
+                        if seen_relays.insert(hosting_relay.clone()) {
+                            upstream_relays
+                                .push(RelayInfo::new(Url::parse(hosting_relay).unwrap()));
+                        }
+                    }
+                }
+            }
 
             // Register this relay as interested in the prefix
             state
@@ -1152,13 +1334,13 @@ mod tests {
                 relay_url,
             };
 
-            Ok(NamespaceSubscription::new(existing, handle))
+            Ok(NamespaceSubscription::new(upstream_relays, handle))
         }
 
         async fn unsubscribe_namespace(
             &self,
             scope: Option<&str>,
-            prefix: &TrackNamespace,
+            prefix: &TrackNamespacePrefix,
         ) -> CoordinatorResult<()> {
             let scope_key = MockState::scope_key(scope);
             let relay_url = self.relay_url.to_string();
@@ -1175,15 +1357,29 @@ mod tests {
             &self,
             scope: Option<&str>,
             namespace: &TrackNamespace,
+            context: &CoordinatorContext,
         ) -> CoordinatorResult<Vec<RelayInfo>> {
             let scope_key = MockState::scope_key(scope);
             let state = self.state.lock().unwrap();
 
+            // Exclude the caller (this relay) and the inbound source peer so a
+            // forwarded PUBLISH_NAMESPACE is never sent to ourselves or echoed
+            // back to the relay it just arrived from.
+            let caller = self.relay_url.to_string();
+            let source = context.source.as_ref().map(|relay| relay.url.to_string());
+
+            let mut seen = std::collections::HashSet::new();
             let mut relays = Vec::new();
             if let Some(subs) = state.namespace_subscribers.get(&scope_key) {
                 for (prefix, relay_urls) in subs {
-                    if ns_has_prefix(namespace, prefix) {
-                        for url_str in relay_urls {
+                    if !ns_has_prefix(namespace, prefix) {
+                        continue;
+                    }
+                    for url_str in relay_urls {
+                        if url_str == &caller || Some(url_str) == source.as_ref() {
+                            continue;
+                        }
+                        if seen.insert(url_str.clone()) {
                             relays.push(RelayInfo::new(Url::parse(url_str).unwrap()));
                         }
                     }
@@ -1359,12 +1555,6 @@ mod tests {
     }
 
     #[test]
-    fn namespace_info_construction() {
-        let info = NamespaceInfo::new(ns("sports/football/match-42"));
-        assert_eq!(info.namespace.to_utf8_path(), "/sports/football/match-42");
-    }
-
-    #[test]
     fn relay_info_without_addr() {
         let info = RelayInfo::new(Url::parse("https://relay-us-east.example.com").unwrap());
         assert_eq!(info.url.as_str(), "https://relay-us-east.example.com/");
@@ -1392,7 +1582,7 @@ mod tests {
     #[test]
     fn namespace_subscription_default_is_empty() {
         let sub = NamespaceSubscription::default();
-        assert!(sub.existing_namespaces.is_empty());
+        assert!(sub.upstream_relays.is_empty());
     }
 
     #[test]
@@ -1502,6 +1692,41 @@ mod tests {
     }
 
     // ========================================================================
+    // RelayInfo / CoordinatorContext
+    // ========================================================================
+
+    #[test]
+    fn relay_info_from_socket_addr_synthesizes_https_identity() {
+        let v4: SocketAddr = "203.0.113.7:4443".parse().unwrap();
+        let info = RelayInfo::from_socket_addr(v4);
+        assert_eq!(info.addr, Some(v4));
+        assert_eq!(info.url.as_str(), "https://203.0.113.7:4443/");
+
+        // IPv6 authorities are bracketed by SocketAddr's Display.
+        let v6: SocketAddr = "[2001:db8::1]:4443".parse().unwrap();
+        let info6 = RelayInfo::from_socket_addr(v6);
+        assert_eq!(info6.addr, Some(v6));
+        assert_eq!(info6.url.as_str(), "https://[2001:db8::1]:4443/");
+    }
+
+    #[test]
+    fn coordinator_context_constructors() {
+        let public = CoordinatorContext::public();
+        assert_eq!(public.interface, SessionInterface::Public);
+        assert!(public.source.is_none());
+
+        let addr: SocketAddr = "10.0.0.7:4443".parse().unwrap();
+        let internal = CoordinatorContext::internal(Some(RelayInfo::from_socket_addr(addr)));
+        assert_eq!(internal.interface, SessionInterface::Internal);
+        assert_eq!(internal.source.unwrap().addr, Some(addr));
+
+        // Default is public with no source.
+        let default = CoordinatorContext::default();
+        assert_eq!(default.interface, SessionInterface::Public);
+        assert!(default.source.is_none());
+    }
+
+    // ========================================================================
     // Namespace registration and lookup
     // ========================================================================
 
@@ -1512,7 +1737,11 @@ mod tests {
         let scope = Some("content-provider-123");
 
         let _reg = coord
-            .register_namespace(scope, &ns("sports/football/match-42"))
+            .register_namespace(
+                scope,
+                &ns("sports/football/match-42"),
+                &CoordinatorContext::public(),
+            )
             .await
             .unwrap();
 
@@ -1532,7 +1761,11 @@ mod tests {
         let scope = Some("content-provider-123");
 
         let _reg = coord
-            .register_namespace(scope, &ns("sports/football/match-42"))
+            .register_namespace(
+                scope,
+                &ns("sports/football/match-42"),
+                &CoordinatorContext::public(),
+            )
             .await
             .unwrap();
 
@@ -1560,7 +1793,11 @@ mod tests {
         let coord = MockCoordinator::new("https://relay-1.example.com");
 
         let _reg = coord
-            .register_namespace(Some("provider-abc"), &ns("live/main"))
+            .register_namespace(
+                Some("provider-abc"),
+                &ns("live/main"),
+                &CoordinatorContext::public(),
+            )
             .await
             .unwrap();
 
@@ -1582,12 +1819,20 @@ mod tests {
         let scope = Some("content-provider-123");
 
         let _reg = coord
-            .register_namespace(scope, &ns("sports/football/match-42"))
+            .register_namespace(
+                scope,
+                &ns("sports/football/match-42"),
+                &CoordinatorContext::public(),
+            )
             .await
             .unwrap();
 
         let result = coord
-            .register_namespace(scope, &ns("sports/football/match-42"))
+            .register_namespace(
+                scope,
+                &ns("sports/football/match-42"),
+                &CoordinatorContext::public(),
+            )
             .await;
         assert!(matches!(
             result,
@@ -1602,7 +1847,11 @@ mod tests {
 
         {
             let _reg = coord
-                .register_namespace(scope, &ns("sports/football/match-42"))
+                .register_namespace(
+                    scope,
+                    &ns("sports/football/match-42"),
+                    &CoordinatorContext::public(),
+                )
                 .await
                 .unwrap();
 
@@ -1623,43 +1872,177 @@ mod tests {
     // ========================================================================
 
     #[tokio::test]
-    async fn subscribe_namespace_returns_existing_matches() {
-        // An edge relay subscribes to all broadcasts from a content provider's
-        // "sports/football" prefix. Two matches are already live; a third
-        // match under "sports/tennis" should NOT match.
-        let coord = MockCoordinator::new("https://relay-1.example.com");
+    async fn subscribe_namespace_returns_hosting_relays_for_matching_prefix() {
+        // Two football matches are live on origin-a; an unrelated tennis match
+        // is live on origin-b. An edge relay subscribes to the "sports/football"
+        // prefix and must be told to pull from origin-a only — deduped across
+        // both football matches, and never origin-b, whose namespace does not
+        // match the prefix.
+        let origin_a = MockCoordinator::new("https://origin-a.example.com");
+        let origin_b = origin_a.peer("https://origin-b.example.com");
+        let edge = origin_a.peer("https://edge.example.com");
         let scope = Some("content-provider-123");
 
-        // Two football matches already live
-        let _reg_match42 = coord
-            .register_namespace(scope, &ns("sports/football/match-42"))
+        // Two football matches, both hosted by origin-a.
+        let _reg_match42 = origin_a
+            .register_namespace(
+                scope,
+                &ns("sports/football/match-42"),
+                &CoordinatorContext::public(),
+            )
             .await
             .unwrap();
-        let _reg_match43 = coord
-            .register_namespace(scope, &ns("sports/football/match-43"))
-            .await
-            .unwrap();
-
-        // A tennis match (should NOT match the football prefix)
-        let _reg_tennis = coord
-            .register_namespace(scope, &ns("sports/tennis/open-7"))
-            .await
-            .unwrap();
-
-        // Subscribe to the football prefix
-        let sub = coord
-            .subscribe_namespace(scope, &ns("sports/football"))
+        let _reg_match43 = origin_a
+            .register_namespace(
+                scope,
+                &ns("sports/football/match-43"),
+                &CoordinatorContext::public(),
+            )
             .await
             .unwrap();
 
-        assert_eq!(sub.existing_namespaces.len(), 2);
-        let paths: Vec<String> = sub
-            .existing_namespaces
+        // A tennis match on a different origin (should NOT match the football
+        // prefix, so origin-b must not appear as an upstream).
+        let _reg_tennis = origin_b
+            .register_namespace(
+                scope,
+                &ns("sports/tennis/open-7"),
+                &CoordinatorContext::public(),
+            )
+            .await
+            .unwrap();
+
+        // Subscribe to the football prefix from a third relay.
+        let sub = edge
+            .subscribe_namespace(
+                scope,
+                &prefix("sports/football"),
+                &CoordinatorContext::public(),
+            )
+            .await
+            .unwrap();
+
+        let urls: Vec<&str> = sub
+            .upstream_relays
             .iter()
-            .map(|n| n.namespace.to_utf8_path())
+            .map(|relay| relay.url.as_str())
             .collect();
-        assert!(paths.contains(&"/sports/football/match-42".to_string()));
-        assert!(paths.contains(&"/sports/football/match-43".to_string()));
+        assert_eq!(urls, vec!["https://origin-a.example.com/"]);
+    }
+
+    #[tokio::test]
+    async fn subscribe_namespace_empty_prefix_matches_all_namespaces() {
+        // An empty prefix matches every namespace, so the subscriber must be
+        // told to pull from every distinct hosting relay.
+        let origin_a = MockCoordinator::new("https://origin-a.example.com");
+        let origin_b = origin_a.peer("https://origin-b.example.com");
+        let edge = origin_a.peer("https://edge-us-west.example.com");
+        let scope = Some("content-provider-123");
+
+        let _football = origin_a
+            .register_namespace(
+                scope,
+                &ns("sports/football/match-42"),
+                &CoordinatorContext::public(),
+            )
+            .await
+            .unwrap();
+        let _tennis = origin_b
+            .register_namespace(
+                scope,
+                &ns("sports/tennis/open-7"),
+                &CoordinatorContext::public(),
+            )
+            .await
+            .unwrap();
+
+        let sub = edge
+            .subscribe_namespace(
+                scope,
+                &TrackNamespacePrefix::new(),
+                &CoordinatorContext::public(),
+            )
+            .await
+            .unwrap();
+
+        let mut urls: Vec<String> = sub
+            .upstream_relays
+            .iter()
+            .map(|relay| relay.url.to_string())
+            .collect();
+        urls.sort();
+
+        assert_eq!(
+            urls,
+            vec![
+                "https://origin-a.example.com/".to_string(),
+                "https://origin-b.example.com/".to_string(),
+            ]
+        );
+
+        // The edge's interest also persists for the reverse (push) direction:
+        // origin-a's lookup finds the edge subscriber.
+        let interested = origin_a
+            .lookup_namespace_subscribers(
+                scope,
+                &ns("sports/football/match-44"),
+                &CoordinatorContext::public(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(interested.len(), 1);
+        assert_eq!(
+            interested[0].url.as_str(),
+            "https://edge-us-west.example.com/"
+        );
+    }
+
+    #[tokio::test]
+    async fn internal_subscribe_namespace_returns_no_upstream_relays() {
+        // A pull opened on another relay's behalf arrives as an internal
+        // session. Even though a peer hosts a matching namespace, the
+        // coordinator returns no upstream relays, so the pull is served from
+        // local state and does not recurse -- this is the loop-breaker. The
+        // source peer is deliberately a *third* relay that does not host the
+        // namespace, so only the interface (not caller/source exclusion) can
+        // explain the empty result.
+        let origin = MockCoordinator::new("https://origin.example.com");
+        let edge = origin.peer("https://edge.example.com");
+        let scope = Some("content-provider-123");
+
+        let _registration = origin
+            .register_namespace(scope, &ns("room/alice"), &CoordinatorContext::public())
+            .await
+            .unwrap();
+
+        // A public subscribe from the edge is told to pull from the origin...
+        let public_sub = edge
+            .subscribe_namespace(scope, &prefix("room"), &CoordinatorContext::public())
+            .await
+            .unwrap();
+        assert_eq!(
+            public_sub.upstream_relays.len(),
+            1,
+            "public sessions fan out to hosting relays"
+        );
+
+        // ...but an internal subscribe (a relay pulling on another's behalf) is
+        // given nothing to pull, so it serves from local state only.
+        let internal_sub = edge
+            .subscribe_namespace(
+                scope,
+                &prefix("room"),
+                &CoordinatorContext::internal(Some(RelayInfo::new(
+                    Url::parse("https://other.example.com").unwrap(),
+                ))),
+            )
+            .await
+            .unwrap();
+        assert!(
+            internal_sub.upstream_relays.is_empty(),
+            "internal sessions are served from local state, breaking the pull loop"
+        );
     }
 
     #[tokio::test]
@@ -1673,13 +2056,24 @@ mod tests {
 
         // Edge relay subscribes to the football prefix
         let _sub = coord
-            .subscribe_namespace(scope, &ns("sports/football"))
+            .subscribe_namespace(
+                scope,
+                &prefix("sports/football"),
+                &CoordinatorContext::public(),
+            )
             .await
             .unwrap();
 
-        // New match starts — who needs to know?
-        let interested = coord
-            .lookup_namespace_subscribers(scope, &ns("sports/football/match-44"))
+        // New match starts — the origin relay (a different relay than the
+        // subscribing edge) asks the oracle who needs to know. The edge
+        // subscriber is returned; the origin itself (the caller) is excluded.
+        let origin = coord.peer("https://origin.example.com");
+        let interested = origin
+            .lookup_namespace_subscribers(
+                scope,
+                &ns("sports/football/match-44"),
+                &CoordinatorContext::public(),
+            )
             .await
             .unwrap();
 
@@ -1691,29 +2085,228 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn lookup_namespace_subscribers_excludes_caller() {
+        // A relay that subscribed and is now performing the lookup must not be
+        // returned to itself; otherwise it would forward PUBLISH_NAMESPACE to
+        // its own endpoint and loop forever.
+        let coord = MockCoordinator::new("https://edge-us-west.example.com");
+        let scope = Some("content-provider-123");
+
+        let _sub = coord
+            .subscribe_namespace(
+                scope,
+                &prefix("sports/football"),
+                &CoordinatorContext::public(),
+            )
+            .await
+            .unwrap();
+
+        let interested = coord
+            .lookup_namespace_subscribers(
+                scope,
+                &ns("sports/football/match-44"),
+                &CoordinatorContext::public(),
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            interested.is_empty(),
+            "caller relay must be excluded from its own lookup results"
+        );
+    }
+
+    #[tokio::test]
+    async fn lookup_namespace_subscribers_excludes_source() {
+        // A PUBLISH_NAMESPACE that arrived from a peer relay must not be echoed
+        // back to that same peer.
+        let origin = MockCoordinator::new("https://origin.example.com");
+        let edge = origin.peer("https://edge-us-west.example.com");
+        let scope = Some("content-provider-123");
+
+        // The edge relay is the only subscriber.
+        let _sub = edge
+            .subscribe_namespace(
+                scope,
+                &prefix("sports/football"),
+                &CoordinatorContext::public(),
+            )
+            .await
+            .unwrap();
+
+        // With no source, the origin sees the edge subscriber.
+        let interested = origin
+            .lookup_namespace_subscribers(
+                scope,
+                &ns("sports/football/match-44"),
+                &CoordinatorContext::public(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(interested.len(), 1);
+
+        // When the PUBLISH_NAMESPACE arrived *from* the edge relay, it must not
+        // be echoed back to it.
+        let from_edge = CoordinatorContext::internal(Some(RelayInfo::new(
+            Url::parse("https://edge-us-west.example.com").unwrap(),
+        )));
+        let interested = origin
+            .lookup_namespace_subscribers(scope, &ns("sports/football/match-44"), &from_edge)
+            .await
+            .unwrap();
+        assert!(
+            interested.is_empty(),
+            "source relay must be excluded to avoid echoing PUBLISH_NAMESPACE back"
+        );
+    }
+
+    #[tokio::test]
     async fn namespace_subscription_cleaned_up_on_drop() {
         let coord = MockCoordinator::new("https://edge-us-west.example.com");
         let scope = Some("content-provider-123");
 
+        // The origin relay (distinct from the subscribing edge) performs the
+        // lookups, so the edge subscriber is visible until it disconnects.
+        let origin = coord.peer("https://origin.example.com");
         {
             let _sub = coord
-                .subscribe_namespace(scope, &ns("sports/football"))
+                .subscribe_namespace(
+                    scope,
+                    &prefix("sports/football"),
+                    &CoordinatorContext::public(),
+                )
                 .await
                 .unwrap();
 
-            let interested = coord
-                .lookup_namespace_subscribers(scope, &ns("sports/football/match-44"))
+            let interested = origin
+                .lookup_namespace_subscribers(
+                    scope,
+                    &ns("sports/football/match-44"),
+                    &CoordinatorContext::public(),
+                )
                 .await
                 .unwrap();
             assert_eq!(interested.len(), 1);
         }
         // _sub dropped — edge relay disconnected
 
-        let interested = coord
-            .lookup_namespace_subscribers(scope, &ns("sports/football/match-44"))
+        let interested = origin
+            .lookup_namespace_subscribers(
+                scope,
+                &ns("sports/football/match-44"),
+                &CoordinatorContext::public(),
+            )
             .await
             .unwrap();
         assert!(interested.is_empty());
+    }
+
+    // ========================================================================
+    // Cross-relay SUBSCRIBE_NAMESPACE choreography (two relays, one oracle)
+    //
+    // These integration-style tests play out the full two-relay handshake the
+    // relay performs across a shared coordinator oracle, in both orderings.
+    // Each step is annotated with the production call site that drives it, so
+    // the tests pin the oracle contract that `Consumer::serve` (consumer.rs) and
+    // `Producer::serve_subscribe_namespace` (producer.rs) rely on: which peer
+    // relay a subscriber pulls from (publish-before-subscribe) and which peer
+    // relays an origin pushes PUBLISH_NAMESPACE to (subscribe-before-publish).
+    //
+    // A live two-relay MoQT session is intentionally out of scope: there is no
+    // in-memory session harness, so `Consumer`/`Producer` cannot be built
+    // without standing up real QUIC endpoints. We validate the coordination
+    // decisions here; the transport plumbing is covered elsewhere.
+    // ========================================================================
+
+    #[tokio::test]
+    async fn two_relay_subscribe_before_publish_routes_publish_namespace() {
+        // Ordering: edge subscribes first, publisher arrives at the origin
+        // later. The origin's reverse lookup must discover the waiting edge so
+        // it pushes PUBLISH_NAMESPACE to it (the publish-after-subscribe path).
+        let origin = MockCoordinator::new("https://origin.example.com");
+        let edge = origin.peer("https://edge.example.com");
+        let scope = Some("content-provider-123");
+
+        // Edge relay: a client sent SUBSCRIBE_NAMESPACE, so the edge records its
+        // interest with the oracle. Maps to Producer::serve_subscribe_namespace
+        // -> coordinator.subscribe_namespace. Nothing is published yet, so there
+        // is no upstream relay to pull from.
+        let sub = edge
+            .subscribe_namespace(scope, &prefix("room"), &CoordinatorContext::public())
+            .await
+            .unwrap();
+        assert!(
+            sub.upstream_relays.is_empty(),
+            "no namespaces exist yet, so there is no upstream relay to pull from"
+        );
+
+        // Origin relay: a publisher sent PUBLISH_NAMESPACE, registering the
+        // namespace. Maps to Consumer::serve -> coordinator.register_namespace.
+        let _registration = origin
+            .register_namespace(scope, &ns("room/alice"), &CoordinatorContext::public())
+            .await
+            .unwrap();
+
+        // Origin relay: still inside Consumer::serve, it asks the oracle who is
+        // interested (coordinator.lookup_namespace_subscribers). The waiting edge
+        // must be returned and the origin (the caller) excluded, so the origin
+        // pushes exactly one PUBLISH_NAMESPACE — to the edge.
+        let interested = origin
+            .lookup_namespace_subscribers(scope, &ns("room/alice"), &CoordinatorContext::public())
+            .await
+            .unwrap();
+        assert_eq!(interested.len(), 1);
+        assert_eq!(interested[0].url.as_str(), "https://edge.example.com/");
+    }
+
+    #[tokio::test]
+    async fn two_relay_publish_before_subscribe_returns_upstream_relay() {
+        // Ordering: the publisher is already live at the origin before any
+        // subscriber. This pins two independent oracle guarantees: the
+        // coordinator returns the origin as an upstream relay for the new
+        // subscriber to pull from, and the subscriber's interest persists so
+        // later namespaces still route to it via the reverse (push) lookup.
+        let origin = MockCoordinator::new("https://origin.example.com");
+        let edge = origin.peer("https://edge.example.com");
+        let scope = Some("content-provider-123");
+
+        // Origin relay: publisher registers the namespace first. Maps to
+        // Consumer::serve -> coordinator.register_namespace.
+        let _registration = origin
+            .register_namespace(scope, &ns("room/alice"), &CoordinatorContext::public())
+            .await
+            .unwrap();
+
+        // Edge relay: a client subscribes to the prefix afterwards. Maps to
+        // Producer::serve_subscribe_namespace -> coordinator.subscribe_namespace.
+        // The oracle reports the origin as the upstream relay to open an upstream
+        // SUBSCRIBE_NAMESPACE session to (the pull path that carries the
+        // already-published namespace, plus live updates, downstream).
+        let sub = edge
+            .subscribe_namespace(scope, &prefix("room"), &CoordinatorContext::public())
+            .await
+            .unwrap();
+        let urls: Vec<&str> = sub
+            .upstream_relays
+            .iter()
+            .map(|relay| relay.url.as_str())
+            .collect();
+        assert_eq!(urls, vec!["https://origin.example.com/"]);
+
+        // The edge's interest also persists for the reverse (push) direction: a
+        // *different* namespace published later under the same prefix must still
+        // discover the edge. Maps to Consumer::serve ->
+        // coordinator.lookup_namespace_subscribers.
+        let interested = origin
+            .lookup_namespace_subscribers(
+                scope,
+                &ns("room/beatrice"),
+                &CoordinatorContext::public(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(interested.len(), 1);
+        assert_eq!(interested[0].url.as_str(), "https://edge.example.com/");
     }
 
     // ========================================================================
@@ -1748,6 +2341,47 @@ mod tests {
         assert!(names.contains(&"video-1080p"));
         assert!(names.contains(&"video-480p"));
         assert!(names.contains(&"audio-en"));
+    }
+
+    #[tokio::test]
+    async fn lookup_track_finds_exact_registered_track() {
+        let coord = MockCoordinator::new("https://relay-1.example.com");
+        let scope = Some("content-provider-123");
+        let match_ns = ns("sports/football/match-42");
+
+        let _reg = coord
+            .register_track(scope, &match_ns, "video-1080p")
+            .await
+            .unwrap();
+
+        let (origin, client) = coord
+            .lookup_track(scope, &match_ns, "video-1080p")
+            .await
+            .unwrap();
+
+        assert_eq!(origin.namespace(), &match_ns);
+        assert_eq!(origin.url().as_str(), "https://relay-1.example.com/");
+        assert!(client.is_none());
+    }
+
+    #[tokio::test]
+    async fn lookup_track_falls_back_to_namespace_registration() {
+        let coord = MockCoordinator::new("https://relay-1.example.com");
+        let scope = Some("content-provider-123");
+        let match_ns = ns("sports/football/match-42");
+
+        let _namespace = coord
+            .register_namespace(scope, &match_ns, &CoordinatorContext::public())
+            .await
+            .unwrap();
+
+        let (origin, client) = coord
+            .lookup_track(scope, &match_ns, "video-1080p")
+            .await
+            .unwrap();
+        assert_eq!(origin.namespace(), &match_ns);
+        assert_eq!(origin.url().as_str(), "https://relay-1.example.com/");
+        assert!(client.is_none());
     }
 
     #[tokio::test]
@@ -1859,7 +2493,11 @@ mod tests {
 
         // Register the match namespace
         let _match_reg = origin
-            .register_namespace(scope, &ns("sports/football/match-42"))
+            .register_namespace(
+                scope,
+                &ns("sports/football/match-42"),
+                &CoordinatorContext::public(),
+            )
             .await
             .unwrap();
 
@@ -1881,7 +2519,11 @@ mod tests {
 
         // Edge subscribes to all football events (SUBSCRIBE_NAMESPACE)
         let _football_sub = edge
-            .subscribe_namespace(scope, &ns("sports/football"))
+            .subscribe_namespace(
+                scope,
+                &prefix("sports/football"),
+                &CoordinatorContext::public(),
+            )
             .await
             .unwrap();
 
@@ -1939,6 +2581,7 @@ mod tests {
             &self,
             _scope: Option<&str>,
             _namespace: &TrackNamespace,
+            _context: &CoordinatorContext,
         ) -> CoordinatorResult<NamespaceRegistration> {
             Ok(NamespaceRegistration::new(()))
         }
@@ -1992,17 +2635,25 @@ mod tests {
     async fn default_subscribe_namespace_returns_empty() {
         let coord = MinimalCoordinator;
         let sub = coord
-            .subscribe_namespace(Some("scope"), &ns("sports/football"))
+            .subscribe_namespace(
+                Some("scope"),
+                &prefix("sports/football"),
+                &CoordinatorContext::public(),
+            )
             .await
             .unwrap();
-        assert!(sub.existing_namespaces.is_empty());
+        assert!(sub.upstream_relays.is_empty());
     }
 
     #[tokio::test]
     async fn default_lookup_namespace_subscribers_returns_empty() {
         let coord = MinimalCoordinator;
         let relays = coord
-            .lookup_namespace_subscribers(Some("scope"), &ns("sports/football/match-42"))
+            .lookup_namespace_subscribers(
+                Some("scope"),
+                &ns("sports/football/match-42"),
+                &CoordinatorContext::public(),
+            )
             .await
             .unwrap();
         assert!(relays.is_empty());

--- a/moq-relay-ietf/src/covering_prefix_set.rs
+++ b/moq-relay-ietf/src/covering_prefix_set.rs
@@ -1,0 +1,214 @@
+// SPDX-FileCopyrightText: 2026 Cloudflare Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::collections::HashSet;
+
+use moq_transport::coding::TrackNamespacePrefix;
+
+#[derive(Debug, Default, Eq, PartialEq)]
+pub(crate) struct RootDelta {
+    pub(crate) added: HashSet<TrackNamespacePrefix>,
+    pub(crate) removed: HashSet<TrackNamespacePrefix>,
+}
+
+#[derive(Default)]
+pub(crate) struct CoveringPrefixSet {
+    // The manager's shared lease layer turns duplicate owners into one active prefix.
+    active: HashSet<TrackNamespacePrefix>,
+    roots: HashSet<TrackNamespacePrefix>,
+}
+
+impl CoveringPrefixSet {
+    pub(crate) fn add(&mut self, prefix: TrackNamespacePrefix) -> RootDelta {
+        if !self.active.insert(prefix.clone()) {
+            return RootDelta::default();
+        }
+
+        if self.roots.iter().any(|root| covers(root, &prefix)) {
+            return RootDelta::default();
+        }
+
+        let removed = self
+            .roots
+            .iter()
+            .filter(|root| covers(&prefix, root))
+            .cloned()
+            .collect::<HashSet<_>>();
+        self.roots.retain(|root| !removed.contains(root));
+        self.roots.insert(prefix.clone());
+
+        RootDelta {
+            added: HashSet::from([prefix]),
+            removed,
+        }
+    }
+
+    pub(crate) fn remove(&mut self, prefix: &TrackNamespacePrefix) -> RootDelta {
+        if !self.active.remove(prefix) {
+            return RootDelta::default();
+        }
+
+        if !self.roots.remove(prefix) {
+            return RootDelta::default();
+        }
+
+        let added = self
+            .active
+            .iter()
+            .filter(|candidate| covers(prefix, candidate))
+            .filter(|candidate| {
+                !self
+                    .active
+                    .iter()
+                    .any(|other| strictly_covers(other, candidate))
+            })
+            .cloned()
+            .collect::<HashSet<_>>();
+        self.roots.extend(added.iter().cloned());
+
+        RootDelta {
+            added,
+            removed: HashSet::from([prefix.clone()]),
+        }
+    }
+}
+
+fn covers(broader: &TrackNamespacePrefix, narrower: &TrackNamespacePrefix) -> bool {
+    broader.fields.len() <= narrower.fields.len() && broader.overlaps(narrower)
+}
+
+fn strictly_covers(broader: &TrackNamespacePrefix, narrower: &TrackNamespacePrefix) -> bool {
+    broader.fields.len() < narrower.fields.len() && broader.overlaps(narrower)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use moq_transport::coding::TupleField;
+
+    fn prefix(path: &str) -> TrackNamespacePrefix {
+        TrackNamespacePrefix::from_utf8_path(path)
+    }
+
+    fn prefixes(paths: &[&str]) -> HashSet<TrackNamespacePrefix> {
+        paths.iter().map(|path| prefix(path)).collect()
+    }
+
+    fn assert_delta(delta: RootDelta, added: &[&str], removed: &[&str]) {
+        assert_eq!(delta.added, prefixes(added));
+        assert_eq!(delta.removed, prefixes(removed));
+    }
+
+    #[test]
+    fn coalesces_idempotent_and_broader_prefixes() {
+        let mut set = CoveringPrefixSet::default();
+        let foo_bar = prefix("foo/bar");
+        let foo = prefix("foo");
+
+        assert_delta(set.add(foo_bar.clone()), &["foo/bar"], &[]);
+        assert_delta(set.add(foo_bar.clone()), &[], &[]);
+        assert_delta(set.add(foo.clone()), &["foo"], &["foo/bar"]);
+        assert_delta(set.remove(&foo), &["foo/bar"], &["foo"]);
+        assert_delta(set.remove(&foo_bar), &[], &["foo/bar"]);
+    }
+
+    #[test]
+    fn keeps_unrelated_siblings_as_roots() {
+        let mut set = CoveringPrefixSet::default();
+        let foo_a = prefix("foo/a");
+        let foo_b = prefix("foo/b");
+
+        assert_delta(set.add(foo_a.clone()), &["foo/a"], &[]);
+        assert_delta(set.add(foo_b.clone()), &["foo/b"], &[]);
+        assert_delta(set.remove(&foo_a), &[], &["foo/a"]);
+        assert_delta(set.remove(&foo_b), &[], &["foo/b"]);
+    }
+
+    #[test]
+    fn ignores_narrower_prefix_under_broad_root() {
+        let mut set = CoveringPrefixSet::default();
+        let foo = prefix("foo");
+        let foo_bar = prefix("foo/bar");
+
+        assert_delta(set.add(foo.clone()), &["foo"], &[]);
+        assert_delta(set.add(foo_bar.clone()), &[], &[]);
+        assert_delta(set.remove(&foo_bar), &[], &[]);
+        assert_delta(set.add(foo_bar.clone()), &[], &[]);
+        assert_delta(set.remove(&foo), &["foo/bar"], &["foo"]);
+        assert_delta(set.remove(&foo_bar), &[], &["foo/bar"]);
+    }
+
+    #[test]
+    fn reexposes_multiple_minimal_roots_after_deep_nesting() {
+        let mut set = CoveringPrefixSet::default();
+        let deep = prefix("foo/a/b/c");
+        let middle = prefix("foo/a/b");
+        let branch = prefix("foo/a/d/e");
+        let branch_leaf = prefix("foo/a/d/e/f");
+        let broad = prefix("foo");
+        let direct = prefix("foo/z");
+
+        assert_delta(set.add(deep.clone()), &["foo/a/b/c"], &[]);
+        assert_delta(set.add(middle.clone()), &["foo/a/b"], &["foo/a/b/c"]);
+        assert_delta(set.add(branch.clone()), &["foo/a/d/e"], &[]);
+        assert_delta(set.add(branch_leaf.clone()), &[], &[]);
+        assert_delta(set.add(broad.clone()), &["foo"], &["foo/a/b", "foo/a/d/e"]);
+        assert_delta(set.add(direct.clone()), &[], &[]);
+        assert_delta(
+            set.remove(&broad),
+            &["foo/a/b", "foo/a/d/e", "foo/z"],
+            &["foo"],
+        );
+        assert_delta(set.remove(&middle), &["foo/a/b/c"], &["foo/a/b"]);
+        assert_delta(set.remove(&branch), &["foo/a/d/e/f"], &["foo/a/d/e"]);
+    }
+
+    #[test]
+    fn empty_prefix_covers_and_reexposes_everything() {
+        let mut set = CoveringPrefixSet::default();
+        let empty = TrackNamespacePrefix::new();
+
+        assert_delta(set.add(prefix("foo/a")), &["foo/a"], &[]);
+        assert_delta(set.add(prefix("bar/b")), &["bar/b"], &[]);
+        assert_delta(set.add(empty.clone()), &[""], &["foo/a", "bar/b"]);
+        assert_delta(set.add(empty.clone()), &[], &[]);
+        assert_delta(set.add(prefix("baz")), &[], &[]);
+        assert_delta(set.remove(&empty), &["foo/a", "bar/b", "baz"], &[""]);
+    }
+
+    #[test]
+    fn removing_absent_prefix_is_a_no_op() {
+        let mut set = CoveringPrefixSet::default();
+        let foo = prefix("foo");
+
+        assert_delta(set.remove(&foo), &[], &[]);
+        assert_delta(set.add(foo.clone()), &["foo"], &[]);
+        assert_delta(set.remove(&prefix("bar")), &[], &[]);
+        assert_delta(set.remove(&foo), &[], &["foo"]);
+    }
+
+    #[test]
+    fn containment_uses_tuple_fields_not_rendered_paths() {
+        let mut set = CoveringPrefixSet::default();
+        let single_field = TrackNamespacePrefix {
+            fields: vec![TupleField::from_utf8("foo/bar")],
+        };
+        let two_fields = prefix("foo/bar");
+
+        assert_eq!(single_field.to_utf8_path(), two_fields.to_utf8_path());
+
+        let delta = set.add(single_field.clone());
+        assert_eq!(delta.added, HashSet::from([single_field.clone()]));
+        assert!(delta.removed.is_empty());
+
+        let delta = set.add(two_fields.clone());
+        assert_eq!(delta.added, HashSet::from([two_fields.clone()]));
+        assert!(delta.removed.is_empty());
+
+        let delta = set.remove(&single_field);
+        assert!(delta.added.is_empty());
+        assert_eq!(delta.removed, HashSet::from([single_field]));
+
+        assert_delta(set.remove(&two_fields), &[], &["foo/bar"]);
+    }
+}

--- a/moq-relay-ietf/src/interest.rs
+++ b/moq-relay-ietf/src/interest.rs
@@ -1,0 +1,254 @@
+// SPDX-FileCopyrightText: 2024-2026 Cloudflare Inc., Luke Curley, Mike English and contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Downstream interest tracking for pull-through cache entries.
+//!
+//! When a relay serves a track it does not publish itself, it subscribes
+//! upstream and caches the resulting reader so later subscribers can share it.
+//! Nothing previously counted how many downstream subscribers were actually
+//! using that cached reader, so the upstream subscription lived until the
+//! upstream session died — the relay kept pulling bytes for a track nobody was
+//! watching.
+//!
+//! [`TrackInterest`] is a reference count with the ability to await "nobody has
+//! held a guard for a while". Each downstream subscriber holds a
+//! [`TrackInterestGuard`] for as long as it is being served, so the count is
+//! maintained by RAII and a cancelled subscriber cannot leak a reference.
+//!
+//! Guards hold a strong reference to the counter itself rather than a cache key.
+//! If a cache entry is evicted and a replacement is created for the same track
+//! name, an outstanding guard from the old entry decrements the old counter
+//! instead of making the new entry look busy.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::watch;
+
+/// Shared interest counter for one cache entry.
+#[derive(Clone, Debug)]
+pub struct TrackInterest {
+    inner: Arc<InterestInner>,
+}
+
+#[derive(Debug)]
+struct InterestInner {
+    /// Number of live guards. The count lives in the watch value so that
+    /// mutations and change notifications cannot get out of step.
+    count: watch::Sender<usize>,
+}
+
+impl Default for TrackInterest {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TrackInterest {
+    pub fn new() -> Self {
+        let (count, _) = watch::channel(0);
+        Self {
+            inner: Arc::new(InterestInner { count }),
+        }
+    }
+
+    /// Register a downstream subscriber, releasing the interest on drop.
+    ///
+    /// Callers must create the guard while holding the same cache lock that
+    /// [`TrackInterest::is_idle`] is checked under, so a subscriber arriving
+    /// concurrently with eviction is either counted or gets a fresh entry.
+    pub fn guard(&self) -> TrackInterestGuard {
+        self.inner.count.send_modify(|count| *count += 1);
+        TrackInterestGuard {
+            inner: self.inner.clone(),
+        }
+    }
+
+    /// Current number of downstream subscribers.
+    pub fn count(&self) -> usize {
+        *self.inner.count.borrow()
+    }
+
+    /// True when no downstream subscriber is being served from this entry.
+    pub fn is_idle(&self) -> bool {
+        self.count() == 0
+    }
+
+    /// True when both handles refer to the same counter, i.e. the same cache
+    /// entry generation.
+    pub fn same_generation(&self, other: &TrackInterest) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
+    }
+
+    /// Resolve once the count has been continuously zero for `grace`.
+    ///
+    /// The timer restarts whenever a subscriber appears, so a track that keeps
+    /// picking up new subscribers is never considered idle. A zero `grace`
+    /// resolves as soon as the count reaches zero.
+    pub async fn idle_for(&self, grace: Duration) {
+        let mut rx = self.inner.count.subscribe();
+
+        loop {
+            // Scoped so the borrow is released before the awaits below.
+            let busy = { *rx.borrow_and_update() > 0 };
+
+            if busy {
+                // Wait for the count to change at all before re-checking.
+                if rx.changed().await.is_err() {
+                    // Sender gone, so the entry is unreachable; treat as idle.
+                    return;
+                }
+                continue;
+            }
+
+            if grace.is_zero() {
+                return;
+            }
+
+            tokio::select! {
+                _ = tokio::time::sleep(grace) => return,
+                // A subscriber arrived (or another change landed) inside the
+                // grace period; go around again and restart the timer.
+                res = rx.changed() => {
+                    if res.is_err() {
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Held for as long as a downstream subscriber is served from a cache entry.
+#[derive(Debug)]
+pub struct TrackInterestGuard {
+    inner: Arc<InterestInner>,
+}
+
+impl Drop for TrackInterestGuard {
+    fn drop(&mut self) {
+        self.inner.count.send_modify(|count| {
+            // Saturating because an underflow here would make a busy track look
+            // permanently busy, pinning the upstream subscription forever.
+            *count = count.saturating_sub(1);
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use tokio::time::Instant;
+
+    const GRACE: Duration = Duration::from_millis(50);
+
+    #[test]
+    fn guards_count_subscribers() {
+        let interest = TrackInterest::new();
+        assert_eq!(interest.count(), 0);
+        assert!(interest.is_idle());
+
+        let first = interest.guard();
+        assert_eq!(interest.count(), 1);
+        assert!(!interest.is_idle());
+
+        let second = interest.guard();
+        assert_eq!(interest.count(), 2);
+
+        drop(first);
+        assert_eq!(interest.count(), 1);
+
+        drop(second);
+        assert_eq!(interest.count(), 0);
+        assert!(interest.is_idle());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn idle_for_resolves_when_nobody_subscribes() {
+        let interest = TrackInterest::new();
+        let start = Instant::now();
+
+        interest.idle_for(GRACE).await;
+
+        assert!(start.elapsed() >= GRACE);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn idle_for_waits_for_the_last_subscriber_to_leave() {
+        let interest = TrackInterest::new();
+        let guard = interest.guard();
+
+        let idle = interest.idle_for(GRACE);
+        tokio::pin!(idle);
+
+        // Busy: must not resolve no matter how long we wait.
+        tokio::select! {
+            _ = &mut idle => panic!("a busy track must never look idle"),
+            _ = tokio::time::sleep(GRACE * 10) => {}
+        }
+
+        drop(guard);
+        idle.await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_new_subscriber_restarts_the_grace_period() {
+        let interest = TrackInterest::new();
+
+        let idle = interest.idle_for(GRACE);
+        tokio::pin!(idle);
+
+        // Part-way through the grace period a subscriber arrives, so the entry
+        // must stop looking idle rather than being evicted out from under it.
+        tokio::select! {
+            _ = &mut idle => panic!("resolved before the grace period elapsed"),
+            _ = tokio::time::sleep(GRACE / 2) => {}
+        }
+
+        let guard = interest.guard();
+
+        tokio::select! {
+            _ = &mut idle => panic!("resolved while a subscriber was present"),
+            _ = tokio::time::sleep(GRACE * 10) => {}
+        }
+
+        // Once it leaves, a full grace period must pass again.
+        drop(guard);
+        let after_drop = Instant::now();
+        idle.await;
+        assert!(after_drop.elapsed() >= GRACE);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn zero_grace_resolves_immediately_when_idle() {
+        let interest = TrackInterest::new();
+        interest.idle_for(Duration::ZERO).await;
+    }
+
+    #[test]
+    fn generations_are_distinguished_by_identity() {
+        let interest = TrackInterest::new();
+        let clone = interest.clone();
+        let replacement = TrackInterest::new();
+
+        assert!(interest.same_generation(&clone));
+        assert!(!interest.same_generation(&replacement));
+    }
+
+    #[test]
+    fn a_stale_guard_does_not_make_a_replacement_look_busy() {
+        // A subscriber served by an evicted entry can outlive that entry. Its
+        // guard must decrement the old counter, not the new one.
+        let old = TrackInterest::new();
+        let stale_guard = old.guard();
+
+        let new = TrackInterest::new();
+        assert!(new.is_idle());
+
+        drop(stale_guard);
+
+        assert_eq!(old.count(), 0);
+        assert!(new.is_idle(), "replacement entry should still be idle");
+    }
+}

--- a/moq-relay-ietf/src/lib.rs
+++ b/moq-relay-ietf/src/lib.rs
@@ -14,18 +14,20 @@
 //!
 //! ```rust,ignore
 //! use std::sync::Arc;
-//! use moq_relay_ietf::{Relay, RelayConfig, FileCoordinator};
+//! use moq_relay_ietf::{RelayConfig, FileCoordinator, SessionConfig};
 //!
 //! // Create a coordinator (FileCoordinator for multi-relay deployments)
 //! let coordinator = FileCoordinator::new("/path/to/coordination/file", "https://relay.example.com");
 //!
 //! // Configure and create the relay
-//! let relay = Relay::new(RelayConfig {
+//! let relay = RelayConfig {
 //!     bind: "[::]:443".parse().unwrap(),
 //!     tls: tls_config,
 //!     coordinator,
+//!     session: SessionConfig::default(),
 //!     // ... other options
-//! })?;
+//! }
+//! .build()?;
 //!
 //! // Run the relay
 //! relay.run().await?;
@@ -34,18 +36,22 @@
 mod api;
 mod consumer;
 mod coordinator;
+mod covering_prefix_set;
+mod interest;
 mod local;
 pub mod metrics;
 mod producer;
 mod relay;
 mod remote;
 mod session;
+mod upstream_namespaces;
 mod web;
 
 pub use api::*;
 pub use consumer::*;
 pub use coordinator::*;
 pub use local::*;
+pub use moq_transport::session::SessionConfig;
 pub use producer::*;
 pub use relay::*;
 pub use remote::RemoteManager;

--- a/moq-relay-ietf/src/local.rs
+++ b/moq-relay-ietf/src/local.rs
@@ -3,14 +3,16 @@
 
 use std::collections::hash_map;
 use std::collections::HashMap;
-
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, RwLock, Weak};
+use std::time::Duration;
 
 use moq_transport::{
-    coding::TrackNamespace,
-    serve::{ServeError, TracksReader},
+    coding::{TrackNamespace, TrackNamespacePrefix},
+    serve::{FullTrackName, ServeError, Track, TrackReader, TrackWriter},
 };
+use tokio::sync::{broadcast, mpsc, watch};
 
+use crate::interest::{TrackInterest, TrackInterestGuard};
 use crate::metrics::GaugeGuard;
 
 /// Scope key for the outer level of the two-level registry.
@@ -19,22 +21,282 @@ use crate::metrics::GaugeGuard;
 /// connections share this bucket — any publisher without a scope can be reached
 /// by any subscriber without a scope. This is the default behavior for backward
 /// compatibility with pre-scope deployments.
-///
-/// We use `String` rather than `Option<String>` so that `HashMap::get` can
-/// accept a `&str` via the `Borrow` trait, avoiding a heap allocation on
-/// every lookup in `retrieve()`.
 type ScopeKey = String;
 
 /// The scope key used for unscoped (global) registrations.
 const UNSCOPED: &str = "";
 
-/// Registry of local tracks, indexed by (scope, namespace).
+const NAMESPACE_REQUEST_CHANNEL_CAPACITY: usize = 1024;
+
+/// How long a pull-through cache entry with no downstream subscribers is kept
+/// before the upstream subscription is released.
 ///
-/// Uses a two-level map so that `retrieve()` only scans namespaces within
-/// the matching scope, rather than iterating all namespaces across all scopes.
+/// The grace period keeps the common case cheap: a subscriber reconnecting, or a
+/// player switching between renditions, reuses the warm cache entry instead of
+/// paying a fresh upstream SUBSCRIBE round trip. Past that we stop paying to
+/// receive a track nobody is watching.
+pub const DEFAULT_CACHE_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Capacity of the namespace add/remove notification broadcast channel used by
+/// SUBSCRIBE_NAMESPACE handlers.
+const NAMESPACE_CHANGE_CHANNEL_CAPACITY: usize = 1024;
+
+/// Capacity of the PUBLISH track add/remove notification broadcast channel used
+/// by Publish/Both fan-out.
+const TRACK_CHANGE_CHANNEL_CAPACITY: usize = 1024;
+
+#[derive(Clone)]
+struct NamespaceSource {
+    requests: mpsc::Sender<TrackRequest>,
+}
+
+/// A request for a track that is not cached yet, sent to the session that
+/// advertised the namespace so it can SUBSCRIBE upstream.
+pub struct TrackRequest {
+    /// Writer the upstream subscription should fill.
+    pub writer: TrackWriter,
+
+    /// Lease on the pull-through cache entry backing this request.
+    ///
+    /// The requester should hold the upstream subscription open until
+    /// [`CacheLease::released`] resolves, then drop it to send UNSUBSCRIBE.
+    pub lease: CacheLease,
+
+    /// Reports whether the upstream subscription was established.
+    ///
+    /// Downstream subscribers wait on this before SUBSCRIBE_OK is sent, so the
+    /// requester must report the outcome as soon as the upstream publisher
+    /// answers — via [`UpstreamReadyTx::established`] or
+    /// [`UpstreamReadyTx::failed`] — or drop the sender to abandon the request,
+    /// which releases any waiting subscribers with an error rather than
+    /// stranding them until the upstream response timeout.
+    pub upstream: UpstreamReadyTx,
+}
+
+/// State of the upstream subscription backing a pull-through cache entry.
+#[derive(Clone)]
+enum UpstreamState {
+    /// The upstream SUBSCRIBE has been queued but not answered yet.
+    Pending,
+
+    /// The upstream publisher acknowledged the SUBSCRIBE.
+    Established,
+
+    /// The upstream subscription could not be established.
+    Failed(ServeError),
+}
+
+/// Readiness gate for the upstream subscription behind a cached track.
+///
+/// Draft-16 §8.4 requires a relay to have an established upstream subscription
+/// before it sends SUBSCRIBE_OK for a downstream SUBSCRIBE. The pull-through
+/// cache reserves its entry synchronously but subscribes upstream asynchronously
+/// (the publishing session owns that side), so the entry exists before the
+/// upstream subscription does. Serving a downstream subscriber has to wait for
+/// this gate rather than for the entry alone.
+///
+/// Shared by every downstream subscriber of the same cache entry, so a second
+/// subscriber arriving mid-handshake waits on the same result instead of
+/// triggering a duplicate upstream SUBSCRIBE.
+#[derive(Clone)]
+pub struct UpstreamReady {
+    state: watch::Receiver<UpstreamState>,
+}
+
+impl UpstreamReady {
+    /// Wait until the upstream subscription is established.
+    ///
+    /// Returns the upstream failure if it could not be established, so the caller
+    /// can reject the downstream request with a matching REQUEST_ERROR instead of
+    /// accepting it and later reporting the failure as PUBLISH_DONE.
+    ///
+    /// Resolves as an error rather than hanging if the requester is dropped
+    /// without answering — an abandoned request is not an established one.
+    pub async fn established(&self) -> Result<(), ServeError> {
+        let mut state = self.state.clone();
+
+        loop {
+            match &*state.borrow_and_update() {
+                UpstreamState::Established => return Ok(()),
+                UpstreamState::Failed(err) => return Err(err.clone()),
+                UpstreamState::Pending => {}
+            }
+
+            if state.changed().await.is_err() {
+                return Err(ServeError::internal_ctx(
+                    "upstream subscription abandoned before it was established",
+                ));
+            }
+        }
+    }
+}
+
+/// Sender half of [`UpstreamReady`], held by the session that owns the upstream
+/// subscription.
+///
+/// Dropping this without resolving it releases any waiting downstream subscriber
+/// with an error, so a requester that gives up cannot strand them.
+pub struct UpstreamReadyTx {
+    state: watch::Sender<UpstreamState>,
+}
+
+impl UpstreamReadyTx {
+    /// Report that the upstream publisher acknowledged the SUBSCRIBE.
+    pub fn established(&self) {
+        // Fails only when every downstream subscriber has already gone away.
+        let _ = self.state.send(UpstreamState::Established);
+    }
+
+    /// Report that the upstream subscription could not be established.
+    pub fn failed(&self, err: ServeError) {
+        let _ = self.state.send(UpstreamState::Failed(err));
+    }
+}
+
+/// Ties an upstream subscription to downstream interest in its cache entry.
+///
+/// Handed to whichever session owns the upstream subscription so it can tell when
+/// the cached track has gone unwatched and stop paying for it.
+pub struct CacheLease {
+    locals: Locals,
+    scope_key: ScopeKey,
+    full_name: FullTrackName,
+    interest: TrackInterest,
+}
+
+impl CacheLease {
+    /// Resolve once the cache entry has been evicted for lack of interest.
+    ///
+    /// The caller should drop its upstream subscription when this returns, which
+    /// sends UNSUBSCRIBE. Eviction happens first so that a subscriber arriving
+    /// afterwards misses the cache and triggers a fresh upstream SUBSCRIBE,
+    /// rather than attaching to a reader that is about to stop being fed.
+    ///
+    /// Never resolves when the idle timeout is disabled, preserving the previous
+    /// behaviour of holding the upstream subscription for the session's lifetime.
+    pub async fn released(&self) {
+        let timeout = self.locals.cache_idle_timeout;
+        if timeout.is_zero() {
+            std::future::pending::<()>().await;
+        }
+
+        loop {
+            self.interest.idle_for(timeout).await;
+
+            if self
+                .locals
+                .evict_idle_cache_entry(&self.scope_key, &self.full_name, &self.interest)
+            {
+                return;
+            }
+
+            // A subscriber arrived between the timer firing and the eviction
+            // taking the lock, so the entry is busy again. Go back to waiting.
+            tracing::trace!(
+                namespace = %self.full_name.namespace,
+                track = %self.full_name.name,
+                "cache eviction abandoned; downstream interest returned"
+            );
+        }
+    }
+}
+
+struct NamespaceEntry {
+    local: Option<NamespaceSource>,
+    remote: Weak<RemoteNamespaceSource>,
+}
+
+struct RemoteNamespaceSource {
+    locals: Locals,
+    scope_key: ScopeKey,
+    namespace: TrackNamespace,
+}
+
+struct TrackEntry {
+    reader: TrackReader,
+    source: TrackSource,
+
+    /// Downstream interest in this entry, for [`TrackSource::Cache`] entries only.
+    ///
+    /// Locally published tracks have no upstream subscription to release, so
+    /// there is nothing to count.
+    interest: Option<TrackInterest>,
+
+    /// Upstream readiness for [`TrackSource::Cache`] entries only.
+    ///
+    /// Locally published tracks are already established by the time they are
+    /// registered, so there is nothing to wait for.
+    upstream: Option<UpstreamReady>,
+}
+
+/// A track resolved from the relay-local registry, with the handles a caller must
+/// observe while serving it.
+pub struct LocalTrack {
+    /// The media reader to serve downstream.
+    pub reader: TrackReader,
+
+    /// Held for as long as the caller serves [`Self::reader`]. Dropping it is what
+    /// eventually lets an idle upstream subscription be released.
+    ///
+    /// `None` for locally published tracks, which have no upstream subscription.
+    pub interest: Option<TrackInterestGuard>,
+
+    /// Must resolve before the caller sends SUBSCRIBE_OK downstream (draft-16
+    /// §8.4).
+    ///
+    /// `None` for locally published tracks, which are already established.
+    pub upstream: Option<UpstreamReady>,
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum TrackSource {
+    Published,
+    Cache,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct NamespaceChange {
+    pub scope: Option<String>,
+    pub namespace: TrackNamespace,
+    pub added: bool,
+}
+
+#[derive(Clone)]
+pub enum TrackChange {
+    Added {
+        scope: Option<String>,
+        track: TrackReader,
+    },
+    Removed {
+        scope: Option<String>,
+        full_name: FullTrackName,
+    },
+}
+
+/// Relay-local registry.
+///
+/// Actual media tracks are always stored by exact Full Track Name. Namespace
+/// entries combine discovery metadata with an optional local PUBLISH_NAMESPACE
+/// route source that can be asked for a missing track.
 #[derive(Clone)]
 pub struct Locals {
-    lookup: Arc<Mutex<HashMap<ScopeKey, HashMap<TrackNamespace, TracksReader>>>>,
+    /// Actual media tracks, indexed by (scope, full track name).
+    tracks: Arc<RwLock<HashMap<ScopeKey, HashMap<FullTrackName, TrackEntry>>>>,
+
+    /// Namespace sources, indexed by (scope, namespace) and matched by prefix.
+    /// Each entry can have one local PUBLISH_NAMESPACE route source and shared
+    /// ownership by any number of remote discovery registrations.
+    namespaces: Arc<RwLock<HashMap<ScopeKey, HashMap<TrackNamespace, NamespaceEntry>>>>,
+
+    /// Namespace add/remove notifications for SUBSCRIBE_NAMESPACE handlers.
+    namespace_changes: broadcast::Sender<NamespaceChange>,
+
+    /// Actual PUBLISH track add/remove notifications for Publish/Both fan-out.
+    track_changes: broadcast::Sender<TrackChange>,
+
+    /// How long an unwatched pull-through cache entry is retained before its
+    /// upstream subscription is released. Zero disables eviction.
+    cache_idle_timeout: Duration,
 }
 
 impl Default for Locals {
@@ -43,68 +305,386 @@ impl Default for Locals {
     }
 }
 
-/// Local tracks registry.
 impl Locals {
     pub fn new() -> Self {
+        Self::with_cache_idle_timeout(DEFAULT_CACHE_IDLE_TIMEOUT)
+    }
+
+    /// Build a registry with a custom pull-through cache idle timeout.
+    ///
+    /// A zero timeout disables idle eviction, holding upstream subscriptions for
+    /// as long as the upstream session lives.
+    pub fn with_cache_idle_timeout(cache_idle_timeout: Duration) -> Self {
+        let (namespace_changes, _) = broadcast::channel(NAMESPACE_CHANGE_CHANNEL_CAPACITY);
+        let (track_changes, _) = broadcast::channel(TRACK_CHANGE_CHANNEL_CAPACITY);
         Self {
-            lookup: Default::default(),
+            tracks: Default::default(),
+            namespaces: Default::default(),
+            namespace_changes,
+            track_changes,
+            cache_idle_timeout,
         }
     }
 
-    /// Register new local tracks.
+    pub fn subscribe_namespace_changes(&self) -> broadcast::Receiver<NamespaceChange> {
+        self.namespace_changes.subscribe()
+    }
+
+    pub fn subscribe_track_changes(&self) -> broadcast::Receiver<TrackChange> {
+        self.track_changes.subscribe()
+    }
+
+    pub fn list_namespaces_matching(
+        &self,
+        scope: Option<&str>,
+        prefix: &TrackNamespacePrefix,
+    ) -> Vec<TrackNamespace> {
+        let Ok(namespaces) = self.namespaces.read() else {
+            return Vec::new();
+        };
+        let Some(bucket) = namespaces.get(scope.unwrap_or(UNSCOPED)) else {
+            return Vec::new();
+        };
+
+        bucket
+            .keys()
+            .filter(|namespace| prefix.is_prefix_of(namespace))
+            .cloned()
+            .collect()
+    }
+
+    pub fn list_tracks_matching(
+        &self,
+        scope: Option<&str>,
+        prefix: &TrackNamespacePrefix,
+    ) -> Vec<TrackReader> {
+        let scope_key = scope.unwrap_or(UNSCOPED);
+
+        // Collect matching readers under a shared read lock so concurrent
+        // SUBSCRIBE_NAMESPACE fan-outs don't serialize against each other. Note any
+        // closed entries and prune them afterwards under a brief write lock, keeping
+        // the common (no-stale) path read-only.
+        let mut matches = Vec::new();
+        let mut stale = Vec::new();
+        {
+            let Ok(tracks) = self.tracks.read() else {
+                return Vec::new();
+            };
+            let Some(bucket) = tracks.get(scope_key) else {
+                return Vec::new();
+            };
+            for (full_name, entry) in bucket.iter() {
+                if entry.reader.is_closed() {
+                    stale.push(full_name.clone());
+                } else if entry.source == TrackSource::Published
+                    && prefix.is_prefix_of(&full_name.namespace)
+                {
+                    matches.push(entry.reader.clone());
+                }
+            }
+        }
+
+        if !stale.is_empty() {
+            self.prune_closed_tracks(scope_key, &stale);
+        }
+
+        matches
+    }
+
+    /// Remove the given tracks from a scope bucket if they are still closed.
     ///
-    /// `scope` is the resolved scope identity from `Coordinator::resolve_scope()`,
-    /// or `None` for unscoped sessions. Registrations are keyed by `(scope, namespace)`,
-    /// so the same namespace in different scopes routes independently.
-    pub async fn register(
+    /// Invoked off the read path (e.g. by [`Locals::list_tracks_matching`]) so that
+    /// closed-entry cleanup takes the write lock only briefly and only when a closed
+    /// entry was actually observed. The re-check guards against removing an entry
+    /// that a concurrent writer replaced with a live reader.
+    fn prune_closed_tracks(&self, scope_key: &str, keys: &[FullTrackName]) {
+        let Ok(mut tracks) = self.tracks.write() else {
+            return;
+        };
+        let Some(bucket) = tracks.get_mut(scope_key) else {
+            return;
+        };
+        for key in keys {
+            if bucket
+                .get(key)
+                .is_some_and(|entry| entry.reader.is_closed())
+            {
+                bucket.remove(key);
+            }
+        }
+        if bucket.is_empty() {
+            tracks.remove(scope_key);
+        }
+    }
+
+    /// Register namespace routing metadata from PUBLISH_NAMESPACE.
+    ///
+    /// This does not register any media tracks. It only creates a request queue
+    /// used when a downstream SUBSCRIBE asks for a missing track under this
+    /// namespace.
+    pub async fn register_namespace(
         &mut self,
         scope: Option<&str>,
-        tracks: TracksReader,
-    ) -> anyhow::Result<Registration> {
-        let namespace = tracks.namespace.clone();
+        namespace: TrackNamespace,
+    ) -> anyhow::Result<(LocalNamespaceRegistration, mpsc::Receiver<TrackRequest>)> {
         let scope_key = scope.unwrap_or(UNSCOPED).to_string();
+        let (tx, rx) = mpsc::channel(NAMESPACE_REQUEST_CHANNEL_CAPACITY);
 
-        // Insert the tracks into the scope bucket
-        let mut lookup = self.lookup.lock().unwrap();
-        let bucket = lookup.entry(scope_key.clone()).or_default();
-        match bucket.entry(namespace.clone()) {
-            hash_map::Entry::Vacant(entry) => entry.insert(tracks),
-            hash_map::Entry::Occupied(_) => return Err(ServeError::Duplicate.into()),
+        let added = {
+            let mut namespaces = self
+                .namespaces
+                .write()
+                .map_err(|_| ServeError::internal_ctx("locals namespace registry lock poisoned"))?;
+            let bucket = namespaces.entry(scope_key.clone()).or_default();
+            match bucket.entry(namespace.clone()) {
+                hash_map::Entry::Vacant(entry) => {
+                    entry.insert(NamespaceEntry {
+                        local: Some(NamespaceSource { requests: tx }),
+                        remote: Weak::new(),
+                    });
+                    true
+                }
+                hash_map::Entry::Occupied(mut entry) => {
+                    if entry.get().local.is_some() {
+                        return Err(ServeError::Duplicate.into());
+                    }
+                    entry.get_mut().local = Some(NamespaceSource { requests: tx });
+                    false
+                }
+            }
         };
 
-        let registration = Registration {
+        let registration = LocalNamespaceRegistration {
             locals: self.clone(),
             scope_key,
-            namespace,
+            namespace: namespace.clone(),
             _gauge_guard: GaugeGuard::new("moq_relay_announced_namespaces"),
         };
+
+        if added {
+            let _ = self.namespace_changes.send(NamespaceChange {
+                scope: scope_key_to_option(&registration.scope_key),
+                namespace,
+                added: true,
+            });
+        }
+
+        Ok((registration, rx))
+    }
+
+    /// Register remote discovery metadata for one exact namespace.
+    pub fn register_remote_namespace(
+        &self,
+        scope: Option<&str>,
+        namespace: TrackNamespace,
+    ) -> anyhow::Result<RemoteNamespaceRegistration> {
+        let scope_key = scope.unwrap_or(UNSCOPED).to_string();
+        let (source, added) = {
+            let mut namespaces = self
+                .namespaces
+                .write()
+                .map_err(|_| ServeError::internal_ctx("locals namespace registry lock poisoned"))?;
+            let bucket = namespaces.entry(scope_key.clone()).or_default();
+            match bucket.entry(namespace.clone()) {
+                hash_map::Entry::Vacant(entry) => {
+                    let source = Arc::new(RemoteNamespaceSource {
+                        locals: self.clone(),
+                        scope_key: scope_key.clone(),
+                        namespace: namespace.clone(),
+                    });
+                    entry.insert(NamespaceEntry {
+                        local: None,
+                        remote: Arc::downgrade(&source),
+                    });
+                    (source, true)
+                }
+                hash_map::Entry::Occupied(mut entry) => {
+                    if let Some(source) = entry.get().remote.upgrade() {
+                        (source, false)
+                    } else {
+                        let source = Arc::new(RemoteNamespaceSource {
+                            locals: self.clone(),
+                            scope_key: scope_key.clone(),
+                            namespace: namespace.clone(),
+                        });
+                        entry.get_mut().remote = Arc::downgrade(&source);
+                        (source, false)
+                    }
+                }
+            }
+        };
+
+        let registration = RemoteNamespaceRegistration { _source: source };
+
+        if added {
+            let _ = self.namespace_changes.send(NamespaceChange {
+                scope: scope_key_to_option(&scope_key),
+                namespace,
+                added: true,
+            });
+        }
 
         Ok(registration)
     }
 
-    /// Retrieve local tracks by namespace using hierarchical prefix matching.
-    /// Returns the TracksReader for the longest matching namespace prefix.
+    /// Register one exact track received via PUBLISH.
+    pub async fn register_track(
+        &mut self,
+        scope: Option<&str>,
+        track: TrackReader,
+    ) -> anyhow::Result<LocalTrackRegistration> {
+        let full_name = FullTrackName {
+            namespace: track.namespace.clone(),
+            name: track.name.clone(),
+        };
+        self.insert_track_with_registration(scope, full_name, track)
+            .await
+    }
+
+    async fn insert_track_with_registration(
+        &mut self,
+        scope: Option<&str>,
+        full_name: FullTrackName,
+        track: TrackReader,
+    ) -> anyhow::Result<LocalTrackRegistration> {
+        let scope_key = scope.unwrap_or(UNSCOPED).to_string();
+
+        let mut tracks = self
+            .tracks
+            .write()
+            .map_err(|_| ServeError::internal_ctx("locals track registry lock poisoned"))?;
+        let bucket = tracks.entry(scope_key.clone()).or_default();
+        match bucket.entry(full_name.clone()) {
+            hash_map::Entry::Vacant(entry) => entry.insert(TrackEntry {
+                reader: track.clone(),
+                source: TrackSource::Published,
+                // A locally published track has no upstream subscription to
+                // release, so there is nothing to count interest against and
+                // nothing to wait for before accepting a downstream SUBSCRIBE.
+                interest: None,
+                upstream: None,
+            }),
+            hash_map::Entry::Occupied(_) => return Err(ServeError::Duplicate.into()),
+        };
+
+        let _ = self.track_changes.send(TrackChange::Added {
+            scope: scope_key_to_option(&scope_key),
+            track,
+        });
+
+        Ok(LocalTrackRegistration {
+            locals: self.clone(),
+            scope_key,
+            full_name,
+            _gauge_guard: GaugeGuard::new("moq_relay_active_published_tracks"),
+        })
+    }
+
+    /// Retrieve one actual media track by exact Full Track Name.
+    pub fn retrieve_track(
+        &self,
+        scope: Option<&str>,
+        full_name: &FullTrackName,
+    ) -> Option<TrackReader> {
+        let scope_key = scope.unwrap_or(UNSCOPED);
+
+        // Fast path: look up under a shared read lock.
+        {
+            let tracks = self.tracks.read().ok()?;
+            let bucket = tracks.get(scope_key)?;
+            match bucket.get(full_name) {
+                Some(entry) if !entry.reader.is_closed() => return Some(entry.reader.clone()),
+                Some(_) => {} // closed: fall through to prune under the write lock
+                None => return None,
+            }
+        }
+
+        // The entry was closed; remove it under a brief write lock (re-checking in
+        // case a concurrent writer replaced it with a live reader).
+        self.prune_closed_tracks(scope_key, std::slice::from_ref(full_name));
+        None
+    }
+
+    /// Remove an unwatched pull-through cache entry.
     ///
-    /// `scope` is the resolved scope identity from `Coordinator::resolve_scope()`,
-    /// or `None` for unscoped sessions. When `scope` is `None`, only tracks
-    /// registered without a scope (the global/unscoped bucket) are searched.
-    pub fn retrieve(
+    /// Returns false, leaving the entry in place, if interest returned before the
+    /// write lock was acquired, or if the entry has since been replaced by a
+    /// different generation or by a locally published track.
+    ///
+    /// The idle check happens under the same lock that guards are created under,
+    /// so a subscriber racing eviction either gets counted here (and eviction is
+    /// abandoned) or misses the cache entirely and requests a fresh one.
+    fn evict_idle_cache_entry(
+        &self,
+        scope_key: &str,
+        full_name: &FullTrackName,
+        interest: &TrackInterest,
+    ) -> bool {
+        let Ok(mut tracks) = self.tracks.write() else {
+            // A poisoned registry means we can no longer reason about the entry;
+            // release the upstream subscription rather than pinning it forever.
+            return true;
+        };
+
+        let Some(bucket) = tracks.get_mut(scope_key) else {
+            return true;
+        };
+
+        match bucket.get(full_name) {
+            Some(entry) => {
+                // Only evict the generation this lease belongs to. A replacement
+                // entry has its own lease and its own idle timer.
+                let ours = entry
+                    .interest
+                    .as_ref()
+                    .is_some_and(|current| current.same_generation(interest));
+
+                if !ours {
+                    return true;
+                }
+
+                if !interest.is_idle() {
+                    return false;
+                }
+
+                bucket.remove(full_name);
+            }
+            // Already gone (e.g. pruned as closed), so the upstream subscription
+            // is no longer serving anything.
+            None => return true,
+        }
+
+        if bucket.is_empty() {
+            tracks.remove(scope_key);
+        }
+
+        tracing::debug!(
+            namespace = %full_name.namespace,
+            track = %full_name.name,
+            "evicting idle cached track and releasing upstream subscription"
+        );
+        metrics::counter!("moq_relay_cache_idle_evictions_total", "source" => "local").increment(1);
+
+        true
+    }
+
+    /// Return the best namespace route source for a requested namespace.
+    fn route_namespace(
         &self,
         scope: Option<&str>,
         namespace: &TrackNamespace,
-    ) -> Option<TracksReader> {
-        let lookup = self.lookup.lock().unwrap();
+    ) -> Option<NamespaceSource> {
+        let namespaces = self.namespaces.read().ok()?;
+        let bucket = namespaces.get(scope.unwrap_or(UNSCOPED))?;
 
-        // Look up the scope bucket directly — O(1), zero allocation.
-        // HashMap<String, V>::get accepts &str via Borrow<str>.
-        let bucket = lookup.get(scope.unwrap_or(UNSCOPED))?;
-
-        // Find the longest matching prefix within this scope
-        let mut best_match: Option<TracksReader> = None;
+        let mut best_match: Option<NamespaceSource> = None;
         let mut best_len = 0;
 
-        for (registered_ns, tracks) in bucket.iter() {
-            // Check if registered_ns is a prefix of namespace
+        for (registered_ns, entry) in bucket.iter() {
+            let Some(source) = entry.local.as_ref() else {
+                continue;
+            };
+
             if namespace.fields.len() >= registered_ns.fields.len() {
                 let is_prefix = registered_ns
                     .fields
@@ -113,7 +693,7 @@ impl Locals {
                     .all(|(a, b)| a == b);
 
                 if is_prefix && registered_ns.fields.len() > best_len {
-                    best_match = Some(tracks.clone());
+                    best_match = Some(source.clone());
                     best_len = registered_ns.fields.len();
                 }
             }
@@ -121,18 +701,189 @@ impl Locals {
 
         best_match
     }
+
+    /// Get an existing exact track or request it from a matching namespace source.
+    ///
+    /// This replaces the old `TracksReader::subscribe` relay registry behavior:
+    /// the actual track reader is stored in `tracks`, while PUBLISH_NAMESPACE is
+    /// only a source to ask when a track is missing.
+    /// Returns the reader plus, for pull-through cache entries, a guard the caller
+    /// must hold for as long as it is serving that reader (dropping it is what
+    /// eventually lets the upstream subscription be released) and a readiness gate
+    /// the caller must await before accepting the downstream request.
+    pub async fn get_or_request_track(
+        &mut self,
+        scope: Option<&str>,
+        namespace: TrackNamespace,
+        track_name: impl Into<moq_transport::coding::TrackName>,
+    ) -> Option<LocalTrack> {
+        let track_name = track_name.into();
+        let full_name = FullTrackName {
+            namespace: namespace.clone(),
+            name: track_name.clone(),
+        };
+        let scope_key = scope.unwrap_or(UNSCOPED).to_string();
+
+        if let Some(hit) = self.retrieve_track_with_interest(&scope_key, &full_name) {
+            return Some(hit);
+        }
+
+        let source = self.route_namespace(scope, &namespace)?;
+
+        // Reserve the pull-through cache slot under a single lock so concurrent
+        // misses for the same track collapse onto one produced reader. The caller
+        // that finds no live entry claims the slot with a freshly produced track and
+        // owns requesting it from the source; concurrent callers share the reserved
+        // reader instead of racing to insert and failing with a spurious `None`.
+        let (writer, reader, interest, guard, upstream_tx, upstream) = {
+            let mut tracks = self.tracks.write().ok()?;
+            let bucket = tracks.entry(scope_key.clone()).or_default();
+
+            if let Some(entry) = bucket.get(&full_name) {
+                if !entry.reader.is_closed() {
+                    return Some(LocalTrack {
+                        reader: entry.reader.clone(),
+                        interest: entry.interest.as_ref().map(TrackInterest::guard),
+                        upstream: entry.upstream.clone(),
+                    });
+                }
+            }
+
+            // Vacant slot (or a stale, closed reader): claim it with a fresh track.
+            let (writer, reader) = Track::new(namespace, track_name).produce();
+            let interest = TrackInterest::new();
+
+            // Take this caller's guard before the entry is visible to anyone
+            // else, so the entry can never be seen as idle while we are still
+            // setting up the upstream subscription.
+            let guard = interest.guard();
+
+            // Published alongside the entry so that a subscriber arriving while
+            // the upstream handshake is still in flight shares this gate rather
+            // than being served a reader nothing has subscribed to yet.
+            let (upstream_tx, upstream_rx) = watch::channel(UpstreamState::Pending);
+            let upstream = UpstreamReady { state: upstream_rx };
+
+            bucket.insert(
+                full_name.clone(),
+                TrackEntry {
+                    reader: reader.clone(),
+                    source: TrackSource::Cache,
+                    interest: Some(interest.clone()),
+                    upstream: Some(upstream.clone()),
+                },
+            );
+            (
+                writer,
+                reader,
+                interest,
+                guard,
+                UpstreamReadyTx { state: upstream_tx },
+                upstream,
+            )
+        };
+
+        let lease = CacheLease {
+            locals: self.clone(),
+            scope_key: scope_key.clone(),
+            full_name: full_name.clone(),
+            interest: interest.clone(),
+        };
+
+        if source
+            .requests
+            .send(TrackRequest {
+                writer,
+                lease,
+                upstream: upstream_tx,
+            })
+            .await
+            .is_err()
+        {
+            // The source is gone, so nothing will ever fill this reader. Remove
+            // the slot we claimed, but only if it is still ours: a concurrent
+            // caller may already have replaced it with a live generation.
+            self.remove_cache_generation(&scope_key, &full_name, &interest);
+            return None;
+        }
+
+        Some(LocalTrack {
+            reader,
+            interest: Some(guard),
+            upstream: Some(upstream),
+        })
+    }
+
+    /// Remove a cache entry if it is still the given generation, regardless of
+    /// whether anyone is currently interested in it.
+    fn remove_cache_generation(
+        &self,
+        scope_key: &str,
+        full_name: &FullTrackName,
+        interest: &TrackInterest,
+    ) {
+        let Ok(mut tracks) = self.tracks.write() else {
+            return;
+        };
+        let Some(bucket) = tracks.get_mut(scope_key) else {
+            return;
+        };
+
+        let ours = bucket.get(full_name).is_some_and(|entry| {
+            entry
+                .interest
+                .as_ref()
+                .is_some_and(|current| current.same_generation(interest))
+        });
+
+        if ours {
+            bucket.remove(full_name);
+        }
+
+        if bucket.is_empty() {
+            tracks.remove(scope_key);
+        }
+    }
+
+    /// Cache lookup that also registers interest, under a single lock.
+    ///
+    /// Interest must be registered while the lock is held: taking the guard after
+    /// releasing it would leave a window where eviction sees an idle entry and
+    /// removes the reader this caller is about to serve.
+    fn retrieve_track_with_interest(
+        &self,
+        scope_key: &str,
+        full_name: &FullTrackName,
+    ) -> Option<LocalTrack> {
+        {
+            let tracks = self.tracks.read().ok()?;
+            let bucket = tracks.get(scope_key)?;
+            match bucket.get(full_name) {
+                Some(entry) if !entry.reader.is_closed() => {
+                    return Some(LocalTrack {
+                        reader: entry.reader.clone(),
+                        interest: entry.interest.as_ref().map(TrackInterest::guard),
+                        upstream: entry.upstream.clone(),
+                    });
+                }
+                Some(_) => {} // closed: fall through to prune under the write lock
+                None => return None,
+            }
+        }
+
+        self.prune_closed_tracks(scope_key, std::slice::from_ref(full_name));
+        None
+    }
 }
 
-pub struct Registration {
+pub struct LocalNamespaceRegistration {
     locals: Locals,
     scope_key: ScopeKey,
     namespace: TrackNamespace,
-    /// Gauge guard for tracking announced namespaces - decrements on drop
     _gauge_guard: GaugeGuard,
 }
 
-/// Deregister local tracks on drop.
-impl Drop for Registration {
+impl Drop for LocalNamespaceRegistration {
     fn drop(&mut self) {
         let ns = self.namespace.to_utf8_path();
         let scope = if self.scope_key.is_empty() {
@@ -140,15 +891,1102 @@ impl Drop for Registration {
         } else {
             &self.scope_key
         };
-        tracing::debug!(namespace = %ns, scope = %scope, "deregistering namespace from locals");
+        tracing::debug!(namespace = %ns, scope = %scope, "deregistering namespace route source from locals");
 
-        let mut lookup = self.locals.lookup.lock().unwrap();
-        if let Some(bucket) = lookup.get_mut(self.scope_key.as_str()) {
-            bucket.remove(&self.namespace);
-            // Clean up empty scope buckets to avoid memory leaks
-            if bucket.is_empty() {
-                lookup.remove(self.scope_key.as_str());
+        let mut removed = false;
+        if let Ok(mut namespaces) = self.locals.namespaces.write() {
+            if let Some(bucket) = namespaces.get_mut(self.scope_key.as_str()) {
+                let remove_namespace = if let Some(entry) = bucket.get_mut(&self.namespace) {
+                    entry.local.take().is_some() && entry.remote.upgrade().is_none()
+                } else {
+                    false
+                };
+                if remove_namespace {
+                    removed = bucket.remove(&self.namespace).is_some();
+                }
+                if bucket.is_empty() {
+                    namespaces.remove(self.scope_key.as_str());
+                }
             }
         }
+
+        if removed {
+            let _ = self.locals.namespace_changes.send(NamespaceChange {
+                scope: scope_key_to_option(&self.scope_key),
+                namespace: self.namespace.clone(),
+                added: false,
+            });
+        }
+    }
+}
+
+pub struct RemoteNamespaceRegistration {
+    _source: Arc<RemoteNamespaceSource>,
+}
+
+impl Drop for RemoteNamespaceSource {
+    fn drop(&mut self) {
+        let mut removed = false;
+        if let Ok(mut namespaces) = self.locals.namespaces.write() {
+            if let Some(bucket) = namespaces.get_mut(self.scope_key.as_str()) {
+                let remove_namespace = if let Some(entry) = bucket.get_mut(&self.namespace) {
+                    if std::ptr::eq(entry.remote.as_ptr(), self) {
+                        entry.remote = Weak::new();
+                        entry.local.is_none()
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                };
+                if remove_namespace {
+                    removed = bucket.remove(&self.namespace).is_some();
+                }
+                if bucket.is_empty() {
+                    namespaces.remove(self.scope_key.as_str());
+                }
+            }
+        }
+
+        if removed {
+            let _ = self.locals.namespace_changes.send(NamespaceChange {
+                scope: scope_key_to_option(&self.scope_key),
+                namespace: self.namespace.clone(),
+                added: false,
+            });
+        }
+    }
+}
+
+fn scope_key_to_option(scope_key: &str) -> Option<String> {
+    if scope_key.is_empty() {
+        None
+    } else {
+        Some(scope_key.to_string())
+    }
+}
+
+pub struct LocalTrackRegistration {
+    locals: Locals,
+    scope_key: ScopeKey,
+    full_name: FullTrackName,
+    _gauge_guard: GaugeGuard,
+}
+
+impl Drop for LocalTrackRegistration {
+    fn drop(&mut self) {
+        let namespace = self.full_name.namespace.to_utf8_path();
+        let track = self.full_name.name.to_string();
+        let scope = if self.scope_key.is_empty() {
+            "<unscoped>"
+        } else {
+            &self.scope_key
+        };
+        tracing::debug!(namespace = %namespace, track = %track, scope = %scope, "deregistering track from locals");
+
+        let mut removed = false;
+        if let Ok(mut tracks) = self.locals.tracks.write() {
+            if let Some(bucket) = tracks.get_mut(self.scope_key.as_str()) {
+                removed = bucket.remove(&self.full_name).is_some();
+                if bucket.is_empty() {
+                    tracks.remove(self.scope_key.as_str());
+                }
+            }
+        }
+
+        if removed {
+            let _ = self.locals.track_changes.send(TrackChange::Removed {
+                scope: scope_key_to_option(&self.scope_key),
+                full_name: self.full_name.clone(),
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use moq_transport::coding::TrackName;
+    use moq_transport::message::RequestErrorCode;
+
+    fn ns(path: &str) -> TrackNamespace {
+        TrackNamespace::from_utf8_path(path)
+    }
+
+    fn full(namespace: &TrackNamespace, name: &str) -> FullTrackName {
+        FullTrackName {
+            namespace: namespace.clone(),
+            name: TrackName::from(name),
+        }
+    }
+
+    async fn assert_no_namespace_change(changes: &mut broadcast::Receiver<NamespaceChange>) {
+        let change =
+            tokio::time::timeout(std::time::Duration::from_millis(50), changes.recv()).await;
+        assert!(change.is_err(), "unexpected namespace change: {change:?}");
+    }
+
+    #[tokio::test]
+    async fn remote_namespace_is_visible_but_not_a_track_route() {
+        let mut locals = Locals::new();
+        let namespace = ns("room/remote");
+        let registration = locals
+            .register_remote_namespace(Some("scope-a"), namespace.clone())
+            .expect("remote namespace should register");
+
+        assert_eq!(
+            locals.list_namespaces_matching(
+                Some("scope-a"),
+                &TrackNamespacePrefix::from_utf8_path("room"),
+            ),
+            vec![namespace.clone()]
+        );
+        assert!(locals
+            .get_or_request_track(Some("scope-a"), namespace, "video")
+            .await
+            .is_none());
+
+        drop(registration);
+    }
+
+    #[tokio::test]
+    async fn local_then_remote_emits_only_union_transitions() {
+        let mut locals = Locals::new();
+        let mut changes = locals.subscribe_namespace_changes();
+        let namespace = ns("room/shared");
+        let (local, _requests) = locals
+            .register_namespace(None, namespace.clone())
+            .await
+            .expect("local namespace should register");
+        assert!(changes.recv().await.expect("local add").added);
+
+        let remote = locals
+            .register_remote_namespace(None, namespace.clone())
+            .expect("remote namespace should coexist");
+        assert_no_namespace_change(&mut changes).await;
+
+        drop(local);
+        assert_no_namespace_change(&mut changes).await;
+        assert_eq!(
+            locals.list_namespaces_matching(
+                None,
+                &TrackNamespacePrefix::from_utf8_path("room/shared"),
+            ),
+            vec![namespace.clone()]
+        );
+
+        drop(remote);
+        let removed = changes.recv().await.expect("last-source removal");
+        assert_eq!(removed.namespace, namespace);
+        assert!(!removed.added);
+    }
+
+    #[tokio::test]
+    async fn remote_then_local_keeps_local_route_until_last_drop() {
+        let mut locals = Locals::new();
+        let mut changes = locals.subscribe_namespace_changes();
+        let namespace = ns("room/shared");
+        let remote = locals
+            .register_remote_namespace(None, namespace.clone())
+            .expect("remote namespace should register");
+        assert!(changes.recv().await.expect("remote add").added);
+
+        let (local, mut requests) = locals
+            .register_namespace(None, namespace.clone())
+            .await
+            .expect("local namespace should coexist");
+        assert_no_namespace_change(&mut changes).await;
+
+        drop(remote);
+        assert_no_namespace_change(&mut changes).await;
+        let requested = locals
+            .get_or_request_track(None, namespace.clone(), "video")
+            .await
+            .expect("local route should remain usable");
+        drop(requested);
+        assert!(requests.recv().await.is_some());
+
+        drop(local);
+        let removed = changes.recv().await.expect("local removal");
+        assert_eq!(removed.namespace, namespace);
+        assert!(!removed.added);
+    }
+
+    #[tokio::test]
+    async fn multiple_remote_sources_remove_on_last_drop() {
+        let locals = Locals::new();
+        let mut changes = locals.subscribe_namespace_changes();
+        let namespace = ns("room/remote");
+        let first = locals
+            .register_remote_namespace(None, namespace.clone())
+            .expect("first remote should register");
+        assert!(changes.recv().await.expect("first add").added);
+
+        let second = locals
+            .register_remote_namespace(None, namespace.clone())
+            .expect("second remote should register");
+        assert_no_namespace_change(&mut changes).await;
+
+        drop(first);
+        assert_no_namespace_change(&mut changes).await;
+        drop(second);
+
+        let removed = changes.recv().await.expect("last remote removal");
+        assert_eq!(removed.namespace, namespace);
+        assert!(!removed.added);
+    }
+
+    #[tokio::test]
+    async fn remote_source_does_not_allow_duplicate_local_registration() {
+        let mut locals = Locals::new();
+        let namespace = ns("room/shared");
+        let _remote = locals
+            .register_remote_namespace(None, namespace.clone())
+            .expect("remote namespace should register");
+        let (_local, _requests) = locals
+            .register_namespace(None, namespace.clone())
+            .await
+            .expect("first local namespace should register");
+
+        let duplicate = locals.register_namespace(None, namespace).await;
+        assert!(duplicate.is_err());
+    }
+
+    #[tokio::test]
+    async fn remote_namespace_scopes_stay_isolated() {
+        let locals = Locals::new();
+        let _a = locals
+            .register_remote_namespace(Some("scope-a"), ns("room/a"))
+            .expect("scope-a remote should register");
+        let _b = locals
+            .register_remote_namespace(Some("scope-b"), ns("room/b"))
+            .expect("scope-b remote should register");
+
+        assert_eq!(
+            locals.list_namespaces_matching(
+                Some("scope-a"),
+                &TrackNamespacePrefix::from_utf8_path("room"),
+            ),
+            vec![ns("room/a")]
+        );
+        assert_eq!(
+            locals.list_namespaces_matching(
+                Some("scope-b"),
+                &TrackNamespacePrefix::from_utf8_path("room"),
+            ),
+            vec![ns("room/b")]
+        );
+    }
+
+    #[tokio::test]
+    async fn register_track_makes_exact_track_retrievable_until_drop() {
+        let mut locals = Locals::new();
+        let namespace = ns("room/123");
+        let (writer, reader) = Track::new(namespace.clone(), "audio").produce();
+        let key = full(&namespace, "audio");
+
+        let registration = locals
+            .register_track(None, reader.clone())
+            .await
+            .expect("track registration should succeed");
+
+        assert!(locals.retrieve_track(None, &key).is_some());
+
+        drop(registration);
+        assert!(locals.retrieve_track(None, &key).is_none());
+
+        drop(writer);
+    }
+
+    #[tokio::test]
+    async fn get_or_request_track_uses_namespace_source_and_caches_reader() {
+        let mut locals = Locals::new();
+        let namespace = ns("room/123");
+        let (_registration, mut requests) = locals
+            .register_namespace(None, namespace.clone())
+            .await
+            .expect("namespace source should register");
+
+        let local = locals
+            .get_or_request_track(None, namespace.clone(), "video")
+            .await
+            .expect("missing track should be requested from namespace source");
+        let reader = local.reader;
+        assert!(
+            local.interest.is_some(),
+            "a cached track should hand back an interest guard"
+        );
+        assert!(
+            local.upstream.is_some(),
+            "a cached track should hand back an upstream readiness gate"
+        );
+
+        let requested = requests
+            .recv()
+            .await
+            .expect("source should get TrackRequest");
+        assert_eq!(requested.writer.namespace, namespace);
+        assert_eq!(requested.writer.name, TrackName::from("video"));
+
+        let key = full(&namespace, "video");
+        let cached = locals
+            .retrieve_track(None, &key)
+            .expect("requested track should be cached");
+        assert_eq!(cached.namespace, reader.namespace);
+        assert_eq!(cached.name, reader.name);
+
+        let again = locals
+            .get_or_request_track(None, namespace.clone(), "video")
+            .await
+            .expect("cached track should be returned");
+        assert_eq!(again.reader.namespace, namespace);
+        assert_eq!(again.reader.name, TrackName::from("video"));
+
+        let no_second_request =
+            tokio::time::timeout(std::time::Duration::from_millis(50), requests.recv()).await;
+        assert!(
+            no_second_request.is_err(),
+            "cache hit should not request again"
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_get_or_request_track_deduplicates_request() {
+        let mut locals = Locals::new();
+        let namespace = ns("room/123");
+        let (_registration, mut requests) = locals
+            .register_namespace(None, namespace.clone())
+            .await
+            .expect("namespace source should register");
+
+        let mut first = locals.clone();
+        let mut second = locals.clone();
+        let (first_reader, second_reader) = tokio::join!(
+            first.get_or_request_track(None, namespace.clone(), "video"),
+            second.get_or_request_track(None, namespace.clone(), "video"),
+        );
+
+        let first_reader = first_reader
+            .expect("first request should get a reader")
+            .reader;
+        let second_reader = second_reader
+            .expect("second request should get cached reader")
+            .reader;
+        assert_eq!(first_reader.namespace, namespace);
+        assert_eq!(second_reader.namespace, namespace);
+        assert_eq!(first_reader.name, TrackName::from("video"));
+        assert_eq!(second_reader.name, TrackName::from("video"));
+
+        requests
+            .recv()
+            .await
+            .expect("source should receive one TrackRequest");
+        let no_second_request =
+            tokio::time::timeout(std::time::Duration::from_millis(50), requests.recv()).await;
+        assert!(
+            no_second_request.is_err(),
+            "concurrent misses should be deduplicated"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_get_or_request_track_multi_thread_never_returns_spurious_none() {
+        // Exercise the cache-slot race across real threads: many callers miss the
+        // cache for the same track at once. Every caller must receive a reader (the
+        // winner's reserved reader), and the source must see exactly one request.
+        for _ in 0..64 {
+            let mut locals = Locals::new();
+            let namespace = ns("room/123");
+            let (_registration, mut requests) = locals
+                .register_namespace(None, namespace.clone())
+                .await
+                .expect("namespace source should register");
+
+            let mut handles = Vec::new();
+            for _ in 0..8 {
+                let mut clone = locals.clone();
+                let namespace = namespace.clone();
+                handles.push(tokio::spawn(async move {
+                    clone.get_or_request_track(None, namespace, "video").await
+                }));
+            }
+
+            for handle in handles {
+                let reader = handle.await.expect("task should not panic");
+                assert!(
+                    reader.is_some(),
+                    "every concurrent caller should receive a reader"
+                );
+            }
+
+            let first = requests
+                .recv()
+                .await
+                .expect("source should receive exactly one TrackRequest");
+            assert_eq!(first.writer.namespace, namespace);
+            let extra =
+                tokio::time::timeout(std::time::Duration::from_millis(50), requests.recv()).await;
+            assert!(
+                extra.is_err(),
+                "concurrent misses across threads must be deduplicated"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn get_or_request_track_uses_longest_namespace_prefix() {
+        let mut locals = Locals::new();
+        let (_short_registration, mut short_requests) = locals
+            .register_namespace(None, ns("room"))
+            .await
+            .expect("short prefix should register");
+        let (_long_registration, mut long_requests) = locals
+            .register_namespace(None, ns("room/123"))
+            .await
+            .expect("long prefix should register");
+
+        let requested_ns = ns("room/123/camera");
+        let local = locals
+            .get_or_request_track(None, requested_ns.clone(), "video")
+            .await
+            .expect("track should be requested from longest prefix");
+        assert_eq!(local.reader.namespace, requested_ns);
+
+        let long_request = long_requests
+            .recv()
+            .await
+            .expect("longest prefix should receive the request");
+        assert_eq!(long_request.writer.namespace, ns("room/123/camera"));
+        assert_eq!(long_request.writer.name, TrackName::from("video"));
+
+        let no_short_request =
+            tokio::time::timeout(std::time::Duration::from_millis(50), short_requests.recv()).await;
+        assert!(
+            no_short_request.is_err(),
+            "shorter prefix should not receive request"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_or_request_track_returns_none_without_track_or_namespace_source() {
+        let mut locals = Locals::new();
+        let result = locals
+            .get_or_request_track(None, ns("unknown"), "video")
+            .await;
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn list_namespaces_matching_filters_by_prefix_and_scope() {
+        let mut locals = Locals::new();
+        let _room = locals
+            .register_namespace(Some("scope-a"), ns("room/123"))
+            .await
+            .expect("room should register");
+        let _camera = locals
+            .register_namespace(Some("scope-a"), ns("room/123/camera"))
+            .await
+            .expect("camera should register");
+        let _other_scope = locals
+            .register_namespace(Some("scope-b"), ns("room/123/other"))
+            .await
+            .expect("other scope should register");
+
+        let mut matches = locals.list_namespaces_matching(
+            Some("scope-a"),
+            &TrackNamespacePrefix::from_utf8_path("room/123"),
+        );
+        matches.sort_by_key(|namespace| namespace.to_utf8_path());
+
+        assert_eq!(matches, vec![ns("room/123"), ns("room/123/camera")]);
+    }
+
+    #[tokio::test]
+    async fn list_namespaces_matching_keeps_unscoped_and_scoped_separate() {
+        let mut locals = Locals::new();
+        let _global = locals
+            .register_namespace(None, ns("room/global"))
+            .await
+            .expect("global namespace should register");
+        let _scoped = locals
+            .register_namespace(Some("scope-a"), ns("room/scoped"))
+            .await
+            .expect("scoped namespace should register");
+
+        let global =
+            locals.list_namespaces_matching(None, &TrackNamespacePrefix::from_utf8_path("room"));
+        assert_eq!(global, vec![ns("room/global")]);
+
+        let scoped = locals.list_namespaces_matching(
+            Some("scope-a"),
+            &TrackNamespacePrefix::from_utf8_path("room"),
+        );
+        assert_eq!(scoped, vec![ns("room/scoped")]);
+    }
+
+    #[tokio::test]
+    async fn namespace_changes_reports_register_and_drop() {
+        let mut locals = Locals::new();
+        let mut changes = locals.subscribe_namespace_changes();
+        let namespace = ns("room/123");
+
+        let registration = locals
+            .register_namespace(Some("scope-a"), namespace.clone())
+            .await
+            .expect("namespace should register")
+            .0;
+
+        let added = changes.recv().await.expect("added event");
+        assert_eq!(
+            added,
+            NamespaceChange {
+                scope: Some("scope-a".to_string()),
+                namespace: namespace.clone(),
+                added: true,
+            }
+        );
+
+        drop(registration);
+
+        let removed = changes.recv().await.expect("removed event");
+        assert_eq!(
+            removed,
+            NamespaceChange {
+                scope: Some("scope-a".to_string()),
+                namespace,
+                added: false,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn namespace_changes_uses_none_for_unscoped() {
+        let mut locals = Locals::new();
+        let mut changes = locals.subscribe_namespace_changes();
+        let namespace = ns("room/123");
+
+        let _registration = locals
+            .register_namespace(None, namespace.clone())
+            .await
+            .expect("namespace should register")
+            .0;
+
+        let added = changes.recv().await.expect("added event");
+        assert_eq!(
+            added,
+            NamespaceChange {
+                scope: None,
+                namespace,
+                added: true,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn list_tracks_matching_filters_by_namespace_prefix_and_scope() {
+        let mut locals = Locals::new();
+        let (_writer_a, reader_a) = Track::new(ns("room/123"), "audio").produce();
+        let (_writer_b, reader_b) = Track::new(ns("room/123/camera"), "video").produce();
+        let (_writer_other_scope, reader_other_scope) =
+            Track::new(ns("room/123"), "other").produce();
+
+        let _a = locals
+            .register_track(Some("scope-a"), reader_a)
+            .await
+            .expect("track a should register");
+        let _b = locals
+            .register_track(Some("scope-a"), reader_b)
+            .await
+            .expect("track b should register");
+        let _other = locals
+            .register_track(Some("scope-b"), reader_other_scope)
+            .await
+            .expect("other scope should register");
+
+        let mut tracks = locals.list_tracks_matching(
+            Some("scope-a"),
+            &TrackNamespacePrefix::from_utf8_path("room/123"),
+        );
+        tracks.sort_by_key(|track| format!("{}/{}", track.namespace, track.name));
+
+        assert_eq!(tracks.len(), 2);
+        assert_eq!(tracks[0].namespace, ns("room/123"));
+        assert_eq!(tracks[0].name, TrackName::from("audio"));
+        assert_eq!(tracks[1].namespace, ns("room/123/camera"));
+        assert_eq!(tracks[1].name, TrackName::from("video"));
+    }
+
+    #[tokio::test]
+    async fn list_tracks_matching_excludes_pull_through_cache_entries() {
+        let mut locals = Locals::new();
+        let namespace = ns("room/123");
+        let (_registration, mut requests) = locals
+            .register_namespace(None, namespace.clone())
+            .await
+            .expect("namespace source should register");
+
+        let _reader = locals
+            .get_or_request_track(None, namespace.clone(), "video")
+            .await
+            .expect("missing track should be requested and cached");
+        let _requested = requests.recv().await.expect("source should get request");
+
+        let tracks =
+            locals.list_tracks_matching(None, &TrackNamespacePrefix::from_utf8_path("room/123"));
+
+        assert!(tracks.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_tracks_matching_keeps_unscoped_and_scoped_separate() {
+        let mut locals = Locals::new();
+        let (_global_writer, global_reader) = Track::new(ns("room/global"), "audio").produce();
+        let (_scoped_writer, scoped_reader) = Track::new(ns("room/scoped"), "video").produce();
+
+        let _global = locals
+            .register_track(None, global_reader)
+            .await
+            .expect("global track should register");
+        let _scoped = locals
+            .register_track(Some("scope-a"), scoped_reader)
+            .await
+            .expect("scoped track should register");
+
+        let global =
+            locals.list_tracks_matching(None, &TrackNamespacePrefix::from_utf8_path("room"));
+        assert_eq!(global.len(), 1);
+        assert_eq!(global[0].namespace, ns("room/global"));
+        assert_eq!(global[0].name, TrackName::from("audio"));
+
+        let scoped = locals.list_tracks_matching(
+            Some("scope-a"),
+            &TrackNamespacePrefix::from_utf8_path("room"),
+        );
+        assert_eq!(scoped.len(), 1);
+        assert_eq!(scoped[0].namespace, ns("room/scoped"));
+        assert_eq!(scoped[0].name, TrackName::from("video"));
+    }
+
+    #[tokio::test]
+    async fn track_changes_reports_register_and_drop() {
+        let mut locals = Locals::new();
+        let mut changes = locals.subscribe_track_changes();
+        let namespace = ns("room/123");
+        let (_writer, reader) = Track::new(namespace.clone(), "audio").produce();
+
+        let registration = locals
+            .register_track(Some("scope-a"), reader)
+            .await
+            .expect("track should register");
+
+        let added = changes.recv().await.expect("added event");
+        match added {
+            TrackChange::Added { scope, track } => {
+                assert_eq!(scope, Some("scope-a".to_string()));
+                assert_eq!(track.namespace, namespace);
+                assert_eq!(track.name, TrackName::from("audio"));
+            }
+            TrackChange::Removed { .. } => panic!("expected added event"),
+        }
+
+        drop(registration);
+
+        let removed = changes.recv().await.expect("removed event");
+        match removed {
+            TrackChange::Removed { scope, full_name } => {
+                assert_eq!(scope, Some("scope-a".to_string()));
+                assert_eq!(full_name.namespace, ns("room/123"));
+                assert_eq!(full_name.name, TrackName::from("audio"));
+            }
+            TrackChange::Added { .. } => panic!("expected removed event"),
+        }
+    }
+    /// Draft-16 §8.4: the gate must not resolve until the requester reports that
+    /// the upstream subscription is established, because the caller sends
+    /// SUBSCRIBE_OK as soon as it does.
+    #[tokio::test]
+    async fn upstream_gate_waits_for_the_requester() {
+        let mut locals = Locals::new();
+        let namespace = ns("room/123");
+        let (_registration, mut requests) = locals
+            .register_namespace(None, namespace.clone())
+            .await
+            .expect("namespace source should register");
+
+        let upstream = locals
+            .get_or_request_track(None, namespace.clone(), "video")
+            .await
+            .expect("missing track should be requested")
+            .upstream
+            .expect("a cached track should hand back an upstream readiness gate");
+        let request = requests.recv().await.expect("source should get a request");
+
+        let pending = tokio::time::timeout(Duration::from_millis(50), upstream.established()).await;
+        assert!(
+            pending.is_err(),
+            "the gate must not resolve before the upstream subscription is established"
+        );
+
+        request.upstream.established();
+
+        upstream
+            .established()
+            .await
+            .expect("gate should resolve once the upstream subscription is established");
+    }
+
+    /// An upstream rejection has to surface as the same error, so the caller can
+    /// answer REQUEST_ERROR with a matching code instead of accepting the request
+    /// and reporting the failure later as PUBLISH_DONE.
+    #[tokio::test]
+    async fn upstream_gate_propagates_the_upstream_rejection() {
+        let mut locals = Locals::new();
+        let namespace = ns("room/123");
+        let (_registration, mut requests) = locals
+            .register_namespace(None, namespace.clone())
+            .await
+            .expect("namespace source should register");
+
+        let upstream = locals
+            .get_or_request_track(None, namespace.clone(), "video")
+            .await
+            .expect("missing track should be requested")
+            .upstream
+            .expect("cached track should hand back a gate");
+        let request = requests.recv().await.expect("source should get a request");
+
+        let rejection = ServeError::Closed(RequestErrorCode::DoesNotExist as u64);
+        request.upstream.failed(rejection.clone());
+
+        let err = upstream
+            .established()
+            .await
+            .expect_err("a rejected upstream subscription must not resolve as established");
+        assert_eq!(err, rejection);
+    }
+
+    /// A subscriber arriving mid-handshake is a cache hit on an entry that is not
+    /// established yet, so it must wait on the same gate rather than be served a
+    /// reader with no upstream subscription behind it.
+    #[tokio::test]
+    async fn upstream_gate_is_shared_by_concurrent_subscribers() {
+        let mut locals = Locals::new();
+        let namespace = ns("room/123");
+        let (_registration, mut requests) = locals
+            .register_namespace(None, namespace.clone())
+            .await
+            .expect("namespace source should register");
+
+        let first = locals
+            .get_or_request_track(None, namespace.clone(), "video")
+            .await
+            .expect("first request")
+            .upstream
+            .expect("first gate");
+        let request = requests.recv().await.expect("source should get a request");
+
+        let second = locals
+            .get_or_request_track(None, namespace.clone(), "video")
+            .await
+            .expect("second request")
+            .upstream
+            .expect("second gate");
+
+        let pending = tokio::time::timeout(Duration::from_millis(50), second.established()).await;
+        assert!(
+            pending.is_err(),
+            "a cache hit on an unestablished entry must still wait"
+        );
+
+        request.upstream.established();
+
+        first
+            .established()
+            .await
+            .expect("first subscriber should be released");
+        second
+            .established()
+            .await
+            .expect("second subscriber should be released");
+        assert!(
+            requests.try_recv().is_err(),
+            "sharing the gate must not trigger a second upstream SUBSCRIBE"
+        );
+    }
+
+    /// A requester that gives up without answering must release waiting
+    /// subscribers with an error rather than stranding them: an abandoned request
+    /// is not an established subscription.
+    #[tokio::test]
+    async fn abandoned_request_releases_waiting_subscribers() {
+        let mut locals = Locals::new();
+        let namespace = ns("room/123");
+        let (_registration, mut requests) = locals
+            .register_namespace(None, namespace.clone())
+            .await
+            .expect("namespace source should register");
+
+        let upstream = locals
+            .get_or_request_track(None, namespace.clone(), "video")
+            .await
+            .expect("missing track should be requested")
+            .upstream
+            .expect("cached track should hand back a gate");
+
+        drop(requests.recv().await.expect("source should get a request"));
+
+        let err = upstream
+            .established()
+            .await
+            .expect_err("an abandoned request must not leave subscribers waiting forever");
+        assert!(
+            matches!(err, ServeError::InternalWithId(_, _)),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// Locally published tracks are already established when they are registered,
+    /// so serving one must not wait on anything.
+    #[tokio::test]
+    async fn published_track_has_no_upstream_gate() {
+        let mut locals = Locals::new();
+        let namespace = ns("room/123");
+        let (_writer, reader) = Track::new(namespace.clone(), "audio").produce();
+        let _registration = locals
+            .register_track(None, reader)
+            .await
+            .expect("track should register");
+
+        let local = locals
+            .get_or_request_track(None, namespace, "audio")
+            .await
+            .expect("published track should be served");
+
+        assert!(
+            local.upstream.is_none(),
+            "a published track needs no upstream readiness gate"
+        );
+        assert!(
+            local.interest.is_none(),
+            "a published track has no upstream subscription to lease"
+        );
+    }
+
+    /// The core fix: once the last downstream subscriber leaves, the cache entry
+    /// is evicted and the lease resolves so the upstream subscription can be
+    /// dropped (sending UNSUBSCRIBE).
+    #[tokio::test(start_paused = true)]
+    async fn idle_cached_track_is_evicted_and_lease_released() {
+        let idle = Duration::from_secs(30);
+        let mut locals = Locals::with_cache_idle_timeout(idle);
+        let namespace = ns("room/123");
+        let (_registration, mut requests) = locals
+            .register_namespace(None, namespace.clone())
+            .await
+            .expect("namespace source should register");
+
+        let guard = locals
+            .get_or_request_track(None, namespace.clone(), "video")
+            .await
+            .expect("missing track should be requested")
+            .interest
+            .expect("cached track should hand back a guard");
+
+        let request = requests.recv().await.expect("source should get a request");
+        let key = full(&namespace, "video");
+
+        // While a subscriber is being served the entry must stay put.
+        let released = request.lease.released();
+        tokio::pin!(released);
+        tokio::select! {
+            _ = &mut released => panic!("evicted a track that still has a subscriber"),
+            _ = tokio::time::sleep(idle * 4) => {}
+        }
+        assert!(locals.retrieve_track(None, &key).is_some());
+
+        // Last subscriber leaves: the entry lingers for the grace period, then goes.
+        drop(guard);
+        tokio::select! {
+            _ = &mut released => panic!("evicted before the grace period elapsed"),
+            _ = tokio::time::sleep(idle / 2) => {}
+        }
+        assert!(
+            locals.retrieve_track(None, &key).is_some(),
+            "a warm cache entry should survive a brief gap between subscribers"
+        );
+
+        released.await;
+        assert!(
+            locals.retrieve_track(None, &key).is_none(),
+            "idle entry should be evicted so the next subscriber re-requests upstream"
+        );
+    }
+
+    /// A subscriber arriving during the grace period keeps the warm entry, and no
+    /// second upstream request is made.
+    #[tokio::test(start_paused = true)]
+    async fn subscriber_returning_within_grace_period_reuses_the_entry() {
+        let idle = Duration::from_secs(30);
+        let mut locals = Locals::with_cache_idle_timeout(idle);
+        let namespace = ns("room/123");
+        let (_registration, mut requests) = locals
+            .register_namespace(None, namespace.clone())
+            .await
+            .expect("namespace source should register");
+
+        let local = locals
+            .get_or_request_track(None, namespace.clone(), "video")
+            .await
+            .expect("missing track should be requested");
+        let request = requests.recv().await.expect("source should get a request");
+
+        let released = request.lease.released();
+        tokio::pin!(released);
+
+        drop(
+            local
+                .interest
+                .expect("cached track should hand back a guard"),
+        );
+
+        tokio::select! {
+            _ = &mut released => panic!("evicted before the grace period elapsed"),
+            _ = tokio::time::sleep(idle / 2) => {}
+        }
+
+        // New subscriber inside the grace period: served from cache, no new request.
+        let guard = locals
+            .get_or_request_track(None, namespace.clone(), "video")
+            .await
+            .expect("warm entry should still be served")
+            .interest
+            .expect("cached track should hand back a guard");
+
+        tokio::select! {
+            _ = &mut released => panic!("evicted while a subscriber was present"),
+            _ = tokio::time::sleep(idle * 4) => {}
+        }
+
+        assert!(
+            requests.try_recv().is_err(),
+            "reusing the warm entry must not trigger a second upstream SUBSCRIBE"
+        );
+
+        // And it still gets evicted once that subscriber leaves too.
+        drop(guard);
+        released.await;
+        assert!(locals
+            .retrieve_track(None, &full(&namespace, "video"))
+            .is_none());
+    }
+
+    /// A subscriber that gives up before the upstream subscription is even set up
+    /// must not pin the entry forever.
+    #[tokio::test(start_paused = true)]
+    async fn cancelled_requester_does_not_pin_the_upstream_subscription() {
+        let idle = Duration::from_secs(30);
+        let mut locals = Locals::with_cache_idle_timeout(idle);
+        let namespace = ns("room/123");
+        let (_registration, mut requests) = locals
+            .register_namespace(None, namespace.clone())
+            .await
+            .expect("namespace source should register");
+
+        let local = locals
+            .get_or_request_track(None, namespace.clone(), "video")
+            .await
+            .expect("missing track should be requested");
+
+        // The subscriber goes away before the source has even picked up the
+        // request, which is what a cancelled SUBSCRIBE looks like.
+        drop(local);
+
+        let request = requests.recv().await.expect("source should get a request");
+        request.lease.released().await;
+
+        assert!(
+            locals
+                .retrieve_track(None, &full(&namespace, "video"))
+                .is_none(),
+            "an abandoned request must not leave a permanently leased entry"
+        );
+    }
+
+    /// A zero timeout preserves the old behaviour: the upstream subscription is
+    /// held for as long as the session lives.
+    #[tokio::test(start_paused = true)]
+    async fn zero_idle_timeout_disables_eviction() {
+        let mut locals = Locals::with_cache_idle_timeout(Duration::ZERO);
+        let namespace = ns("room/123");
+        let (_registration, mut requests) = locals
+            .register_namespace(None, namespace.clone())
+            .await
+            .expect("namespace source should register");
+
+        let local = locals
+            .get_or_request_track(None, namespace.clone(), "video")
+            .await
+            .expect("missing track should be requested");
+        let request = requests.recv().await.expect("source should get a request");
+
+        drop(local);
+
+        tokio::select! {
+            _ = request.lease.released() => panic!("eviction should be disabled"),
+            _ = tokio::time::sleep(Duration::from_secs(3600)) => {}
+        }
+
+        assert!(locals
+            .retrieve_track(None, &full(&namespace, "video"))
+            .is_some());
+    }
+
+    /// A guard from an evicted generation must not keep a replacement entry alive.
+    #[tokio::test(start_paused = true)]
+    async fn stale_guard_does_not_block_eviction_of_a_replacement() {
+        let idle = Duration::from_secs(30);
+        let mut locals = Locals::with_cache_idle_timeout(idle);
+        let namespace = ns("room/123");
+        let (_registration, mut requests) = locals
+            .register_namespace(None, namespace.clone())
+            .await
+            .expect("namespace source should register");
+
+        let first = locals
+            .get_or_request_track(None, namespace.clone(), "video")
+            .await
+            .expect("first request");
+        let first_request = requests.recv().await.expect("first request received");
+
+        // Drop the first generation's entry while deliberately keeping its guard
+        // alive, modelling a slow subscriber that outlives its cache entry.
+        let stale_guard = first.interest.expect("guard");
+        let key = full(&namespace, "video");
+        locals
+            .tracks
+            .write()
+            .unwrap()
+            .get_mut(UNSCOPED)
+            .unwrap()
+            .remove(&key);
+        drop(first_request);
+
+        // A second subscriber creates a fresh generation.
+        let second = locals
+            .get_or_request_track(None, namespace.clone(), "video")
+            .await
+            .expect("second request");
+        let second_request = requests.recv().await.expect("second request received");
+        drop(second.interest.expect("guard"));
+
+        // The stale guard belongs to the old counter, so it must not make the new
+        // entry look busy.
+        let _ = &stale_guard;
+        second_request.lease.released().await;
+
+        assert!(
+            locals.retrieve_track(None, &key).is_none(),
+            "a stale guard must not pin a replacement entry"
+        );
     }
 }

--- a/moq-relay-ietf/src/metrics.rs
+++ b/moq-relay-ietf/src/metrics.rs
@@ -29,7 +29,12 @@
 //! | `moq_relay_subscribers_total` | - | Total subscribers (SUBSCRIBE requests) received |
 //! | `moq_relay_subscribe_not_found_total` | - | Track not found after checking all sources |
 //! | `moq_relay_subscribe_route_errors_total` | - | Infrastructure failure when routing to remote |
+//! | `moq_relay_subscribe_upstream_errors_total` | - | Upstream subscription could not be established, so the downstream SUBSCRIBE was rejected |
 //! | `moq_relay_upstream_errors_total` | `stage` | Upstream connection failures (stage: connect, session) |
+//! | `moq_relay_namespace_transition_timeouts_total` | - | Namespace pull streams reset after graceful transition timeout |
+//! | `moq_relay_cache_idle_evictions_total` | `source` | Unwatched cache entries evicted, releasing an upstream subscription (source: local, remote) |
+//! | `moq_relay_change_channel_lagged_total` | `channel` | Change notifications skipped by a lagging receiver, forcing a resync (channel: namespace, track) |
+//! | `moq_relay_lease_registry_lock_poisoned_total` | `operation` | Upstream namespace lease registry lock found poisoned (operation: acquire, release) |
 //!
 //! ## Gauges
 //!
@@ -46,7 +51,7 @@
 //!
 //! | Name | Labels | Description |
 //! |------|--------|-------------|
-//! | `moq_relay_subscribe_latency_seconds` | `source` | Time to resolve subscription (source: local, remote, not_found, route_error) |
+//! | `moq_relay_subscribe_latency_seconds` | `source` | Time to resolve subscription (source: local, remote, not_found, route_error, upstream_error, downstream_left) |
 
 use metrics::{describe_counter, describe_gauge, describe_histogram, Unit};
 
@@ -77,6 +82,14 @@ pub fn describe_metrics() {
         "Total publishers (PUBLISH_NAMESPACE requests) received"
     );
     describe_counter!(
+        "moq_relay_published_tracks_total",
+        "Total publisher-initiated PUBLISH track requests received"
+    );
+    describe_counter!(
+        "moq_relay_publish_errors_total",
+        "Publisher-initiated PUBLISH failures by phase (take_reader, local_register, coordinator_register, send_ok)"
+    );
+    describe_counter!(
         "moq_relay_announce_ok_total",
         "Successful REQUEST_OK responses sent for PUBLISH_NAMESPACE"
     );
@@ -97,8 +110,28 @@ pub fn describe_metrics() {
         "Infrastructure failure when routing to remote"
     );
     describe_counter!(
+        "moq_relay_subscribe_upstream_errors_total",
+        "Upstream subscription could not be established, so the downstream SUBSCRIBE was rejected"
+    );
+    describe_counter!(
         "moq_relay_upstream_errors_total",
         "Upstream connection failures by stage (connect, session)"
+    );
+    describe_counter!(
+        "moq_relay_namespace_transition_timeouts_total",
+        "Namespace pull streams reset after graceful transition timeout"
+    );
+    describe_counter!(
+        "moq_relay_cache_idle_evictions_total",
+        "Unwatched cache entries evicted, releasing an upstream subscription, by source (local, remote)"
+    );
+    describe_counter!(
+        "moq_relay_change_channel_lagged_total",
+        "Change notifications skipped by a lagging receiver, forcing a resync, by channel (namespace, track)"
+    );
+    describe_counter!(
+        "moq_relay_lease_registry_lock_poisoned_total",
+        "Upstream namespace lease registry lock found poisoned by operation (acquire, release)"
     );
 
     // Gauges
@@ -119,6 +152,10 @@ pub fn describe_metrics() {
         "Current number of tracks being served"
     );
     describe_gauge!(
+        "moq_relay_active_published_tracks",
+        "Current number of exact tracks registered from PUBLISH"
+    );
+    describe_gauge!(
         "moq_relay_announced_namespaces",
         "Current number of registered namespaces"
     );
@@ -131,7 +168,7 @@ pub fn describe_metrics() {
     describe_histogram!(
         "moq_relay_subscribe_latency_seconds",
         Unit::Seconds,
-        "Time to resolve subscription by source (local, remote, not_found, route_error)"
+        "Time to resolve subscription by source (local, remote, not_found, route_error, upstream_error, downstream_left)"
     );
 }
 

--- a/moq-relay-ietf/src/producer.rs
+++ b/moq-relay-ietf/src/producer.rs
@@ -1,15 +1,23 @@
 // SPDX-FileCopyrightText: 2024-2026 Cloudflare Inc., Luke Curley, Mike English and contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::collections::HashSet;
+use std::sync::Arc;
+
 use futures::{stream::FuturesUnordered, FutureExt, StreamExt};
 use moq_transport::{
-    serve::{ServeError, TracksReader},
-    session::{Publisher, SessionError, Subscribed, TrackStatusRequested},
+    coding::{KeyValuePairs, TrackNamespace},
+    message::SubscribeOptions,
+    serve::{FullTrackName, ServeError, TrackReader, TracksReader},
+    session::{Publisher, SessionError, Subscribed, SubscribedNamespace, TrackStatusRequested},
 };
+use tokio::sync::broadcast;
 
 use crate::{
     metrics::{GaugeGuard, TimingGuard},
-    Locals, RemoteManager,
+    upstream_namespaces::UpstreamNamespaces,
+    Coordinator, Locals, NamespaceChange, RemoteManager, SessionContext, TrackChange,
+    UpstreamReady,
 };
 
 /// Producer of tracks to a remote Subscriber
@@ -18,10 +26,25 @@ pub struct Producer {
     publisher: Publisher,
     locals: Locals,
     remotes: RemoteManager,
-    /// The resolved scope identity for this session, if any.
-    /// Produced by `Coordinator::resolve_scope()` from the connection path.
-    /// Passed to locals/remotes to isolate namespace lookups.
-    scope: Option<String>,
+    upstream_namespaces: UpstreamNamespaces,
+    /// Relay-level context for this MoQT session.
+    context: SessionContext,
+}
+
+/// Why the wait for upstream readiness ended without the subscription being
+/// established.
+///
+/// The two cases carry the same [`ServeError`] variants — an upstream rejection
+/// can be `Cancel` or `Done` just as a departing subscriber can — so the
+/// direction has to come from which branch resolved rather than from the error.
+/// Getting it wrong misreports publisher failures as subscriber cancellations in
+/// the subscribe metrics.
+enum UpstreamWait {
+    /// The upstream subscription could not be established.
+    UpstreamFailed(ServeError),
+
+    /// The downstream subscriber went away before it was established.
+    DownstreamLeft(ServeError),
 }
 
 impl Producer {
@@ -29,13 +52,28 @@ impl Producer {
         publisher: Publisher,
         locals: Locals,
         remotes: RemoteManager,
-        scope: Option<String>,
+        coordinator: Arc<dyn Coordinator>,
+        context: SessionContext,
+    ) -> Self {
+        let (upstream_namespaces, runner) =
+            UpstreamNamespaces::new(locals.clone(), remotes.clone(), coordinator);
+        tokio::spawn(runner.run());
+        Self::new_with_upstream_namespaces(publisher, locals, remotes, upstream_namespaces, context)
+    }
+
+    pub(crate) fn new_with_upstream_namespaces(
+        publisher: Publisher,
+        locals: Locals,
+        remotes: RemoteManager,
+        upstream_namespaces: UpstreamNamespaces,
+        context: SessionContext,
     ) -> Self {
         Self {
             publisher,
             locals,
             remotes,
-            scope,
+            upstream_namespaces,
+            context,
         }
     }
 
@@ -52,6 +90,7 @@ impl Producer {
         loop {
             let mut publisher_subscribed = self.publisher.clone();
             let mut publisher_track_status = self.publisher.clone();
+            let mut publisher_subscribed_namespace = self.publisher.clone();
 
             tokio::select! {
                 // Handle a new subscribe request
@@ -94,6 +133,23 @@ impl Producer {
                         }
                     }.boxed())
                 },
+                // Handle a new namespace subscription request.
+                Some(subscribed_namespace) = publisher_subscribed_namespace.subscribed_namespace() => {
+                    let this = self.clone();
+
+                    tasks.push(async move {
+                        let prefix = subscribed_namespace.namespace_prefix.to_utf8_path();
+                        tracing::info!(namespace_prefix = %prefix, "serving subscribe namespace");
+
+                        if let Err(err) = this.serve_subscribe_namespace(subscribed_namespace).await {
+                            if Self::is_expected_serve_shutdown(&err) {
+                                tracing::debug!(namespace_prefix = %prefix, error = %err, "stopped serving subscribe namespace");
+                            } else {
+                                tracing::warn!(namespace_prefix = %prefix, error = %err, "failed serving subscribe namespace");
+                            }
+                        }
+                    }.boxed())
+                },
                 _= tasks.next(), if !tasks.is_empty() => {},
                 else => return Ok(()),
             };
@@ -111,34 +167,75 @@ impl Producer {
         let namespace = subscribed.track_namespace.clone();
         let track_name = subscribed.track_name.clone();
 
-        // Check local tracks first, and serve from local if possible
-        if let Some(mut local) = self.locals.retrieve(self.scope.as_deref(), &namespace) {
-            // Pass the full requested namespace, not the announced prefix
-            if let Some(track) = local.subscribe(namespace.clone(), &track_name) {
-                let ns = namespace.to_utf8_path();
-                tracing::info!(namespace = %ns, track = %track_name, source = "local", "serving subscribe from local: {:?}", track.info);
-                // Update label to indicate local source, timing recorded on drop
-                timing_guard.set_label("source", "local");
-                // Track active tracks - decrements when serve completes
-                let _track_guard = GaugeGuard::new("moq_relay_active_tracks");
-                return Ok(subscribed.serve(track).await?);
+        // Local lookup order inside Locals:
+        // 1. actual FullTrackName -> TrackReader media cache
+        // 2. PUBLISH_NAMESPACE route source, which triggers upstream SUBSCRIBE
+        let mut locals = self.locals.clone();
+        if let Some(local) = locals
+            .get_or_request_track(self.context.scope(), namespace.clone(), &track_name)
+            .await
+        {
+            let ns = namespace.to_utf8_path();
+            tracing::info!(namespace = %ns, track = %track_name, source = "local", "serving subscribe from local: {:?}", local.reader.info);
+            timing_guard.set_label("source", "local");
+            let _track_guard = GaugeGuard::new("moq_relay_active_tracks");
+            // Held until serving finishes. Once the last guard for a cached track
+            // drops, its upstream subscription becomes eligible for release.
+            let _interest_guard = local.interest;
+
+            // Draft-16 §8.4: a relay MUST have an Established upstream
+            // subscription before it sends SUBSCRIBE_OK. A pull-through cache
+            // entry exists before its upstream subscription does, so wait for it.
+            if let Some(upstream) = local.upstream {
+                if let Err(outcome) = Self::await_upstream(&subscribed, &upstream).await {
+                    // Which side ended the wait is decided by the branch that
+                    // resolved, not by the error variant: an upstream failure can
+                    // itself be Cancel or Done, so sniffing the variant would
+                    // report a publisher-side failure as a subscriber cancellation
+                    // and skip the upstream-error counter.
+                    let err = match outcome {
+                        UpstreamWait::DownstreamLeft(err) => {
+                            tracing::debug!(namespace = %ns, track = %track_name, error = %err, "downstream subscriber left before the upstream subscription was established");
+                            timing_guard.set_label("source", "downstream_left");
+                            err
+                        }
+                        UpstreamWait::UpstreamFailed(err) => {
+                            tracing::warn!(namespace = %ns, track = %track_name, error = %err, "upstream subscription could not be established");
+                            metrics::counter!("moq_relay_subscribe_upstream_errors_total")
+                                .increment(1);
+                            timing_guard.set_label("source", "upstream_error");
+                            err
+                        }
+                    };
+
+                    // Rejects when the subscription is already closed (the
+                    // downstream-left case), which is fine: the error below is
+                    // still the reason we stopped.
+                    let _ = subscribed.close(err.clone());
+                    return Err(err.into());
+                }
             }
+
+            return Ok(subscribed.serve(local.reader).await?);
         }
 
-        // Check remote tracks second, and serve from remote if possible
+        // Check remote tracks after local exact tracks and namespace route sources.
         match self
             .remotes
-            .subscribe(self.scope.as_deref(), &namespace, &track_name)
+            .subscribe(self.context.scope(), &namespace, &track_name)
             .await
         {
             Ok(track) => {
-                if let Some(track) = track {
+                if let Some((track, interest_guard)) = track {
                     let ns = namespace.to_utf8_path();
                     tracing::info!(namespace = %ns, track = %track_name, source = "remote", "serving subscribe from remote: {:?}", track.info);
                     // Update label to indicate remote source, timing recorded on drop
                     timing_guard.set_label("source", "remote");
                     // Track active tracks - decrements when serve completes
                     let _track_guard = GaugeGuard::new("moq_relay_active_tracks");
+                    // Held until serving finishes; the cross-relay subscription is
+                    // released once the last guard for this track drops.
+                    let _interest_guard = interest_guard;
                     return Ok(subscribed.serve(track).await?);
                 }
             }
@@ -173,14 +270,330 @@ impl Producer {
         Err(err.into())
     }
 
-    fn is_expected_serve_shutdown(err: &anyhow::Error) -> bool {
-        matches!(
-            err.downcast_ref::<SessionError>(),
-            Some(SessionError::Serve(ServeError::Cancel | ServeError::Done))
-        ) || matches!(
-            err.downcast_ref::<ServeError>(),
-            Some(ServeError::Cancel | ServeError::Done)
+    /// Wait for the upstream subscription behind a cached track to be established.
+    ///
+    /// Also completes when the downstream subscriber goes away first, so a
+    /// cancelled SUBSCRIBE is not held here for the full upstream response
+    /// timeout. The two cases are reported separately because they cannot be
+    /// told apart from the error alone — see [`UpstreamWait`].
+    async fn await_upstream(
+        subscribed: &Subscribed,
+        upstream: &UpstreamReady,
+    ) -> Result<(), UpstreamWait> {
+        tokio::select! {
+            res = upstream.established() => res.map_err(UpstreamWait::UpstreamFailed),
+            res = subscribed.closed() => Err(UpstreamWait::DownstreamLeft(
+                res.err().unwrap_or(ServeError::Done),
+            )),
+        }
+    }
+
+    /// Serve a SUBSCRIBE_NAMESPACE request using relay-local namespace state.
+    async fn serve_subscribe_namespace(
+        self,
+        mut subscribed_namespace: SubscribedNamespace,
+    ) -> Result<(), anyhow::Error> {
+        let wants_namespace = wants_namespace(subscribed_namespace.subscribe_options);
+        let wants_publish = wants_publish(subscribed_namespace.subscribe_options);
+        let namespace_changes = self.locals.subscribe_namespace_changes();
+        let track_changes = self.locals.subscribe_track_changes();
+        let mut publish_tasks: FuturesUnordered<futures::future::BoxFuture<'static, ()>> =
+            FuturesUnordered::new();
+
+        let _upstream_lease = if wants_namespace {
+            match self
+                .upstream_namespaces
+                .subscribe(&self.context, subscribed_namespace.namespace_prefix.clone())
+            {
+                Ok(lease) => Some(lease),
+                Err(error) => {
+                    tracing::error!(
+                        prefix = %subscribed_namespace.namespace_prefix,
+                        error = %error,
+                        "failed to acquire shared upstream namespace lease; serving local state only"
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        subscribed_namespace.ok()?;
+
+        let mut known_namespaces = HashSet::new();
+
+        if wants_namespace {
+            self.send_namespace_snapshot(&mut subscribed_namespace, &mut known_namespaces)?;
+        }
+
+        let mut known_tracks = HashSet::new();
+        if wants_publish {
+            self.send_publish_snapshot(
+                &subscribed_namespace,
+                &mut known_tracks,
+                &mut publish_tasks,
+            )
+            .await?;
+        }
+
+        self.serve_subscribe_namespace_loop(
+            subscribed_namespace,
+            wants_namespace,
+            wants_publish,
+            namespace_changes,
+            track_changes,
+            publish_tasks,
+            known_namespaces,
+            known_tracks,
         )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn serve_subscribe_namespace_loop(
+        self,
+        subscribed_namespace: SubscribedNamespace,
+        wants_namespace: bool,
+        wants_publish: bool,
+        mut namespace_changes: tokio::sync::broadcast::Receiver<NamespaceChange>,
+        mut track_changes: tokio::sync::broadcast::Receiver<TrackChange>,
+        mut publish_tasks: FuturesUnordered<futures::future::BoxFuture<'static, ()>>,
+        mut known_namespaces: HashSet<TrackNamespace>,
+        mut known_tracks: HashSet<FullTrackName>,
+    ) -> Result<(), anyhow::Error> {
+        let mut subscribed_namespace = subscribed_namespace;
+        loop {
+            tokio::select! {
+                res = subscribed_namespace.closed() => {
+                    res?;
+                    return Ok(());
+                }
+                change = namespace_changes.recv(), if wants_namespace => {
+                    match change {
+                        Ok(change) => {
+                            self.apply_namespace_change(&mut subscribed_namespace, &mut known_namespaces, change)?;
+                        }
+                        Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                            // Recoverable: a full resync reconstructs the state the
+                            // skipped events would have produced. Counted so that
+                            // sustained churn outgrowing the channel capacity is
+                            // visible before it shows up as latency.
+                            metrics::counter!("moq_relay_change_channel_lagged_total", "channel" => "namespace")
+                                .increment(skipped);
+                            self.resync_namespaces(&mut subscribed_namespace, &mut known_namespaces)?;
+                        }
+                        Err(broadcast::error::RecvError::Closed) => return Ok(()),
+                    }
+                }
+                change = track_changes.recv(), if wants_publish => {
+                    match change {
+                        Ok(change) => {
+                            self.apply_track_change(&subscribed_namespace, &mut known_tracks, &mut publish_tasks, change).await?;
+                        }
+                        Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                            metrics::counter!("moq_relay_change_channel_lagged_total", "channel" => "track")
+                                .increment(skipped);
+                            self.resync_publish_tracks(&subscribed_namespace, &mut known_tracks, &mut publish_tasks).await?;
+                        }
+                        Err(broadcast::error::RecvError::Closed) => return Ok(()),
+                    }
+                }
+                _ = publish_tasks.next(), if !publish_tasks.is_empty() => {},
+            }
+        }
+    }
+
+    fn send_namespace_snapshot(
+        &self,
+        subscribed_namespace: &mut SubscribedNamespace,
+        known: &mut HashSet<TrackNamespace>,
+    ) -> Result<(), ServeError> {
+        for namespace in self
+            .locals
+            .list_namespaces_matching(self.context.scope(), &subscribed_namespace.namespace_prefix)
+        {
+            if known.insert(namespace.clone()) {
+                subscribed_namespace.namespace(&namespace)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn apply_namespace_change(
+        &self,
+        subscribed_namespace: &mut SubscribedNamespace,
+        known: &mut HashSet<TrackNamespace>,
+        change: NamespaceChange,
+    ) -> Result<(), ServeError> {
+        if change.scope.as_deref() != self.context.scope() {
+            return Ok(());
+        }
+
+        if !subscribed_namespace
+            .namespace_prefix
+            .is_prefix_of(&change.namespace)
+        {
+            return Ok(());
+        }
+
+        if change.added {
+            if known.insert(change.namespace.clone()) {
+                subscribed_namespace.namespace(&change.namespace)?;
+            }
+        } else if known.remove(&change.namespace) {
+            subscribed_namespace.namespace_done(&change.namespace)?;
+        }
+
+        Ok(())
+    }
+
+    fn resync_namespaces(
+        &self,
+        subscribed_namespace: &mut SubscribedNamespace,
+        known: &mut HashSet<TrackNamespace>,
+    ) -> Result<(), ServeError> {
+        let current: HashSet<_> = self
+            .locals
+            .list_namespaces_matching(self.context.scope(), &subscribed_namespace.namespace_prefix)
+            .into_iter()
+            .collect();
+
+        for namespace in current.difference(known) {
+            subscribed_namespace.namespace(namespace)?;
+        }
+
+        for namespace in known.difference(&current) {
+            subscribed_namespace.namespace_done(namespace)?;
+        }
+
+        *known = current;
+        Ok(())
+    }
+
+    async fn send_publish_snapshot(
+        &self,
+        subscribed_namespace: &SubscribedNamespace,
+        known: &mut HashSet<FullTrackName>,
+        publish_tasks: &mut FuturesUnordered<futures::future::BoxFuture<'static, ()>>,
+    ) -> Result<(), anyhow::Error> {
+        for track in self
+            .locals
+            .list_tracks_matching(self.context.scope(), &subscribed_namespace.namespace_prefix)
+        {
+            self.publish_track_for_namespace(subscribed_namespace, known, publish_tasks, track)
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn apply_track_change(
+        &self,
+        subscribed_namespace: &SubscribedNamespace,
+        known: &mut HashSet<FullTrackName>,
+        publish_tasks: &mut FuturesUnordered<futures::future::BoxFuture<'static, ()>>,
+        change: TrackChange,
+    ) -> Result<(), anyhow::Error> {
+        match change {
+            TrackChange::Added { scope, track } => {
+                if scope.as_deref() != self.context.scope()
+                    || !subscribed_namespace
+                        .namespace_prefix
+                        .is_prefix_of(&track.namespace)
+                {
+                    return Ok(());
+                }
+
+                self.publish_track_for_namespace(subscribed_namespace, known, publish_tasks, track)
+                    .await
+            }
+            TrackChange::Removed { scope, full_name } => {
+                if scope.as_deref() == self.context.scope() {
+                    known.remove(&full_name);
+                }
+                Ok(())
+            }
+        }
+    }
+
+    async fn resync_publish_tracks(
+        &self,
+        subscribed_namespace: &SubscribedNamespace,
+        known: &mut HashSet<FullTrackName>,
+        publish_tasks: &mut FuturesUnordered<futures::future::BoxFuture<'static, ()>>,
+    ) -> Result<(), anyhow::Error> {
+        // Single pass: build only the `current` set while publishing new tracks,
+        // instead of materializing an intermediate Vec of (name, reader) pairs.
+        let mut current = HashSet::new();
+        for track in self
+            .locals
+            .list_tracks_matching(self.context.scope(), &subscribed_namespace.namespace_prefix)
+        {
+            let full_name = full_name_for_track(&track);
+            if !known.contains(&full_name) {
+                self.publish_track_for_namespace(subscribed_namespace, known, publish_tasks, track)
+                    .await?;
+            }
+            current.insert(full_name);
+        }
+
+        known.retain(|full_name| current.contains(full_name));
+        Ok(())
+    }
+
+    async fn publish_track_for_namespace(
+        &self,
+        subscribed_namespace: &SubscribedNamespace,
+        known: &mut HashSet<FullTrackName>,
+        publish_tasks: &mut FuturesUnordered<futures::future::BoxFuture<'static, ()>>,
+        track: TrackReader,
+    ) -> Result<(), anyhow::Error> {
+        let full_name = full_name_for_track(&track);
+        if known.contains(&full_name) {
+            return Ok(());
+        }
+
+        let mut params = KeyValuePairs::default();
+        if !subscribed_namespace.forward {
+            params.set_forward(false);
+        }
+
+        let namespace = full_name.namespace.to_utf8_path();
+        let track_name = full_name.name.to_string();
+        let mut publisher = self.publisher.clone();
+        let published = match publisher.publish(track, params).await {
+            Ok(published) => published,
+            Err(SessionError::Serve(ServeError::Duplicate)) => return Ok(()),
+            Err(err) => return Err(err.into()),
+        };
+        known.insert(full_name);
+        publish_tasks.push(
+            async move {
+                if let Err(err) = published.serve().await {
+                    tracing::warn!(namespace = %namespace, track = %track_name, error = %err, "failed serving PUBLISH for SUBSCRIBE_NAMESPACE");
+                }
+            }
+            .boxed(),
+        );
+
+        Ok(())
+    }
+
+    fn is_expected_serve_shutdown(err: &anyhow::Error) -> bool {
+        let serve = match err.downcast_ref::<SessionError>() {
+            Some(SessionError::Serve(err)) => Some(err),
+            _ => err.downcast_ref::<ServeError>(),
+        };
+
+        serve.is_some_and(Self::is_expected_serve_shutdown_err)
+    }
+
+    /// True for the errors that mean nobody is waiting for the subscription any
+    /// more, rather than a failure worth warning about.
+    fn is_expected_serve_shutdown_err(err: &ServeError) -> bool {
+        matches!(err, ServeError::Cancel | ServeError::Done)
     }
 
     /// Serve a track_status request.
@@ -188,23 +601,17 @@ impl Producer {
         self,
         mut track_status_requested: TrackStatusRequested,
     ) -> Result<(), anyhow::Error> {
-        // Check local tracks first, and serve from local if possible
-        if let Some(mut local_tracks) = self.locals.retrieve(
-            self.scope.as_deref(),
-            &track_status_requested.request_msg.track_namespace,
-        ) {
-            if let Some(track) = local_tracks.get_track_reader(
-                &track_status_requested.request_msg.track_namespace,
-                &track_status_requested.request_msg.track_name,
-            ) {
-                let namespace = track_status_requested
-                    .request_msg
-                    .track_namespace
-                    .to_utf8_path();
-                let track_name = &track_status_requested.request_msg.track_name;
-                tracing::info!(namespace = %namespace, track = %track_name, source = "local", "serving track_status from local: {:?}", track.info);
-                return Ok(track_status_requested.respond_ok(&track)?);
-            }
+        let full_name = FullTrackName {
+            namespace: track_status_requested.request_msg.track_namespace.clone(),
+            name: track_status_requested.request_msg.track_name.clone(),
+        };
+
+        // Check actual local tracks first.
+        if let Some(track) = self.locals.retrieve_track(self.context.scope(), &full_name) {
+            let namespace = full_name.namespace.to_utf8_path();
+            let track_name = &full_name.name;
+            tracing::info!(namespace = %namespace, track = %track_name, source = "local", "serving track_status from local: {:?}", track.info);
+            return Ok(track_status_requested.respond_ok(&track)?);
         }
 
         // TODO - forward track status to remotes?
@@ -235,6 +642,24 @@ impl Producer {
             track_status_requested.request_msg.track_name
         ))
         .into())
+    }
+}
+
+fn wants_namespace(options: SubscribeOptions) -> bool {
+    matches!(
+        options,
+        SubscribeOptions::Namespace | SubscribeOptions::Both
+    )
+}
+
+fn wants_publish(options: SubscribeOptions) -> bool {
+    matches!(options, SubscribeOptions::Publish | SubscribeOptions::Both)
+}
+
+fn full_name_for_track(track: &TrackReader) -> FullTrackName {
+    FullTrackName {
+        namespace: track.namespace.clone(),
+        name: track.name.clone(),
     }
 }
 

--- a/moq-relay-ietf/src/relay.rs
+++ b/moq-relay-ietf/src/relay.rs
@@ -1,15 +1,20 @@
 // SPDX-FileCopyrightText: 2024-2026 Cloudflare Inc., Luke Curley, Mike English and contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::{future::Future, net, path::PathBuf, pin::Pin, sync::Arc};
+use std::{future::Future, net, path::PathBuf, pin::Pin, sync::Arc, time::Duration};
 
 use anyhow::Context;
 
 use futures::{stream::FuturesUnordered, FutureExt, StreamExt};
 use moq_native_ietf::quic::{self, Endpoint};
+use moq_transport::session::SessionConfig;
 use url::Url;
 
-use crate::{metrics::GaugeGuard, Consumer, Coordinator, Locals, Producer, RemoteManager, Session};
+use crate::upstream_namespaces::{UpstreamNamespaces, UpstreamNamespacesRunner};
+use crate::{
+    metrics::GaugeGuard, ConnectionMeta, ConnectionTagger, Consumer, Coordinator, Locals, Producer,
+    RelayInfo, RemoteManager, Session, SessionContext, DEFAULT_CACHE_IDLE_TIMEOUT,
+};
 
 // A type alias for boxed future
 type ServerFuture = Pin<
@@ -49,36 +54,79 @@ pub struct RelayConfig {
 
     /// The coordinator for namespace/track registration and discovery.
     pub coordinator: Arc<dyn Coordinator>,
+
+    /// MoQT session configuration used for inbound and relay-to-relay sessions.
+    pub session: SessionConfig,
+
+    /// Classifies inbound connections as public clients or internal relay
+    /// peers via connection tags (the well-known `interface` tag). Consulted
+    /// once per accepted connection with the peer's socket address and
+    /// connection path.
+    ///
+    /// When `None`, every inbound connection is treated as a public client.
+    /// Outbound connections the relay dials itself (`--announce`,
+    /// [`RemoteManager`]) are always tagged internal and bypass this.
+    pub connection_tagger: Option<Arc<dyn ConnectionTagger>>,
+}
+
+impl RelayConfig {
+    /// Build a relay from this configuration.
+    pub fn build(self) -> anyhow::Result<Relay> {
+        Relay::new(self)
+    }
+
+    /// Build a relay with a custom pull-through cache idle timeout.
+    ///
+    /// See [`Relay::new_with_cache_idle_timeout`]. This is a separate
+    /// constructor rather than a `RelayConfig` field so that adding it does not
+    /// break existing struct-literal construction of [`RelayConfig`].
+    pub fn build_with_cache_idle_timeout(
+        self,
+        cache_idle_timeout: Duration,
+    ) -> anyhow::Result<Relay> {
+        Relay::new_with_cache_idle_timeout(self, cache_idle_timeout)
+    }
 }
 
 /// MoQ Relay server.
 pub struct Relay {
-    quic_endpoints: Vec<Endpoint>,
-    announce_url: Option<Url>,
-    mlog_dir: Option<PathBuf>,
+    config: RelayConfig,
     locals: Locals,
     remotes: RemoteManager,
-    coordinator: Arc<dyn Coordinator>,
+    upstream_namespaces: UpstreamNamespaces,
+    upstream_namespaces_runner: UpstreamNamespacesRunner,
 }
 
 impl Relay {
     pub fn new(config: RelayConfig) -> anyhow::Result<Self> {
+        Self::new_with_cache_idle_timeout(config, DEFAULT_CACHE_IDLE_TIMEOUT)
+    }
+
+    /// Create a relay that releases upstream subscriptions for cached tracks that
+    /// have had no downstream subscribers for `cache_idle_timeout`.
+    ///
+    /// The relay caches tracks it does not publish itself so multiple downstream
+    /// subscribers can share one upstream subscription. Without a timeout that
+    /// subscription outlives the last subscriber and the relay keeps receiving a
+    /// track nobody is watching. A zero timeout restores that behaviour.
+    pub fn new_with_cache_idle_timeout(
+        mut config: RelayConfig,
+        cache_idle_timeout: Duration,
+    ) -> anyhow::Result<Self> {
         if config.bind.is_some() && !config.endpoints.is_empty() {
             anyhow::bail!("cannot specify both bind and endpoints");
         }
 
-        let endpoints = if let Some(bind) = config.bind {
+        if let Some(bind) = config.bind.take() {
             let endpoint = quic::Endpoint::new(quic::Config::new(
                 bind,
                 config.qlog_dir.clone(),
                 config.tls.clone(),
             )?)?;
-            vec![endpoint]
-        } else {
-            config.endpoints
-        };
+            config.endpoints = vec![endpoint];
+        }
 
-        if endpoints.is_empty() {
+        if config.endpoints.is_empty() {
             anyhow::bail!("no endpoints available to start the server");
         }
 
@@ -93,40 +141,63 @@ impl Relay {
             tracing::info!("mlog output enabled: {}", mlog_dir.display());
         }
 
-        let locals = Locals::new();
+        let locals = Locals::with_cache_idle_timeout(cache_idle_timeout);
 
         // FIXME(itzmanish): have a generic filter to find endpoints for forward, remote etc.
-        let remote_clients = endpoints
+        let remote_clients = config
+            .endpoints
             .iter()
             .map(|endpoint| endpoint.client.clone())
             .collect::<Vec<_>>();
 
         // Create remote manager - uses coordinator for namespace lookups
-        let remotes = RemoteManager::new(config.coordinator.clone(), remote_clients);
+        let remotes = RemoteManager::new_with_session_config(
+            config.coordinator.clone(),
+            remote_clients,
+            config.session,
+        )
+        .with_cache_idle_timeout(cache_idle_timeout);
+        let (upstream_namespaces, upstream_namespaces_runner) =
+            UpstreamNamespaces::new(locals.clone(), remotes.clone(), config.coordinator.clone());
 
         Ok(Self {
-            quic_endpoints: endpoints,
-            announce_url: config.announce,
-            mlog_dir: config.mlog_dir,
+            config,
             locals,
             remotes,
-            coordinator: config.coordinator,
+            upstream_namespaces,
+            upstream_namespaces_runner,
         })
     }
 
     /// Run the relay server.
     pub async fn run(self) -> anyhow::Result<()> {
         let Self {
-            quic_endpoints,
-            announce_url,
-            mlog_dir,
+            config,
             locals,
             remotes,
-            coordinator,
+            upstream_namespaces,
+            upstream_namespaces_runner,
         } = self;
+
+        let RelayConfig {
+            endpoints: quic_endpoints,
+            announce: announce_url,
+            mlog_dir,
+            coordinator,
+            session: session_config,
+            connection_tagger,
+            ..
+        } = config;
 
         let run_result = async {
             let mut tasks = FuturesUnordered::new();
+            tasks.push(
+                async move {
+                    upstream_namespaces_runner.run().await;
+                    Ok::<(), anyhow::Error>(())
+                }
+                .boxed(),
+            );
 
             // Use the remote manager for routing to remote relays.
             let remote_manager = remotes.clone();
@@ -143,10 +214,14 @@ impl Relay {
                     .context("failed to establish forward connection")?;
 
                 // Create the MoQ session over the connection
-                let (session, publisher, subscriber) =
-                    moq_transport::session::Session::connect(session, None, transport)
-                        .await
-                        .context("failed to establish forward session")?;
+                let (session, publisher, subscriber) = moq_transport::session::Session::connect_with_config(
+                    session,
+                    None,
+                    transport,
+                    session_config,
+                )
+                .await
+                .context("failed to establish forward session")?;
 
                 // Use the connection path already validated and stored by Session::connect().
                 // The forward session is scoped to whatever path the announce URL specifies.
@@ -162,22 +237,28 @@ impl Relay {
                 // Multi-scope forwarding (routing different incoming scopes to different
                 // upstream paths) would require per-scope forward connections.
                 let forward_scope = session.connection_path().map(|s| s.to_string());
+                let forward_context = SessionContext::internal(
+                    forward_scope,
+                    Some(RelayInfo::new(url.clone())),
+                );
 
                 let forward_coordinator = coordinator.clone();
                 let session = Session {
                     session,
-                    producer: Some(Producer::new(
+                    producer: Some(Producer::new_with_upstream_namespaces(
                         publisher,
                         locals.clone(),
                         remote_manager.clone(),
-                        forward_scope.clone(),
+                        upstream_namespaces.clone(),
+                        forward_context.clone(),
                     )),
                     consumer: Some(Consumer::new(
                         subscriber,
                         locals.clone(),
                         forward_coordinator,
+                        remote_manager.clone(),
                         None,
-                        forward_scope,
+                        forward_context,
                     )),
                     // Forward connections are always full read-write relay peers,
                     // so no reject loops needed.
@@ -228,9 +309,17 @@ impl Relay {
                             .boxed(),
                         );
 
-                        let (conn, conn_info) = conn_result.context("failed to accept QUIC connection")?;
-                        let connection_id = conn_info.id;
-                        let transport = conn_info.transport;
+                        let (conn, info) = conn_result.context("failed to accept QUIC connection")?;
+                        let quic::ConnInfo {
+                            id: connection_id,
+                            transport,
+                            remote_address: remote_addr,
+                            // The local IP the connection was accepted on
+                            // (destination IP the peer targeted); forwarded to the
+                            // connection tagger for inbound-interface classification.
+                            local_ip,
+                            server_name,
+                        } = info;
 
                         metrics::counter!("moq_relay_connections_total").increment(1);
 
@@ -242,6 +331,8 @@ impl Relay {
                         let remotes = remote_manager.clone();
                         let forward = forward_producer.clone();
                         let coordinator = coordinator.clone();
+                        let upstream_namespaces = upstream_namespaces.clone();
+                        let connection_tagger = connection_tagger.clone();
 
                         // Spawn a new task to handle the connection
                         tasks.push(async move {
@@ -253,7 +344,7 @@ impl Relay {
                             let raw_conn = conn.clone();
 
                             // Create the MoQ session over the connection (setup handshake etc)
-                            let (session, publisher, subscriber) = match moq_transport::session::Session::accept(conn, mlog_path, transport).await {
+                            let (session, publisher, subscriber) = match moq_transport::session::Session::accept_with_config(conn, mlog_path, transport, session_config).await {
                                 Ok(session) => session,
                                 Err(err) => {
                                     tracing::warn!(error = %err, "failed to accept MoQ session: {}", err);
@@ -292,9 +383,32 @@ impl Relay {
                                 }
                             };
 
-                            let scope_id = scope_info.as_ref().map(|s| s.scope_id.clone());
                             let can_publish = scope_info.as_ref().is_none_or(|s| s.permissions.can_publish());
                             let can_subscribe = scope_info.as_ref().is_none_or(|s| s.permissions.can_subscribe());
+
+                            // Classify the connection interface (public client vs internal
+                            // relay peer). This is deliberately separate from scope
+                            // resolution above: resolve_scope() returns identity +
+                            // permissions, while the embedder-supplied tagger decides the
+                            // transport interface from the peer socket address, TLS SNI, and
+                            // connection path. With no tagger configured every inbound
+                            // connection is treated as a public client. For connections
+                            // classified internal, the peer relay identity is derived from
+                            // the inbound socket address (see RelayInfo::from_socket_addr).
+                            let scope = scope_info.as_ref().map(|info| info.scope_id.clone());
+                            let context = match connection_tagger.as_ref() {
+                                Some(tagger) => {
+                                    let meta = ConnectionMeta::new(
+                                        Some(remote_addr),
+                                        server_name,
+                                        moq_session.connection_path().map(str::to_string),
+                                    )
+                                    .with_local_ip(local_ip);
+                                    let tags = tagger.tag(&meta);
+                                    SessionContext::from_tags(scope, &tags, Some(remote_addr))
+                                }
+                                None => SessionContext::public(scope),
+                            };
 
                             if let Some(ref info) = scope_info {
                                 tracing::debug!(
@@ -314,13 +428,13 @@ impl Relay {
                             // to the Session's reject fields so unauthorized messages get
                             // an explicit error response instead of being silently ignored.
                             let (producer, reject_subscribes) = if can_subscribe {
-                                (publisher.map(|publisher| Producer::new(publisher, locals.clone(), remotes, scope_id.clone())), None)
+                                (publisher.map(|publisher| Producer::new_with_upstream_namespaces(publisher, locals.clone(), remotes.clone(), upstream_namespaces, context.clone())), None)
                             } else {
                                 (None, publisher)
                             };
 
                             let (consumer, reject_publishes) = if can_publish {
-                                (subscriber.map(|subscriber| Consumer::new(subscriber, locals, coordinator, forward, scope_id)), None)
+                                (subscriber.map(|subscriber| Consumer::new(subscriber, locals, coordinator, remotes.clone(), forward, context)), None)
                             } else {
                                 (None, subscriber)
                             };

--- a/moq-relay-ietf/src/remote.rs
+++ b/moq-relay-ietf/src/remote.rs
@@ -5,15 +5,20 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Weak};
+use std::time::Duration;
 
 use moq_native_ietf::quic;
-use moq_transport::coding::{TrackName, TrackNamespace};
-use moq_transport::serve::{Track, TrackReader};
+use moq_transport::coding::{KeyValuePairs, TrackName, TrackNamespace, TrackNamespacePrefix};
+use moq_transport::message::SubscribeOptions;
+use moq_transport::serve::{Track, TrackReader, TracksReader};
+use moq_transport::session::{Publisher, SessionConfig, SubscribeNamespace};
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 use url::Url;
 
-use crate::{metrics::GaugeGuard, Coordinator, CoordinatorError};
+use crate::interest::{TrackInterest, TrackInterestGuard};
+use crate::local::DEFAULT_CACHE_IDLE_TIMEOUT;
+use crate::{metrics::GaugeGuard, Coordinator, CoordinatorError, RelayInfo, SessionContext};
 
 /// Cache key for upstream relay-to-relay connections.
 ///
@@ -22,7 +27,17 @@ use crate::{metrics::GaugeGuard, Coordinator, CoordinatorError};
 type RemoteCacheKey = (Url, Option<SocketAddr>);
 type RemoteSlot = Arc<Mutex<Option<Remote>>>;
 type TrackCacheKey = (TrackNamespace, TrackName);
-type TrackSlot = Arc<Mutex<Option<TrackReader>>>;
+type TrackSlot = Arc<Mutex<Option<CachedTrack>>>;
+
+/// A cached cross-relay track reader plus the downstream interest in it.
+#[derive(Clone)]
+struct CachedTrack {
+    reader: TrackReader,
+
+    /// Interest in this cached reader. When it goes idle for the configured
+    /// grace period the upstream subscription to the peer relay is released.
+    interest: TrackInterest,
+}
 
 /// Manages connections to remote relays.
 ///
@@ -33,17 +48,241 @@ type TrackSlot = Arc<Mutex<Option<TrackReader>>>;
 pub struct RemoteManager {
     coordinator: Arc<dyn Coordinator>,
     clients: Vec<quic::Client>,
+    session_config: SessionConfig,
     remotes: Arc<Mutex<HashMap<RemoteCacheKey, RemoteSlot>>>,
+
+    /// How long an unwatched cross-relay cache entry is retained before its
+    /// upstream subscription is released. Zero disables eviction.
+    cache_idle_timeout: Duration,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct NoopCoordinator;
+
+    #[async_trait::async_trait]
+    impl Coordinator for NoopCoordinator {
+        async fn register_namespace(
+            &self,
+            _scope: Option<&str>,
+            _namespace: &TrackNamespace,
+            _context: &crate::CoordinatorContext,
+        ) -> crate::CoordinatorResult<crate::NamespaceRegistration> {
+            Ok(crate::NamespaceRegistration::new(()))
+        }
+
+        async fn unregister_namespace(
+            &self,
+            _scope: Option<&str>,
+            _namespace: &TrackNamespace,
+        ) -> crate::CoordinatorResult<()> {
+            Ok(())
+        }
+
+        async fn lookup(
+            &self,
+            _scope: Option<&str>,
+            _namespace: &TrackNamespace,
+        ) -> crate::CoordinatorResult<(crate::NamespaceOrigin, Option<quic::Client>)> {
+            Err(crate::CoordinatorError::NamespaceNotFound)
+        }
+    }
+
+    #[test]
+    fn new_uses_default_session_config() {
+        let manager = RemoteManager::new(Arc::new(NoopCoordinator), vec![]);
+
+        assert_eq!(manager.session_config, SessionConfig::default());
+    }
+
+    #[test]
+    fn new_with_session_config_stores_custom_config() {
+        let config = SessionConfig { max_request_id: 7 };
+        let manager =
+            RemoteManager::new_with_session_config(Arc::new(NoopCoordinator), vec![], config);
+
+        assert_eq!(manager.session_config, config);
+    }
+
+    #[test]
+    fn remote_endpoint_context_is_internal() {
+        let url = Url::parse("https://relay.example.com/live").unwrap();
+        let addr = "127.0.0.1:4433".parse().unwrap();
+
+        let context = Remote::context_for_endpoint(url.clone(), Some(addr));
+
+        assert_eq!(context.interface, crate::SessionInterface::Internal);
+        assert!(context.scope().is_none());
+        let peer = context.peer.unwrap();
+        assert_eq!(peer.url, url);
+        assert_eq!(peer.addr, Some(addr));
+    }
+
+    #[tokio::test]
+    async fn subscribe_namespace_without_clients_errors() {
+        // No QUIC clients configured, so get_or_connect() fails before any
+        // network activity. This exercises the new forwarding entry point's
+        // connect + error plumbing without needing a live peer.
+        let manager = RemoteManager::new(Arc::new(NoopCoordinator), vec![]);
+        let relay = RelayInfo::new(Url::parse("https://relay.example.com/live").unwrap());
+
+        let result = manager
+            .subscribe_namespace(
+                &relay,
+                TrackNamespacePrefix::from_utf8_path("example.com"),
+                SubscribeOptions::Namespace,
+            )
+            .await;
+
+        // `SubscribeNamespace` is not `Debug`, so match rather than expect_err.
+        let err = match result {
+            Ok(_) => panic!("expected connect failure with no clients"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string().contains("no QUIC clients configured"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn publish_namespace_without_clients_errors() {
+        let manager = RemoteManager::new(Arc::new(NoopCoordinator), vec![]);
+        let relay = RelayInfo::new(Url::parse("https://relay.example.com/live").unwrap());
+        let (_writer, _request, reader) =
+            moq_transport::serve::Tracks::new(TrackNamespace::from_utf8_path("example.com"))
+                .produce();
+
+        let result = manager.publish_namespace(&relay, reader).await;
+
+        let err = result.expect_err("expected connect failure with no clients");
+        assert!(
+            err.to_string().contains("no QUIC clients configured"),
+            "unexpected error: {err}"
+        );
+    }
+
+    fn cached_track() -> (TrackSlot, TrackInterest) {
+        let (_writer, reader) = moq_transport::serve::Track::new(
+            TrackNamespace::from_utf8_path("example.com"),
+            "video",
+        )
+        .produce();
+        let interest = TrackInterest::new();
+        let slot: TrackSlot = Arc::new(Mutex::new(Some(CachedTrack {
+            reader,
+            interest: interest.clone(),
+        })));
+        (slot, interest)
+    }
+
+    const GRACE: Duration = Duration::from_secs(30);
+
+    /// The slot must be cleared before the caller drops its peer subscription, so
+    /// a later subscriber re-subscribes instead of attaching to a dying reader.
+    #[tokio::test(start_paused = true)]
+    async fn evict_when_idle_clears_the_slot_once_unwatched() {
+        let (slot, interest) = cached_track();
+
+        evict_when_idle(&slot, &interest, GRACE).await;
+
+        assert!(
+            slot.lock().await.is_none(),
+            "slot must be cleared before the subscription is released"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn evict_when_idle_waits_for_the_last_subscriber() {
+        let (slot, interest) = cached_track();
+        let guard = interest.guard();
+
+        let evict = evict_when_idle(&slot, &interest, GRACE);
+        tokio::pin!(evict);
+
+        tokio::select! {
+            _ = &mut evict => panic!("evicted a track that still has a subscriber"),
+            _ = tokio::time::sleep(GRACE * 4) => {}
+        }
+        assert!(slot.lock().await.is_some());
+
+        drop(guard);
+        evict.await;
+        assert!(slot.lock().await.is_none());
+    }
+
+    /// A replacement generation owns the slot now, so this subscription is stale:
+    /// it should be released without disturbing the new entry.
+    #[tokio::test(start_paused = true)]
+    async fn evict_when_idle_leaves_a_replacement_generation_alone() {
+        let (slot, interest) = cached_track();
+        let (_replacement_slot, replacement_interest) = cached_track();
+
+        {
+            let mut cached = slot.lock().await;
+            let reader = cached.as_ref().unwrap().reader.clone();
+            *cached = Some(CachedTrack {
+                reader,
+                interest: replacement_interest.clone(),
+            });
+        }
+
+        // Resolves (so the stale subscription is dropped) but must not clear the
+        // slot the replacement is using.
+        evict_when_idle(&slot, &interest, GRACE).await;
+
+        assert!(
+            slot.lock().await.is_some(),
+            "a stale lease must not evict the replacement entry"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn evict_when_idle_is_disabled_by_a_zero_timeout() {
+        let (slot, interest) = cached_track();
+
+        tokio::select! {
+            _ = evict_when_idle(&slot, &interest, Duration::ZERO) => {
+                panic!("a zero timeout must disable eviction")
+            }
+            _ = tokio::time::sleep(Duration::from_secs(3600)) => {}
+        }
+
+        assert!(slot.lock().await.is_some());
+    }
 }
 
 impl RemoteManager {
     /// Create a new RemoteManager.
     pub fn new(coordinator: Arc<dyn Coordinator>, clients: Vec<quic::Client>) -> Self {
+        Self::new_with_session_config(coordinator, clients, SessionConfig::default())
+    }
+
+    /// Create a new RemoteManager with explicit MoQT session configuration.
+    pub fn new_with_session_config(
+        coordinator: Arc<dyn Coordinator>,
+        clients: Vec<quic::Client>,
+        session_config: SessionConfig,
+    ) -> Self {
         Self {
             coordinator,
             clients,
+            session_config,
             remotes: Arc::new(Mutex::new(HashMap::new())),
+            cache_idle_timeout: DEFAULT_CACHE_IDLE_TIMEOUT,
         }
+    }
+
+    /// Override how long an unwatched cross-relay cache entry is retained before
+    /// its upstream subscription is released.
+    ///
+    /// A zero timeout disables idle eviction, holding subscriptions to peer
+    /// relays for as long as the peer session lives.
+    pub fn with_cache_idle_timeout(mut self, cache_idle_timeout: Duration) -> Self {
+        self.cache_idle_timeout = cache_idle_timeout;
+        self
     }
 
     /// Subscribe to a track from a remote relay.
@@ -57,9 +296,17 @@ impl RemoteManager {
         scope: Option<&str>,
         namespace: &TrackNamespace,
         track_name: impl Into<TrackName>,
-    ) -> anyhow::Result<Option<TrackReader>> {
+    ) -> anyhow::Result<Option<(TrackReader, TrackInterestGuard)>> {
         let track_name = track_name.into();
-        let (origin, client) = match self.coordinator.lookup(scope, namespace).await {
+
+        // Coordinator::lookup_track is the ergonomic routing entry point: it
+        // tries exact PUBLISH track registrations first, then falls back to
+        // PUBLISH_NAMESPACE namespace routing.
+        let (origin, client) = match self
+            .coordinator
+            .lookup_track(scope, namespace, &track_name.to_string())
+            .await
+        {
             Ok(result) => result,
             Err(CoordinatorError::NamespaceNotFound) => return Ok(None),
             Err(err) => return Err(err.into()),
@@ -85,6 +332,70 @@ impl RemoteManager {
                 tracing::warn!(remote_url = %url, error = %err, "remote subscribe failed, removing from cache");
                 self.remove_if_same_remote(&cache_key, &remote).await;
 
+                Err(err)
+            }
+        }
+    }
+
+    /// Forward a `SUBSCRIBE_NAMESPACE` to a specific relay peer.
+    ///
+    /// Connects to (or reuses a connection to) `relay` and opens a namespace
+    /// subscription for `prefix`, returning the [`SubscribeNamespace`] handle.
+    ///
+    /// The target `relay` is supplied explicitly by the caller (from a
+    /// coordinator lookup result). This is the namespace-level counterpart of
+    /// [`Self::subscribe`], which instead resolves a single origin internally
+    /// via [`Coordinator::lookup_track`].
+    pub async fn subscribe_namespace(
+        &self,
+        relay: &RelayInfo,
+        prefix: TrackNamespacePrefix,
+        options: SubscribeOptions,
+    ) -> anyhow::Result<SubscribeNamespace> {
+        let cache_key = (relay.url.clone(), relay.addr);
+
+        let remote = match self.get_or_connect(cache_key.clone(), None).await {
+            Ok(remote) => remote,
+            Err(err) => {
+                tracing::error!(remote_url = %relay.url, error = %err, "failed to connect to remote relay: {}", err);
+                return Err(err);
+            }
+        };
+
+        // A namespace request owns a dedicated bidirectional stream. Its
+        // rejection or reset must not evict the pooled session, which may still
+        // carry exact-track subscriptions and other non-overlapping requests.
+        remote.subscribe_namespace(prefix, options).await
+    }
+
+    /// Forward a `PUBLISH_NAMESPACE` to a specific relay peer.
+    ///
+    /// Connects to (or reuses a connection to) `relay` and advertises
+    /// `tracks.namespace`, serving its tracks from `tracks`. The target `relay`
+    /// is supplied explicitly by the caller (from a coordinator lookup result).
+    /// Blocks until the namespace is unannounced or the session errors (see
+    /// [`Remote::publish_namespace`]), so callers typically drive it from a
+    /// dedicated task.
+    pub async fn publish_namespace(
+        &self,
+        relay: &RelayInfo,
+        tracks: TracksReader,
+    ) -> anyhow::Result<()> {
+        let cache_key = (relay.url.clone(), relay.addr);
+
+        let remote = match self.get_or_connect(cache_key.clone(), None).await {
+            Ok(remote) => remote,
+            Err(err) => {
+                tracing::error!(remote_url = %relay.url, error = %err, "failed to connect to remote relay: {}", err);
+                return Err(err);
+            }
+        };
+
+        match remote.publish_namespace(tracks).await {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                tracing::warn!(remote_url = %relay.url, error = %err, "remote publish_namespace failed, removing from cache");
+                self.remove_if_same_remote(&cache_key, &remote).await;
                 Err(err)
             }
         }
@@ -142,9 +453,13 @@ impl RemoteManager {
                 cache_key.0.clone(),
                 cache_key.1,
                 client,
-                Arc::downgrade(&self.remotes),
-                cache_key.clone(),
-                Arc::downgrade(&slot),
+                self.session_config,
+                self.cache_idle_timeout,
+                RemoteCacheHandle {
+                    remotes: Arc::downgrade(&self.remotes),
+                    key: cache_key.clone(),
+                    slot: Arc::downgrade(&slot),
+                },
             )
             .await
             {
@@ -216,6 +531,52 @@ async fn remove_empty_remote_slot(
     }
 }
 
+/// Clear a cached cross-relay track once it has been unwatched for `timeout`.
+///
+/// Resolving means the caller should drop its subscription to the peer relay. The
+/// slot is cleared *before* returning, while the lock is still held, so a
+/// subscriber arriving afterwards misses the cache and re-subscribes instead of
+/// attaching to a reader whose upstream subscription is being torn down.
+///
+/// The idle re-check happens under the slot lock, which is also where interest
+/// guards are created, so a subscriber racing eviction is either counted here
+/// (and we keep waiting) or misses the slot entirely.
+///
+/// Never resolves when `timeout` is zero, preserving the previous behaviour of
+/// holding the subscription for as long as the peer session lives.
+async fn evict_when_idle(slot: &TrackSlot, interest: &TrackInterest, timeout: Duration) {
+    if timeout.is_zero() {
+        // Idle eviction disabled.
+        std::future::pending::<()>().await;
+    }
+
+    loop {
+        interest.idle_for(timeout).await;
+
+        let mut cached = slot.lock().await;
+
+        // A different generation now owns the slot; it has its own idle timer, so
+        // this subscription is no longer serving anything and must not clear it.
+        let ours = matches!(
+            cached.as_ref(),
+            Some(current) if current.interest.same_generation(interest)
+        );
+
+        if !ours {
+            return;
+        }
+
+        if interest.is_idle() {
+            cached.take();
+            return;
+        }
+
+        // Interest returned between the timer firing and taking the lock, so keep
+        // serving and start waiting again.
+        drop(cached);
+    }
+}
+
 async fn remove_empty_track_slot(
     tracks: &Arc<Mutex<HashMap<TrackCacheKey, TrackSlot>>>,
     key: &TrackCacheKey,
@@ -236,13 +597,28 @@ async fn remove_empty_track_slot(
 #[derive(Clone)]
 struct Remote {
     url: Url,
+    context: SessionContext,
+    /// Subscriber role: exact-track `SUBSCRIBE` and `SUBSCRIBE_NAMESPACE`.
     subscriber: moq_transport::session::Subscriber,
+    /// Publisher role: outbound `PUBLISH_NAMESPACE` to advertise namespaces
+    /// to this peer.
+    publisher: Publisher,
     /// Track subscriptions keyed by full track name.
     tracks: Arc<Mutex<HashMap<TrackCacheKey, TrackSlot>>>,
     /// Flag indicating if the connection is still alive.
     connected: Arc<AtomicBool>,
     /// Cancellation token for the session task.
     cancel: CancellationToken,
+    /// Idle timeout applied to this peer's cached track readers.
+    cache_idle_timeout: Duration,
+}
+
+/// Where a connection caches itself, so the session task can evict its own slot
+/// from the pool once the connection closes.
+struct RemoteCacheHandle {
+    remotes: Weak<Mutex<HashMap<RemoteCacheKey, RemoteSlot>>>,
+    key: RemoteCacheKey,
+    slot: Weak<Mutex<Option<Remote>>>,
 }
 
 impl Remote {
@@ -251,10 +627,15 @@ impl Remote {
         url: Url,
         addr: Option<SocketAddr>,
         client: &quic::Client,
-        remotes: Weak<Mutex<HashMap<RemoteCacheKey, RemoteSlot>>>,
-        cache_key: RemoteCacheKey,
-        cache_slot: Weak<Mutex<Option<Remote>>>,
+        session_config: SessionConfig,
+        cache_idle_timeout: Duration,
+        cache: RemoteCacheHandle,
     ) -> anyhow::Result<Self> {
+        let RemoteCacheHandle {
+            remotes,
+            key: cache_key,
+            slot: cache_slot,
+        } = cache;
         let (session, _quic_client_initial_cid, transport) = match client.connect(&url, addr).await
         {
             Ok(session) => session,
@@ -265,9 +646,21 @@ impl Remote {
             }
         };
 
-        let (session, subscriber) =
-            match moq_transport::session::Subscriber::connect(session, transport).await {
-                Ok(session) => session,
+        // Establish a full relay-to-relay MoQT session so this connection can
+        // act in both roles: Subscriber (exact-track SUBSCRIBE and
+        // SUBSCRIBE_NAMESPACE discovery) and Publisher (outbound
+        // PUBLISH_NAMESPACE). This mirrors the `--announce` forward path in
+        // relay.rs rather than the subscriber-only upstream pull it replaces.
+        let (session, publisher, subscriber) =
+            match moq_transport::session::Session::connect_with_config(
+                session,
+                None,
+                transport,
+                session_config,
+            )
+            .await
+            {
+                Ok(parts) => parts,
                 Err(err) => {
                     metrics::counter!("moq_relay_upstream_errors_total", "stage" => "session")
                         .increment(1);
@@ -278,6 +671,7 @@ impl Remote {
         let connected = Arc::new(AtomicBool::new(true));
         let cancel = CancellationToken::new();
         let upstream_guard = GaugeGuard::new("moq_relay_upstream_connections");
+        let context = Self::context_for_endpoint(url.clone(), addr);
 
         let session_url = url.clone();
         let session_connected = connected.clone();
@@ -321,10 +715,13 @@ impl Remote {
 
         Ok(Self {
             url,
+            context,
             subscriber,
+            publisher,
             tracks: Arc::new(Mutex::new(HashMap::new())),
             connected,
             cancel,
+            cache_idle_timeout,
         })
     }
 
@@ -335,6 +732,30 @@ impl Remote {
 
     fn is_same_connection(&self, other: &Self) -> bool {
         Arc::ptr_eq(&self.connected, &other.connected)
+    }
+
+    /// Build the [`SessionContext`] for an outbound connection dialed by the
+    /// [`RemoteManager`].
+    ///
+    /// Every connection originated here targets a relay-mesh peer resolved via
+    /// the coordinator for relay-to-relay routing, so it is always tagged
+    /// [`SessionContext::internal`]. Inbound classification (public vs internal)
+    /// is handled separately in `relay.rs` via the connection tagger.
+    ///
+    /// This label is local to this relay and is **not** sent over the wire: the
+    /// relay on the accepting end sees only the raw connection and classifies it
+    /// independently with its own [`ConnectionTagger`]. To have the peer treat
+    /// this link as internal, dial it on an address/SNI/path its tagger
+    /// recognizes.
+    ///
+    /// [`ConnectionTagger`]: crate::ConnectionTagger
+    fn context_for_endpoint(url: Url, addr: Option<SocketAddr>) -> SessionContext {
+        let endpoint = match addr {
+            Some(addr) => RelayInfo::with_addr(url, addr),
+            None => RelayInfo::new(url),
+        };
+
+        SessionContext::internal(None, Some(endpoint))
     }
 
     /// Shutdown the remote connection.
@@ -349,7 +770,7 @@ impl Remote {
         &self,
         namespace: TrackNamespace,
         track_name: TrackName,
-    ) -> anyhow::Result<Option<TrackReader>> {
+    ) -> anyhow::Result<Option<(TrackReader, TrackInterestGuard)>> {
         let key = (namespace.clone(), track_name.clone());
 
         loop {
@@ -376,9 +797,11 @@ impl Remote {
                 continue;
             }
 
-            if let Some(reader) = cached.as_ref() {
-                if !reader.is_closed() {
-                    return Ok(Some(reader.clone()));
+            if let Some(entry) = cached.as_ref() {
+                if !entry.reader.is_closed() {
+                    // Register interest while still holding the slot lock, which
+                    // is the same lock idle eviction re-checks under.
+                    return Ok(Some((entry.reader.clone(), entry.interest.guard())));
                 }
 
                 tracing::debug!(remote_url = %self.url, namespace = %key.0, track = %key.1, "removing closed remote track from cache");
@@ -418,12 +841,22 @@ impl Remote {
                 anyhow::bail!("remote connection to {} is closed", self.url);
             }
 
-            *cached = Some(reader.clone());
+            let interest = TrackInterest::new();
+
+            // Take this caller's guard before the entry becomes visible, so the
+            // cleanup task cannot see a brand new entry as idle.
+            let guard = interest.guard();
+
+            *cached = Some(CachedTrack {
+                reader: reader.clone(),
+                interest: interest.clone(),
+            });
             drop(cached);
 
             let cleanup_key = key.clone();
             let cleanup_reader = reader.clone();
             let cleanup_slot = slot.clone();
+            let idle_timeout = self.cache_idle_timeout;
             tokio::spawn(async move {
                 tokio::select! {
                     result = subscribe.closed() => {
@@ -439,11 +872,23 @@ impl Remote {
                     _ = cancel.cancelled() => {
                         tracing::debug!(remote_url = %url, namespace = %cleanup_key.0, track = %cleanup_key.1, "remote track subscription cancelled");
                     }
+                    // Nobody downstream is watching this cross-relay track any
+                    // more, so stop pulling it from the peer relay. The slot is
+                    // already cleared by the time this resolves, so a later
+                    // subscriber re-subscribes rather than attaching to a reader
+                    // that is about to go silent.
+                    _ = evict_when_idle(&cleanup_slot, &interest, idle_timeout) => {
+                        tracing::info!(remote_url = %url, namespace = %cleanup_key.0, track = %cleanup_key.1, "releasing idle remote track subscription");
+                        metrics::counter!("moq_relay_cache_idle_evictions_total", "source" => "remote").increment(1);
+                    }
                 }
+
+                // Sends UNSUBSCRIBE to the peer relay if it is still open.
+                drop(subscribe);
 
                 if let Some(tracks) = tracks.upgrade() {
                     let mut cached = cleanup_slot.lock().await;
-                    if matches!(cached.as_ref(), Some(current) if Arc::ptr_eq(&current.info, &cleanup_reader.info))
+                    if matches!(cached.as_ref(), Some(current) if Arc::ptr_eq(&current.reader.info, &cleanup_reader.info))
                     {
                         cached.take();
                     }
@@ -453,8 +898,66 @@ impl Remote {
                 }
             });
 
-            return Ok(Some(reader));
+            return Ok(Some((reader, guard)));
         }
+    }
+
+    /// Forward a `SUBSCRIBE_NAMESPACE` to this peer (Subscriber role).
+    ///
+    /// Opens a namespace subscription for `prefix` and returns the
+    /// [`SubscribeNamespace`] handle; the caller drives it via
+    /// [`SubscribeNamespace::next`] / [`SubscribeNamespace::closed`], the same
+    /// way [`Self::subscribe`] returns a [`TrackReader`] for the caller to read.
+    ///
+    /// Unlike [`Self::subscribe`], namespace subscriptions are not cached or
+    /// deduplicated here: per-session prefix aggregation (to avoid draft-16
+    /// `PREFIX_OVERLAP` on reused sessions) is deferred to the multi-relay
+    /// routing work.
+    async fn subscribe_namespace(
+        &self,
+        prefix: TrackNamespacePrefix,
+        options: SubscribeOptions,
+    ) -> anyhow::Result<SubscribeNamespace> {
+        if !self.is_connected() {
+            anyhow::bail!("remote connection to {} is closed", self.url);
+        }
+
+        tracing::info!(remote_url = %self.url, prefix = %prefix, "forwarding SUBSCRIBE_NAMESPACE to remote relay");
+
+        let mut subscriber = self.subscriber.clone();
+        let subscribe_namespace = tokio::select! {
+            result = subscriber.subscribe_namespace(prefix, options, KeyValuePairs::default()) => result?,
+            _ = self.cancel.cancelled() => {
+                anyhow::bail!("subscribe_namespace cancelled, remote connection to {} is closed", self.url);
+            }
+        };
+
+        Ok(subscribe_namespace)
+    }
+
+    /// Forward a `PUBLISH_NAMESPACE` to this peer (Publisher role).
+    ///
+    /// Advertises `tracks.namespace` to the peer and serves its tracks from the
+    /// provided [`TracksReader`]. Like [`moq_transport::session::Publisher::publish_namespace`]
+    /// this blocks until the namespace is unannounced or the session errors, so
+    /// callers typically drive it from a dedicated task (mirroring the
+    /// `--announce` forward path in `consumer.rs`).
+    async fn publish_namespace(&self, tracks: TracksReader) -> anyhow::Result<()> {
+        if !self.is_connected() {
+            anyhow::bail!("remote connection to {} is closed", self.url);
+        }
+
+        tracing::info!(remote_url = %self.url, namespace = %tracks.namespace, "forwarding PUBLISH_NAMESPACE to remote relay");
+
+        let mut publisher = self.publisher.clone();
+        tokio::select! {
+            result = publisher.publish_namespace(tracks) => result?,
+            _ = self.cancel.cancelled() => {
+                anyhow::bail!("publish_namespace cancelled, remote connection to {} is closed", self.url);
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -462,6 +965,7 @@ impl std::fmt::Debug for Remote {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Remote")
             .field("url", &self.url.to_string())
+            .field("interface", &self.context.interface)
             .field("connected", &self.is_connected())
             .finish()
     }

--- a/moq-relay-ietf/src/session.rs
+++ b/moq-relay-ietf/src/session.rs
@@ -1,10 +1,335 @@
 // SPDX-FileCopyrightText: 2024-2026 Cloudflare Inc., Luke Curley, Mike English and contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::collections::BTreeMap;
+use std::net::{IpAddr, SocketAddr};
+
 use futures::{stream::FuturesUnordered, FutureExt, StreamExt};
 use moq_transport::session::{Publisher, SessionError, Subscriber};
 
-use crate::{Consumer, Producer};
+use crate::{Consumer, CoordinatorContext, Producer, RelayInfo};
+
+/// Well-known connection tag key identifying the session interface.
+pub const TAG_INTERFACE: &str = "interface";
+
+/// [`TAG_INTERFACE`] value for public, client-facing connections.
+pub const INTERFACE_PUBLIC: &str = "public";
+
+/// [`TAG_INTERFACE`] value for internal, relay-to-relay connections.
+pub const INTERFACE_INTERNAL: &str = "internal";
+
+/// Identifies whether a relay session came from a public client or another relay.
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Default)]
+pub enum SessionInterface {
+    /// A public, client-facing connection.
+    ///
+    /// This is the default: an unclassified connection is treated as a public
+    /// client (see [`ConnectionTags::interface`]).
+    #[default]
+    Public,
+    /// An internal, relay-to-relay connection.
+    Internal,
+}
+
+/// Key-value tags describing an accepted connection.
+///
+/// The relay only interprets the well-known [`TAG_INTERFACE`] key today, but
+/// the map is intentionally open so embedders can attach their own metadata
+/// from a [`ConnectionTagger`].
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ConnectionTags {
+    tags: BTreeMap<String, String>,
+}
+
+impl ConnectionTags {
+    /// Create an empty set of tags.
+    ///
+    /// An empty set resolves to [`SessionInterface::Public`] — see
+    /// [`interface`](Self::interface).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert a tag, consuming and returning `self` for builder-style chaining.
+    pub fn with(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.tags.insert(key.into(), value.into());
+        self
+    }
+
+    /// Set the well-known [`TAG_INTERFACE`] tag.
+    pub fn with_interface(self, interface: SessionInterface) -> Self {
+        let value = match interface {
+            SessionInterface::Public => INTERFACE_PUBLIC,
+            SessionInterface::Internal => INTERFACE_INTERNAL,
+        };
+        self.with(TAG_INTERFACE, value)
+    }
+
+    /// Look up a tag value by key.
+    pub fn get(&self, key: &str) -> Option<&str> {
+        self.tags.get(key).map(String::as_str)
+    }
+
+    /// Resolve the session interface from the well-known [`TAG_INTERFACE`] tag.
+    ///
+    /// Defaults to [`SessionInterface::Public`] when the tag is missing or
+    /// holds an unrecognized value: an untagged connection is treated as a
+    /// public client.
+    pub fn interface(&self) -> SessionInterface {
+        match self.get(TAG_INTERFACE) {
+            Some(value) if value == INTERFACE_INTERNAL => SessionInterface::Internal,
+            _ => SessionInterface::Public,
+        }
+    }
+}
+
+/// Metadata about an accepted connection, passed to a [`ConnectionTagger`].
+///
+/// All fields work uniformly across WebTransport and raw MoQT (`moqt://`)
+/// connections, so taggers can match on them without caring about the
+/// transport. (The WebTransport request URL is intentionally omitted: it is
+/// synthetic for raw MoQT, so [`server_name`](Self::server_name) is the
+/// portable way to match on host/authority.)
+#[derive(Debug, Clone, Default)]
+pub struct ConnectionMeta {
+    /// Remote socket address of the peer, when known.
+    pub remote_addr: Option<SocketAddr>,
+
+    /// Local IP the connection was accepted on: the destination IP the peer
+    /// targeted, when known.
+    ///
+    /// On a wildcard bind (`0.0.0.0` / `[::]`) this identifies which local
+    /// address/interface (e.g. an anycast VIP) actually received the
+    /// connection, letting a tagger classify by inbound interface. `None` when
+    /// the platform does not expose the destination address.
+    pub local_ip: Option<IpAddr>,
+
+    /// TLS SNI (Server Name Indication) the client requested, when present.
+    ///
+    /// Available for both WebTransport and raw MoQT connections, so this is the
+    /// portable signal for host/authority-based classification.
+    pub server_name: Option<String>,
+
+    /// Normalized connection path (WebTransport URL path or CLIENT_SETUP PATH
+    /// parameter), when present.
+    pub path: Option<String>,
+}
+
+impl ConnectionMeta {
+    /// Create connection metadata from a remote address, TLS SNI, and path.
+    ///
+    /// Use [`with_local_ip`](Self::with_local_ip) to attach the local IP the
+    /// connection was accepted on.
+    pub fn new(
+        remote_addr: Option<SocketAddr>,
+        server_name: Option<String>,
+        path: Option<String>,
+    ) -> Self {
+        Self {
+            remote_addr,
+            local_ip: None,
+            server_name,
+            path,
+        }
+    }
+
+    /// Attach the local IP the connection was accepted on (the destination IP
+    /// the peer targeted, from `ConnInfo::local_ip`). Returns `self` for
+    /// builder-style chaining. See [`local_ip`](Self::local_ip).
+    pub fn with_local_ip(mut self, local_ip: Option<IpAddr>) -> Self {
+        self.local_ip = local_ip;
+        self
+    }
+}
+
+/// Classifies accepted connections into [`ConnectionTags`].
+///
+/// The relay calls this once for every **inbound** connection it accepts, to
+/// decide whether the peer is a public client or an internal relay-to-relay
+/// peer, via the well-known [`TAG_INTERFACE`] tag. Embedders implement it to
+/// match on the remote socket address, TLS SNI, or connection path.
+///
+/// The library ships **no** concrete implementation: it owns only the trait and
+/// the [`TAG_INTERFACE`] contract, while the embedder owns the site-specific
+/// policy of what counts as "internal". A relay with no tagger
+/// (`RelayConfig.connection_tagger = None`) treats every inbound connection as
+/// public. Interface classification is deliberately separate from
+/// [`Coordinator::resolve_scope`], which resolves *identity and permissions*;
+/// the coordinator cannot know the transport interface a connection arrived on.
+///
+/// # Where classification happens (important)
+///
+/// The `public`/`internal` label is **local to the relay that accepts the
+/// connection and is never sent over the wire**. Each relay classifies its own
+/// inbound connections independently:
+///
+/// * Connections the relay dials itself (`--announce`, [`RemoteManager`]) are
+///   tagged [`SessionInterface::Internal`] at dial time and never reach a
+///   tagger.
+/// * When relay A dials relay B, the MoQT handshake carries **no** "I am a
+///   relay" signal. Relay B must recognize relay A purely from the raw
+///   connection attributes in [`ConnectionMeta`]. If relay B has no tagger, it
+///   treats relay A as a public client.
+///
+/// So to make a relay-to-relay link internal on the accepting end, the tagger
+/// must identify the dialing relay from what actually crosses the wire:
+///
+/// * [`ConnectionMeta::remote_addr`] — the dialer's source IP/port (e.g. match
+///   an internal subnet or allowlist).
+/// * [`ConnectionMeta::local_ip`] — the local IP/interface the connection was
+///   accepted on (e.g. match an internal-facing VIP on a multi-homed or
+///   anycast host).
+/// * [`ConnectionMeta::server_name`] — the TLS SNI the dialer presents, derived
+///   from the host of the URL it dialed, so relays that dial an internal
+///   hostname can be matched here.
+/// * [`ConnectionMeta::path`] — the connection path from the dialed URL.
+///
+/// For a mesh where both relays should see each other as internal, both relays
+/// need a tagger, and each must dial the other on an address/SNI/path the
+/// peer's tagger recognizes.
+///
+/// # Implementing a tagger
+///
+/// Return [`ConnectionTags`] carrying the [`TAG_INTERFACE`] tag (via
+/// [`ConnectionTags::with_interface`]); empty/untagged results resolve to
+/// [`SessionInterface::Public`]. Then wire the tagger into the relay through
+/// `RelayConfig.connection_tagger`.
+///
+/// ```
+/// use std::net::{IpAddr, SocketAddr};
+/// use std::sync::Arc;
+///
+/// use moq_relay_ietf::{ConnectionMeta, ConnectionTagger, ConnectionTags, SessionInterface};
+///
+/// /// Treats peers on the 10.0.0.0/8 mesh subnet, or presenting the mesh SNI,
+/// /// as internal relay-to-relay; everything else stays public.
+/// struct MeshTagger;
+///
+/// impl ConnectionTagger for MeshTagger {
+///     fn tag(&self, meta: &ConnectionMeta) -> ConnectionTags {
+///         let from_mesh_subnet = matches!(
+///             meta.remote_addr.map(|addr| addr.ip()),
+///             Some(IpAddr::V4(ip)) if ip.octets()[0] == 10
+///         );
+///         let from_mesh_sni = meta.server_name.as_deref() == Some("mesh.internal");
+///
+///         if from_mesh_subnet || from_mesh_sni {
+///             ConnectionTags::new().with_interface(SessionInterface::Internal)
+///         } else {
+///             // Empty tags resolve to SessionInterface::Public.
+///             ConnectionTags::new()
+///         }
+///     }
+/// }
+///
+/// // Hand it to the relay as `RelayConfig { connection_tagger: Some(tagger), .. }`.
+/// let tagger: Arc<dyn ConnectionTagger> = Arc::new(MeshTagger);
+///
+/// let mesh_peer: SocketAddr = "10.0.0.7:4443".parse().unwrap();
+/// assert_eq!(
+///     tagger
+///         .tag(&ConnectionMeta::new(Some(mesh_peer), None, None))
+///         .interface(),
+///     SessionInterface::Internal,
+/// );
+///
+/// let public_peer: SocketAddr = "203.0.113.7:4443".parse().unwrap();
+/// assert_eq!(
+///     tagger
+///         .tag(&ConnectionMeta::new(Some(public_peer), None, None))
+///         .interface(),
+///     SessionInterface::Public,
+/// );
+/// ```
+///
+/// [`Coordinator::resolve_scope`]: crate::Coordinator::resolve_scope
+/// [`RemoteManager`]: crate::RemoteManager
+pub trait ConnectionTagger: Send + Sync {
+    /// Classify a connection from its metadata.
+    fn tag(&self, meta: &ConnectionMeta) -> ConnectionTags;
+}
+
+/// Context carried by relay-side producer and consumer tasks for one MoQT session.
+#[derive(Debug, Clone)]
+pub struct SessionContext {
+    /// The resolved scope identity for this session, if any.
+    pub scope: Option<String>,
+
+    /// Whether this session is public client-facing or internal relay-to-relay.
+    pub interface: SessionInterface,
+
+    /// Relay endpoint for internal sessions, when known.
+    ///
+    /// Populated for outbound connections the relay dials itself, where the
+    /// destination URL is known. Inbound connections leave this `None` even
+    /// when classified internal, since only the remote socket address is known.
+    pub peer: Option<RelayInfo>,
+}
+
+impl SessionContext {
+    /// Build a public, client-facing context for the given scope.
+    pub fn public(scope: Option<String>) -> Self {
+        Self {
+            scope,
+            interface: SessionInterface::Public,
+            peer: None,
+        }
+    }
+
+    /// Build an internal, relay-to-relay context for the given scope and peer.
+    pub fn internal(scope: Option<String>, peer: Option<RelayInfo>) -> Self {
+        Self {
+            scope,
+            interface: SessionInterface::Internal,
+            peer,
+        }
+    }
+
+    /// Build an inbound context from a resolved scope, connection tags, and
+    /// the peer's socket address.
+    ///
+    /// The interface is taken from the tags (see [`ConnectionTags::interface`]).
+    /// For connections classified [`SessionInterface::Internal`], the peer
+    /// identity is derived from `remote_addr` (the relay trusts the inbound
+    /// socket address rather than asking the coordinator to resolve it; see
+    /// [`RelayInfo::from_socket_addr`]). Public connections — and internal
+    /// connections with no known address — leave `peer` as `None`.
+    pub fn from_tags(
+        scope: Option<String>,
+        tags: &ConnectionTags,
+        remote_addr: Option<SocketAddr>,
+    ) -> Self {
+        let interface = tags.interface();
+        let peer = match interface {
+            SessionInterface::Internal => remote_addr.map(RelayInfo::from_socket_addr),
+            SessionInterface::Public => None,
+        };
+        Self {
+            scope,
+            interface,
+            peer,
+        }
+    }
+
+    /// The resolved scope identity, if any.
+    pub fn scope(&self) -> Option<&str> {
+        self.scope.as_deref()
+    }
+
+    /// Build the [`CoordinatorContext`] for coordinator calls made on behalf
+    /// of this session.
+    ///
+    /// Maps the session interface through unchanged and forwards [`peer`] as
+    /// the operation's `source`.
+    ///
+    /// [`peer`]: Self::peer
+    pub fn coordinator_context(&self) -> CoordinatorContext {
+        CoordinatorContext {
+            interface: self.interface,
+            source: self.peer.clone(),
+        }
+    }
+}
 
 pub struct Session {
     pub session: moq_transport::session::Session,
@@ -54,36 +379,283 @@ impl Session {
         tasks.select_next_some().await
     }
 
-    /// Drain incoming PUBLISH_NAMESPACEs and reject each one.
+    /// Drain incoming PUBLISH_NAMESPACE and PUBLISH requests and reject each one.
     ///
     /// Dropping a `PublishedNamespace` without calling `ok()` triggers its
     /// `Drop` impl, which sends REQUEST_ERROR back to the peer.
-    async fn drain_and_reject_publishes(mut subscriber: Subscriber) -> Result<(), SessionError> {
-        while let Some(published_ns) = subscriber.published_namespace().await {
-            tracing::debug!(
-                namespace = %published_ns.namespace,
-                "rejecting PUBLISH_NAMESPACE: publish not permitted for this session"
-            );
-            drop(published_ns);
+    async fn drain_and_reject_publishes(subscriber: Subscriber) -> Result<(), SessionError> {
+        let mut namespace_subscriber = subscriber.clone();
+        let mut publish_subscriber = subscriber;
+
+        loop {
+            tokio::select! {
+                Some(published_ns) = namespace_subscriber.published_namespace() => {
+                    tracing::debug!(
+                        namespace = %published_ns.namespace,
+                        "rejecting PUBLISH_NAMESPACE: publish not permitted for this session"
+                    );
+                    drop(published_ns);
+                },
+                Some(publish) = publish_subscriber.publish_received() => {
+                    tracing::debug!(
+                        namespace = %publish.namespace(),
+                        track = %publish.name(),
+                        "rejecting PUBLISH: publish not permitted for this session"
+                    );
+                    drop(publish);
+                },
+                else => return Ok(()),
+            }
         }
-        Ok(())
     }
 
-    /// Drain incoming SUBSCRIBEs and reject each one.
+    /// Drain incoming SUBSCRIBE and SUBSCRIBE_NAMESPACE requests and reject each one.
     ///
     /// The transport `Publisher` queues incoming SUBSCRIBE messages as
     /// `Subscribed` events. Dropping a `Subscribed` without calling `ok()`
     /// triggers its `Drop` impl, which sends SUBSCRIBE_ERROR back to the
     /// peer.
     async fn drain_and_reject_subscribes(mut publisher: Publisher) -> Result<(), SessionError> {
-        while let Some(subscribed) = publisher.subscribed().await {
-            tracing::debug!(
-                namespace = %subscribed.track_namespace,
-                track = %subscribed.track_name,
-                "rejecting SUBSCRIBE: subscribe not permitted for this session"
-            );
-            drop(subscribed);
+        loop {
+            let mut namespace_publisher = publisher.clone();
+            tokio::select! {
+                Some(subscribed) = publisher.subscribed() => {
+                    tracing::debug!(
+                        namespace = %subscribed.track_namespace,
+                        track = %subscribed.track_name,
+                        "rejecting SUBSCRIBE: subscribe not permitted for this session"
+                    );
+                    drop(subscribed);
+                }
+                Some(subscribed_namespace) = namespace_publisher.subscribed_namespace() => {
+                    tracing::debug!(
+                        namespace_prefix = %subscribed_namespace.namespace_prefix,
+                        "rejecting SUBSCRIBE_NAMESPACE: subscribe not permitted for this session"
+                    );
+                    drop(subscribed_namespace);
+                }
+                else => return Ok(()),
+            }
         }
-        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use url::Url;
+
+    #[test]
+    fn connection_tags_default_interface_is_public() {
+        // An untagged connection is treated as a public client.
+        assert_eq!(ConnectionTags::new().interface(), SessionInterface::Public);
+        assert_eq!(
+            ConnectionTags::default().interface(),
+            SessionInterface::Public
+        );
+    }
+
+    #[test]
+    fn connection_tags_with_interface_roundtrips() {
+        assert_eq!(
+            ConnectionTags::new()
+                .with_interface(SessionInterface::Internal)
+                .interface(),
+            SessionInterface::Internal
+        );
+        assert_eq!(
+            ConnectionTags::new()
+                .with_interface(SessionInterface::Public)
+                .interface(),
+            SessionInterface::Public
+        );
+    }
+
+    #[test]
+    fn connection_tags_unknown_interface_value_falls_back_to_public() {
+        let tags = ConnectionTags::new().with(TAG_INTERFACE, "bogus");
+        assert_eq!(tags.interface(), SessionInterface::Public);
+    }
+
+    #[test]
+    fn connection_tags_store_and_retrieve_arbitrary_keys() {
+        let tags = ConnectionTags::new()
+            .with("tenant", "acme")
+            .with_interface(SessionInterface::Internal);
+        assert_eq!(tags.get("tenant"), Some("acme"));
+        assert_eq!(tags.get(TAG_INTERFACE), Some(INTERFACE_INTERNAL));
+        assert_eq!(tags.get("missing"), None);
+    }
+
+    #[test]
+    fn session_context_public_has_no_peer() {
+        let context = SessionContext::public(Some("scope-a".to_string()));
+        assert_eq!(context.scope(), Some("scope-a"));
+        assert_eq!(context.interface, SessionInterface::Public);
+        assert!(context.peer.is_none());
+    }
+
+    #[test]
+    fn session_context_internal_carries_peer() {
+        let url = Url::parse("https://relay.example.com/live").unwrap();
+        let context = SessionContext::internal(
+            Some("scope-b".to_string()),
+            Some(RelayInfo::new(url.clone())),
+        );
+        assert_eq!(context.scope(), Some("scope-b"));
+        assert_eq!(context.interface, SessionInterface::Internal);
+        assert_eq!(context.peer.unwrap().url, url);
+    }
+
+    #[test]
+    fn session_context_from_tags_populates_peer_for_internal() {
+        let addr: SocketAddr = "10.0.0.7:4443".parse().unwrap();
+
+        // Internal + known address → peer derived from the socket address.
+        let internal = SessionContext::from_tags(
+            Some("scope-c".to_string()),
+            &ConnectionTags::new().with_interface(SessionInterface::Internal),
+            Some(addr),
+        );
+        assert_eq!(internal.interface, SessionInterface::Internal);
+        assert_eq!(internal.scope(), Some("scope-c"));
+        let peer = internal.peer.expect("internal context should carry a peer");
+        assert_eq!(peer.addr, Some(addr));
+        assert_eq!(peer.url.as_str(), "https://10.0.0.7:4443/");
+
+        // Internal but no known address → no peer.
+        let internal_no_addr = SessionContext::from_tags(
+            None,
+            &ConnectionTags::new().with_interface(SessionInterface::Internal),
+            None,
+        );
+        assert_eq!(internal_no_addr.interface, SessionInterface::Internal);
+        assert!(internal_no_addr.peer.is_none());
+
+        // Public → never carries a peer, even with a known address.
+        let public = SessionContext::from_tags(None, &ConnectionTags::new(), Some(addr));
+        assert_eq!(public.interface, SessionInterface::Public);
+        assert!(public.scope().is_none());
+        assert!(public.peer.is_none());
+    }
+
+    #[test]
+    fn coordinator_context_forwards_interface_and_peer() {
+        let addr: SocketAddr = "10.0.0.7:4443".parse().unwrap();
+        let internal = SessionContext::from_tags(
+            None,
+            &ConnectionTags::new().with_interface(SessionInterface::Internal),
+            Some(addr),
+        );
+        let ctx = internal.coordinator_context();
+        assert_eq!(ctx.interface, SessionInterface::Internal);
+        assert_eq!(ctx.source.expect("source should be set").addr, Some(addr));
+
+        let public = SessionContext::public(None);
+        let ctx = public.coordinator_context();
+        assert_eq!(ctx.interface, SessionInterface::Public);
+        assert!(ctx.source.is_none());
+    }
+
+    #[test]
+    fn connection_meta_new_sets_fields() {
+        let addr: SocketAddr = "203.0.113.5:4433".parse().unwrap();
+        let meta = ConnectionMeta::new(
+            Some(addr),
+            Some("relay.example.com".to_string()),
+            Some("/tenant/stream".to_string()),
+        );
+        assert_eq!(meta.remote_addr, Some(addr));
+        assert_eq!(meta.server_name.as_deref(), Some("relay.example.com"));
+        assert_eq!(meta.path.as_deref(), Some("/tenant/stream"));
+        // local_ip is opt-in and defaults to None.
+        assert_eq!(meta.local_ip, None);
+
+        let local: IpAddr = "10.0.0.1".parse().unwrap();
+        assert_eq!(meta.with_local_ip(Some(local)).local_ip, Some(local));
+    }
+
+    /// Example tagger that marks connections internal when they arrive on a
+    /// known internal SNI, otherwise leaves them public. Mirrors how an
+    /// embedder wires relay-to-relay classification.
+    struct SniTagger {
+        internal_server_name: &'static str,
+    }
+
+    impl ConnectionTagger for SniTagger {
+        fn tag(&self, meta: &ConnectionMeta) -> ConnectionTags {
+            match meta.server_name.as_deref() {
+                Some(name) if name == self.internal_server_name => {
+                    ConnectionTags::new().with_interface(SessionInterface::Internal)
+                }
+                _ => ConnectionTags::new(),
+            }
+        }
+    }
+
+    #[test]
+    fn connection_tagger_classifies_by_server_name() {
+        let tagger = SniTagger {
+            internal_server_name: "mesh.internal",
+        };
+
+        let internal = tagger.tag(&ConnectionMeta::new(
+            None,
+            Some("mesh.internal".to_string()),
+            None,
+        ));
+        assert_eq!(internal.interface(), SessionInterface::Internal);
+
+        let public = tagger.tag(&ConnectionMeta::new(
+            None,
+            Some("public.example.com".to_string()),
+            None,
+        ));
+        assert_eq!(public.interface(), SessionInterface::Public);
+
+        // Missing SNI (e.g. no server name) defaults to public.
+        let no_sni = tagger.tag(&ConnectionMeta::new(None, None, None));
+        assert_eq!(no_sni.interface(), SessionInterface::Public);
+    }
+
+    /// Example tagger that marks connections internal when accepted on a known
+    /// internal-facing local IP (e.g. a private VIP), otherwise public.
+    /// Exercises the `local_ip` plumbing all the way to a tagger.
+    struct LocalIpTagger {
+        internal_local_ip: IpAddr,
+    }
+
+    impl ConnectionTagger for LocalIpTagger {
+        fn tag(&self, meta: &ConnectionMeta) -> ConnectionTags {
+            match meta.local_ip {
+                Some(ip) if ip == self.internal_local_ip => {
+                    ConnectionTags::new().with_interface(SessionInterface::Internal)
+                }
+                _ => ConnectionTags::new(),
+            }
+        }
+    }
+
+    #[test]
+    fn connection_tagger_classifies_by_local_ip() {
+        let internal_vip: IpAddr = "10.0.0.9".parse().unwrap();
+        let public_vip: IpAddr = "203.0.113.9".parse().unwrap();
+        let tagger = LocalIpTagger {
+            internal_local_ip: internal_vip,
+        };
+
+        // Accepted on the internal VIP -> internal.
+        let internal =
+            tagger.tag(&ConnectionMeta::new(None, None, None).with_local_ip(Some(internal_vip)));
+        assert_eq!(internal.interface(), SessionInterface::Internal);
+
+        // Accepted on a public VIP -> public.
+        let public =
+            tagger.tag(&ConnectionMeta::new(None, None, None).with_local_ip(Some(public_vip)));
+        assert_eq!(public.interface(), SessionInterface::Public);
+
+        // Unknown local IP defaults to public.
+        let unknown = tagger.tag(&ConnectionMeta::new(None, None, None));
+        assert_eq!(unknown.interface(), SessionInterface::Public);
     }
 }

--- a/moq-relay-ietf/src/upstream_namespaces.rs
+++ b/moq-relay-ietf/src/upstream_namespaces.rs
@@ -1,0 +1,1098 @@
+// SPDX-FileCopyrightText: 2026 Cloudflare Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::{
+    collections::{HashMap, HashSet, VecDeque},
+    net::SocketAddr,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, Mutex, Weak,
+    },
+    time::Duration,
+};
+
+use moq_transport::{
+    coding::{TrackNamespace, TrackNamespacePrefix},
+    message::SubscribeOptions,
+    session::{NamespaceEvent, SubscribeNamespace},
+};
+use tokio::{
+    sync::{mpsc, oneshot},
+    task::JoinHandle,
+};
+use url::Url;
+
+use crate::{
+    covering_prefix_set::{CoveringPrefixSet, RootDelta},
+    Coordinator, CoordinatorContext, Locals, NamespaceSubscription, RelayInfo, RemoteManager,
+    RemoteNamespaceRegistration, SessionContext, SessionInterface,
+};
+
+const TRANSITION_TIMEOUT: Duration = Duration::from_secs(60);
+const CANCELLED_STREAM_CODE: u32 = 0x1;
+const INITIAL_RETRY_BACKOFF: Duration = Duration::from_millis(100);
+const MAX_RETRY_BACKOFF: Duration = Duration::from_secs(30);
+
+#[derive(Clone, Eq, Hash, PartialEq)]
+struct GroupKey {
+    scope: Option<String>,
+    interface: SessionInterface,
+}
+
+#[derive(Clone, Eq, Hash, PartialEq)]
+struct PrefixKey {
+    group: GroupKey,
+    prefix: TrackNamespacePrefix,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct RelayKey {
+    url: Url,
+    addr: Option<SocketAddr>,
+}
+
+impl From<&RelayInfo> for RelayKey {
+    fn from(relay: &RelayInfo) -> Self {
+        Self {
+            url: relay.url.clone(),
+            addr: relay.addr,
+        }
+    }
+}
+
+struct InterestSlot {
+    generation: u64,
+    interest: Weak<PrefixInterest>,
+}
+
+struct LeaseRegistry {
+    slots: Mutex<HashMap<PrefixKey, InterestSlot>>,
+    next_generation: AtomicU64,
+    commands: mpsc::UnboundedSender<Command>,
+}
+
+struct PrefixInterest {
+    key: PrefixKey,
+    generation: u64,
+    registry: Weak<LeaseRegistry>,
+}
+
+impl Drop for PrefixInterest {
+    fn drop(&mut self) {
+        let Some(registry) = self.registry.upgrade() else {
+            return;
+        };
+        let Ok(mut slots) = registry.slots.lock() else {
+            // Poisoning means a panic happened while holding the lock, so this
+            // lease can no longer be retired: the upstream namespace pull it
+            // owns leaks for the lifetime of the process. Surface it as a
+            // counter rather than only a log line, since the visible symptom
+            // (upstream subscriptions that never go away) is otherwise hard to
+            // trace back to here.
+            metrics::counter!(
+                "moq_relay_lease_registry_lock_poisoned_total",
+                "operation" => "release"
+            )
+            .increment(1);
+            tracing::error!("upstream namespace lease registry lock poisoned");
+            return;
+        };
+
+        let current = slots
+            .get(&self.key)
+            .is_some_and(|slot| slot.generation == self.generation);
+        if !current {
+            return;
+        }
+
+        slots.remove(&self.key);
+        let _ = registry.commands.send(Command::Unsubscribe {
+            key: self.key.clone(),
+            generation: self.generation,
+        });
+    }
+}
+
+/// Keeps one exact downstream namespace-prefix interest alive.
+pub(crate) struct PrefixLease {
+    _interest: Arc<PrefixInterest>,
+}
+
+/// Relay-wide handle for shared upstream namespace discovery.
+#[derive(Clone)]
+pub(crate) struct UpstreamNamespaces {
+    registry: Arc<LeaseRegistry>,
+}
+
+impl UpstreamNamespaces {
+    pub(crate) fn new(
+        locals: Locals,
+        remotes: RemoteManager,
+        coordinator: Arc<dyn Coordinator>,
+    ) -> (Self, UpstreamNamespacesRunner) {
+        let (commands, receiver) = mpsc::unbounded_channel();
+        let manager = Self::from_sender(commands.clone());
+        let runner = UpstreamNamespacesRunner {
+            receiver,
+            commands: commands.downgrade(),
+            locals,
+            remotes,
+            coordinator,
+            covering: HashMap::new(),
+            active: HashMap::new(),
+            roots: HashMap::new(),
+            root_ids: HashMap::new(),
+            next_root_id: 0,
+            next_pull_id: 0,
+            transition: None,
+            deferred: VecDeque::new(),
+        };
+        (manager, runner)
+    }
+
+    fn from_sender(commands: mpsc::UnboundedSender<Command>) -> Self {
+        Self {
+            registry: Arc::new(LeaseRegistry {
+                slots: Mutex::new(HashMap::new()),
+                next_generation: AtomicU64::new(0),
+                commands,
+            }),
+        }
+    }
+
+    pub(crate) fn subscribe(
+        &self,
+        context: &SessionContext,
+        prefix: TrackNamespacePrefix,
+    ) -> anyhow::Result<PrefixLease> {
+        let key = PrefixKey {
+            group: GroupKey {
+                scope: context.scope.clone(),
+                interface: context.interface,
+            },
+            prefix,
+        };
+        let mut slots = self.registry.slots.lock().map_err(|_| {
+            metrics::counter!(
+                "moq_relay_lease_registry_lock_poisoned_total",
+                "operation" => "acquire"
+            )
+            .increment(1);
+            anyhow::anyhow!("upstream namespace lease registry lock poisoned")
+        })?;
+
+        if let Some(interest) = slots.get(&key).and_then(|slot| slot.interest.upgrade()) {
+            return Ok(PrefixLease {
+                _interest: interest,
+            });
+        }
+
+        let generation = self
+            .registry
+            .next_generation
+            .fetch_add(1, Ordering::Relaxed);
+        let interest = Arc::new(PrefixInterest {
+            key: key.clone(),
+            generation,
+            registry: Arc::downgrade(&self.registry),
+        });
+        slots.insert(
+            key.clone(),
+            InterestSlot {
+                generation,
+                interest: Arc::downgrade(&interest),
+            },
+        );
+
+        let send_result = self.registry.commands.send(Command::Subscribe {
+            key: key.clone(),
+            generation,
+            context: context.coordinator_context(),
+        });
+        if send_result.is_err() {
+            slots.remove(&key);
+            drop(slots);
+            return Err(anyhow::anyhow!("upstream namespace manager is closed"));
+        }
+
+        Ok(PrefixLease {
+            _interest: interest,
+        })
+    }
+}
+
+enum Command {
+    Subscribe {
+        key: PrefixKey,
+        generation: u64,
+        context: CoordinatorContext,
+    },
+    Unsubscribe {
+        key: PrefixKey,
+        generation: u64,
+    },
+    PullEvent {
+        root_id: u64,
+        pull_id: u64,
+        event: NamespaceEvent,
+    },
+    PullEnded {
+        root_id: u64,
+        pull_id: u64,
+        outcome: PullOutcome,
+    },
+}
+
+struct ActiveInterest {
+    generation: u64,
+    context: CoordinatorContext,
+}
+
+struct PullState {
+    relay: RelayKey,
+    cancel: Option<oneshot::Sender<()>>,
+    task: JoinHandle<()>,
+}
+
+impl Drop for PullState {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+struct RootState {
+    id: u64,
+    key: PrefixKey,
+    _subscription: Option<NamespaceSubscription>,
+    relays: Vec<RelayInfo>,
+    pulls: HashMap<u64, PullState>,
+    sources: HashMap<u64, HashMap<TrackNamespace, RemoteNamespaceRegistration>>,
+    retained: HashMap<TrackNamespace, Vec<RemoteNamespaceRegistration>>,
+    retiring: bool,
+}
+
+struct Transition {
+    removed: HashSet<u64>,
+    old_pulls: HashMap<u64, RelayKey>,
+    relays: HashMap<RelayKey, RelayTransition>,
+}
+
+struct RelayTransition {
+    waiting: HashSet<u64>,
+    targets: Vec<(u64, RelayInfo)>,
+    started: bool,
+}
+
+#[derive(Clone, Copy)]
+enum PullOutcome {
+    Intentional { timed_out: bool },
+    Rejected,
+    OpenFailed,
+    Ended,
+}
+
+pub(crate) struct UpstreamNamespacesRunner {
+    receiver: mpsc::UnboundedReceiver<Command>,
+    commands: mpsc::WeakUnboundedSender<Command>,
+    locals: Locals,
+    remotes: RemoteManager,
+    coordinator: Arc<dyn Coordinator>,
+    covering: HashMap<GroupKey, CoveringPrefixSet>,
+    active: HashMap<PrefixKey, ActiveInterest>,
+    roots: HashMap<u64, RootState>,
+    root_ids: HashMap<PrefixKey, u64>,
+    next_root_id: u64,
+    next_pull_id: u64,
+    transition: Option<Transition>,
+    deferred: VecDeque<Command>,
+}
+
+impl UpstreamNamespacesRunner {
+    pub(crate) async fn run(mut self) {
+        loop {
+            let command = if self.transition.is_none() {
+                self.deferred.pop_front()
+            } else {
+                None
+            };
+            let command = match command {
+                Some(command) => Some(command),
+                None => self.receiver.recv().await,
+            };
+            let Some(command) = command else {
+                return;
+            };
+
+            if self.transition.is_some()
+                && matches!(
+                    command,
+                    Command::Subscribe { .. } | Command::Unsubscribe { .. }
+                )
+            {
+                self.deferred.push_back(command);
+                continue;
+            }
+
+            match command {
+                Command::Subscribe {
+                    key,
+                    generation,
+                    context,
+                } => self.add_interest(key, generation, context).await,
+                Command::Unsubscribe { key, generation } => {
+                    self.remove_interest(key, generation).await
+                }
+                Command::PullEvent {
+                    root_id,
+                    pull_id,
+                    event,
+                } => self.handle_pull_event(root_id, pull_id, event),
+                Command::PullEnded {
+                    root_id,
+                    pull_id,
+                    outcome,
+                } => self.handle_pull_ended(root_id, pull_id, outcome),
+            }
+        }
+    }
+
+    async fn add_interest(&mut self, key: PrefixKey, generation: u64, context: CoordinatorContext) {
+        if self
+            .active
+            .get(&key)
+            .is_some_and(|active| active.generation >= generation)
+        {
+            return;
+        }
+        let first = self
+            .active
+            .insert(
+                key.clone(),
+                ActiveInterest {
+                    generation,
+                    context,
+                },
+            )
+            .is_none();
+        if !first {
+            return;
+        }
+
+        let delta = self
+            .covering
+            .entry(key.group.clone())
+            .or_default()
+            .add(key.prefix.clone());
+        self.apply_delta(key.group, delta).await;
+    }
+
+    async fn remove_interest(&mut self, key: PrefixKey, generation: u64) {
+        if self
+            .active
+            .get(&key)
+            .is_none_or(|active| active.generation != generation)
+        {
+            return;
+        }
+        self.active.remove(&key);
+
+        let Some(covering) = self.covering.get_mut(&key.group) else {
+            return;
+        };
+        let delta = covering.remove(&key.prefix);
+        self.apply_delta(key.group, delta).await;
+    }
+
+    async fn apply_delta(&mut self, group: GroupKey, delta: RootDelta) {
+        if delta.added.is_empty() && delta.removed.is_empty() {
+            return;
+        }
+
+        let removed = delta
+            .removed
+            .iter()
+            .filter_map(|prefix| {
+                self.root_ids
+                    .get(&PrefixKey {
+                        group: group.clone(),
+                        prefix: prefix.clone(),
+                    })
+                    .copied()
+            })
+            .collect::<HashSet<_>>();
+
+        let mut added = Vec::new();
+        for prefix in delta.added {
+            let key = PrefixKey {
+                group: group.clone(),
+                prefix,
+            };
+            added.push(self.prepare_root(key).await);
+        }
+
+        if removed.is_empty() {
+            for root in added {
+                self.start_root(root);
+            }
+            return;
+        }
+
+        for root_id in &removed {
+            let Some(root) = self.roots.get_mut(root_id) else {
+                continue;
+            };
+            root.retiring = true;
+
+            let sources = std::mem::take(&mut root.sources);
+            for registrations in sources.into_values() {
+                for (namespace, registration) in registrations {
+                    transfer_registration(namespace, registration, root, &mut added);
+                }
+            }
+            let retained = std::mem::take(&mut root.retained);
+            for (namespace, registrations) in retained {
+                for registration in registrations {
+                    transfer_registration(namespace.clone(), registration, root, &mut added);
+                }
+            }
+        }
+
+        let added_ids = added.iter().map(|root| root.id).collect::<HashSet<_>>();
+        for root in added {
+            let root_id = root.id;
+            self.root_ids.insert(root.key.clone(), root_id);
+            self.roots.insert(root_id, root);
+        }
+
+        let old = removed.iter().flat_map(|root_id| {
+            self.roots
+                .get(root_id)
+                .into_iter()
+                .flat_map(|root| root.pulls.iter())
+                .map(|(pull_id, pull)| (*pull_id, pull.relay.clone()))
+        });
+        let targets = added_ids.iter().flat_map(|root_id| {
+            self.roots
+                .get(root_id)
+                .into_iter()
+                .flat_map(|root| root.relays.iter())
+                .map(|relay| (*root_id, relay.clone()))
+        });
+        let (old_pulls, relays) = plan_relay_transitions(old, targets);
+
+        self.transition = Some(Transition {
+            removed: removed.clone(),
+            old_pulls,
+            relays,
+        });
+
+        let mut completed_pulls = Vec::new();
+        for root_id in removed {
+            let Some(root) = self.roots.get_mut(&root_id) else {
+                continue;
+            };
+            let mut completed = Vec::new();
+            for (pull_id, pull) in &mut root.pulls {
+                let sent = pull
+                    .cancel
+                    .take()
+                    .is_some_and(|cancel| cancel.send(()).is_ok());
+                if !sent {
+                    completed.push(*pull_id);
+                }
+            }
+            for pull_id in completed {
+                root.pulls.remove(&pull_id);
+                completed_pulls.push(pull_id);
+            }
+        }
+        for pull_id in completed_pulls {
+            self.mark_old_pull_complete(pull_id);
+        }
+
+        self.start_ready_relay_transitions();
+        self.finish_transition_if_ready();
+    }
+
+    async fn prepare_root(&mut self, key: PrefixKey) -> RootState {
+        let id = self.next_root_id;
+        self.next_root_id = self.next_root_id.wrapping_add(1);
+        let context = self
+            .active
+            .get(&key)
+            .map(|active| active.context.clone())
+            .unwrap_or_default();
+
+        let subscription = match self
+            .coordinator
+            .subscribe_namespace(key.group.scope.as_deref(), &key.prefix, &context)
+            .await
+        {
+            Ok(subscription) => Some(subscription),
+            Err(error) => {
+                tracing::error!(
+                    scope = key.group.scope.as_deref().unwrap_or("<unscoped>"),
+                    prefix = %key.prefix,
+                    error = %error,
+                    "failed to register shared upstream namespace interest"
+                );
+                None
+            }
+        };
+        let relays = subscription
+            .as_ref()
+            .map(|subscription| subscription.upstream_relays.clone())
+            .unwrap_or_default();
+
+        RootState {
+            id,
+            key,
+            _subscription: subscription,
+            relays,
+            pulls: HashMap::new(),
+            sources: HashMap::new(),
+            retained: HashMap::new(),
+            retiring: false,
+        }
+    }
+
+    fn start_root(&mut self, root: RootState) {
+        let root_id = root.id;
+        let key = root.key.clone();
+        let relays = root.relays.clone();
+        self.root_ids.insert(key, root_id);
+        self.roots.insert(root_id, root);
+
+        for relay in relays {
+            self.start_pull(root_id, relay);
+        }
+    }
+
+    fn start_pull(&mut self, root_id: u64, relay: RelayInfo) {
+        let Some(root) = self.roots.get(&root_id) else {
+            return;
+        };
+        let prefix = root.key.prefix.clone();
+        let pull_id = self.next_pull_id;
+        self.next_pull_id = self.next_pull_id.wrapping_add(1);
+        let (cancel, recv_cancel) = oneshot::channel();
+        let relay_key = RelayKey::from(&relay);
+        let task = tokio::spawn(run_pull(
+            self.remotes.clone(),
+            self.commands.clone(),
+            root_id,
+            pull_id,
+            relay,
+            prefix,
+            recv_cancel,
+        ));
+        if let Some(root) = self.roots.get_mut(&root_id) {
+            root.pulls.insert(
+                pull_id,
+                PullState {
+                    relay: relay_key,
+                    cancel: Some(cancel),
+                    task,
+                },
+            );
+        }
+    }
+
+    fn handle_pull_event(&mut self, root_id: u64, pull_id: u64, event: NamespaceEvent) {
+        let Some(root) = self.roots.get_mut(&root_id) else {
+            return;
+        };
+        if root.retiring || !root.pulls.contains_key(&pull_id) {
+            return;
+        }
+
+        match event {
+            NamespaceEvent::Added(namespace) => {
+                if !root.key.prefix.is_prefix_of(&namespace) {
+                    return;
+                }
+                let sources = root.sources.entry(pull_id).or_default();
+                if sources.contains_key(&namespace) {
+                    return;
+                }
+                match self
+                    .locals
+                    .register_remote_namespace(root.key.group.scope.as_deref(), namespace.clone())
+                {
+                    Ok(registration) => {
+                        sources.insert(namespace.clone(), registration);
+                        root.retained.remove(&namespace);
+                    }
+                    Err(error) => {
+                        tracing::error!(
+                            namespace = %namespace,
+                            error = %error,
+                            "failed to register upstream namespace source"
+                        );
+                    }
+                }
+            }
+            NamespaceEvent::Removed(namespace) => {
+                if let Some(sources) = root.sources.get_mut(&pull_id) {
+                    sources.remove(&namespace);
+                }
+            }
+        }
+    }
+
+    fn handle_pull_ended(&mut self, root_id: u64, pull_id: u64, outcome: PullOutcome) {
+        let Some(root) = self.roots.get_mut(&root_id) else {
+            return;
+        };
+        root.pulls.remove(&pull_id);
+        root.sources.remove(&pull_id);
+
+        match outcome {
+            PullOutcome::Intentional { timed_out: true } => {
+                tracing::error!(root_id, pull_id, "upstream namespace transition timed out");
+            }
+            PullOutcome::Rejected => {
+                tracing::warn!(root_id, pull_id, "upstream namespace request was rejected");
+            }
+            PullOutcome::OpenFailed => {
+                tracing::warn!(
+                    root_id,
+                    pull_id,
+                    "upstream namespace request failed to open"
+                );
+            }
+            PullOutcome::Intentional { timed_out: false } | PullOutcome::Ended => {}
+        }
+
+        self.mark_old_pull_complete(pull_id);
+        self.start_ready_relay_transitions();
+        self.finish_transition_if_ready();
+    }
+
+    fn mark_old_pull_complete(&mut self, pull_id: u64) {
+        let Some(transition) = self.transition.as_mut() else {
+            return;
+        };
+        complete_old_pull(transition, pull_id);
+    }
+
+    fn start_ready_relay_transitions(&mut self) {
+        let ready = self
+            .transition
+            .as_mut()
+            .map(take_ready_targets)
+            .unwrap_or_default();
+
+        for (root_id, relay) in ready {
+            self.start_pull(root_id, relay);
+        }
+    }
+
+    fn finish_transition_if_ready(&mut self) {
+        let ready = self
+            .transition
+            .as_ref()
+            .is_some_and(|transition| transition.old_pulls.is_empty());
+        if !ready {
+            return;
+        }
+
+        let Some(transition) = self.transition.take() else {
+            return;
+        };
+        for root_id in transition.removed {
+            if let Some(root) = self.roots.remove(&root_id) {
+                self.root_ids.remove(&root.key);
+            }
+        }
+    }
+}
+
+fn complete_old_pull(transition: &mut Transition, pull_id: u64) {
+    let Some(relay) = transition.old_pulls.remove(&pull_id) else {
+        return;
+    };
+    if let Some(relay_transition) = transition.relays.get_mut(&relay) {
+        relay_transition.waiting.remove(&pull_id);
+    }
+}
+
+fn plan_relay_transitions(
+    old: impl IntoIterator<Item = (u64, RelayKey)>,
+    targets: impl IntoIterator<Item = (u64, RelayInfo)>,
+) -> (HashMap<u64, RelayKey>, HashMap<RelayKey, RelayTransition>) {
+    let mut old_pulls = HashMap::new();
+    let mut relays = HashMap::<RelayKey, RelayTransition>::new();
+    for (pull_id, relay) in old {
+        old_pulls.insert(pull_id, relay.clone());
+        relays
+            .entry(relay)
+            .or_insert_with(|| RelayTransition {
+                waiting: HashSet::new(),
+                targets: Vec::new(),
+                started: false,
+            })
+            .waiting
+            .insert(pull_id);
+    }
+    for (root_id, relay) in targets {
+        relays
+            .entry(RelayKey::from(&relay))
+            .or_insert_with(|| RelayTransition {
+                waiting: HashSet::new(),
+                targets: Vec::new(),
+                started: false,
+            })
+            .targets
+            .push((root_id, relay));
+    }
+    (old_pulls, relays)
+}
+
+fn take_ready_targets(transition: &mut Transition) -> Vec<(u64, RelayInfo)> {
+    transition
+        .relays
+        .values_mut()
+        .filter(|relay| !relay.started && relay.waiting.is_empty())
+        .flat_map(|relay| {
+            relay.started = true;
+            std::mem::take(&mut relay.targets)
+        })
+        .collect()
+}
+
+fn transfer_registration(
+    namespace: TrackNamespace,
+    registration: RemoteNamespaceRegistration,
+    old_root: &mut RootState,
+    added: &mut [RootState],
+) {
+    if let Some(root) = added
+        .iter_mut()
+        .find(|root| root.key.prefix.is_prefix_of(&namespace))
+    {
+        root.retained
+            .entry(namespace)
+            .or_default()
+            .push(registration);
+    } else {
+        old_root
+            .retained
+            .entry(namespace)
+            .or_default()
+            .push(registration);
+    }
+}
+
+async fn run_pull(
+    remotes: RemoteManager,
+    commands: mpsc::WeakUnboundedSender<Command>,
+    root_id: u64,
+    pull_id: u64,
+    relay: RelayInfo,
+    prefix: TrackNamespacePrefix,
+    mut cancel: oneshot::Receiver<()>,
+) {
+    let mut backoff = INITIAL_RETRY_BACKOFF;
+    let outcome = loop {
+        let outcome = run_pull_inner(
+            &remotes,
+            &commands,
+            root_id,
+            pull_id,
+            &relay,
+            prefix.clone(),
+            &mut cancel,
+        )
+        .await;
+
+        // Only requests that fail before a subscription is established are
+        // retried, so no upstream namespace sources are ever left registered
+        // across attempts. Cancellation and clean/streamed endings fall through.
+        //
+        // TODO(subscribe-namespace): this is an optimistic blanket retry. It
+        // should branch on the rejection/error kind and, for a cleanly rejected
+        // coalesced (broad) request, restore the narrower pulls that were
+        // coalesced away instead of retrying the broad request indefinitely.
+        if !is_retryable(outcome) {
+            break outcome;
+        }
+
+        tokio::select! {
+            _ = &mut cancel => break PullOutcome::Intentional { timed_out: false },
+            _ = tokio::time::sleep(backoff) => {}
+        }
+        backoff = next_backoff(backoff);
+    };
+
+    send_command(
+        &commands,
+        Command::PullEnded {
+            root_id,
+            pull_id,
+            outcome,
+        },
+    );
+}
+
+fn is_retryable(outcome: PullOutcome) -> bool {
+    matches!(outcome, PullOutcome::Rejected | PullOutcome::OpenFailed)
+}
+
+fn next_backoff(current: Duration) -> Duration {
+    current.saturating_mul(2).min(MAX_RETRY_BACKOFF)
+}
+
+async fn run_pull_inner(
+    remotes: &RemoteManager,
+    commands: &mpsc::WeakUnboundedSender<Command>,
+    root_id: u64,
+    pull_id: u64,
+    relay: &RelayInfo,
+    prefix: TrackNamespacePrefix,
+    cancel: &mut oneshot::Receiver<()>,
+) -> PullOutcome {
+    let handle = tokio::select! {
+        _ = &mut *cancel => return PullOutcome::Intentional { timed_out: false },
+        result = remotes.subscribe_namespace(relay, prefix, SubscribeOptions::Namespace) => {
+            match result {
+                Ok(handle) => handle,
+                Err(error) => {
+                    tracing::warn!(upstream = %relay.url, error = %error, "failed to open shared upstream SUBSCRIBE_NAMESPACE");
+                    return PullOutcome::OpenFailed;
+                }
+            }
+        }
+    };
+    let mut handle = handle;
+
+    let accepted = tokio::select! {
+        _ = &mut *cancel => return cancel_pull(&mut handle, relay).await,
+        result = handle.ok() => result,
+    };
+    if let Err(error) = accepted {
+        tracing::debug!(upstream = %relay.url, error = %error, "shared upstream SUBSCRIBE_NAMESPACE rejected");
+        return PullOutcome::Rejected;
+    }
+
+    loop {
+        tokio::select! {
+            _ = &mut *cancel => return cancel_pull(&mut handle, relay).await,
+            event = handle.next() => {
+                match event {
+                    Ok(Some(event)) => send_command(commands, Command::PullEvent { root_id, pull_id, event }),
+                    Ok(None) => return PullOutcome::Ended,
+                    Err(error) => {
+                        tracing::debug!(upstream = %relay.url, error = %error, "shared upstream SUBSCRIBE_NAMESPACE ended");
+                        return PullOutcome::Ended;
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn cancel_pull(handle: &mut SubscribeNamespace, relay: &RelayInfo) -> PullOutcome {
+    if let Err(error) = handle.finish_request() {
+        tracing::debug!(upstream = %relay.url, error = %error, "failed to finish upstream namespace request stream");
+        return PullOutcome::Intentional { timed_out: false };
+    }
+
+    let drain = async {
+        loop {
+            match handle.next().await {
+                Ok(Some(_)) => {}
+                Ok(None) | Err(_) => return,
+            }
+        }
+    };
+    if tokio::time::timeout(TRANSITION_TIMEOUT, drain)
+        .await
+        .is_ok()
+    {
+        return PullOutcome::Intentional { timed_out: false };
+    }
+
+    metrics::counter!("moq_relay_namespace_transition_timeouts_total").increment(1);
+    tracing::error!(
+        upstream = %relay.url,
+        timeout_seconds = TRANSITION_TIMEOUT.as_secs(),
+        "timed out draining upstream namespace transition; resetting request stream"
+    );
+    handle.reset_request(CANCELLED_STREAM_CODE);
+    PullOutcome::Intentional { timed_out: true }
+}
+
+fn send_command(commands: &mpsc::WeakUnboundedSender<Command>, command: Command) {
+    if let Some(commands) = commands.upgrade() {
+        let _ = commands.send(command);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn relay(name: &str) -> RelayInfo {
+        RelayInfo::new(Url::parse(&format!("https://{name}.example.com/live")).expect("relay URL"))
+    }
+
+    #[test]
+    fn duplicate_leases_share_automatic_ownership() {
+        let (commands, mut receiver) = mpsc::unbounded_channel();
+        let manager = UpstreamNamespaces::from_sender(commands);
+        let context = SessionContext::public(None);
+        let prefix = TrackNamespacePrefix::from_utf8_path("foo/bar");
+
+        let first = manager
+            .subscribe(&context, prefix.clone())
+            .expect("first lease");
+        let first_generation = match receiver.try_recv().expect("first subscribe") {
+            Command::Subscribe {
+                key, generation, ..
+            } => {
+                assert_eq!(key.prefix, prefix);
+                generation
+            }
+            _ => panic!("expected subscribe command"),
+        };
+
+        let second = manager
+            .subscribe(&context, prefix.clone())
+            .expect("second lease");
+        assert!(matches!(
+            receiver.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty)
+        ));
+
+        drop(first);
+        assert!(matches!(
+            receiver.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty)
+        ));
+
+        drop(second);
+        match receiver.try_recv().expect("last-owner unsubscribe") {
+            Command::Unsubscribe {
+                key, generation, ..
+            } => {
+                assert_eq!(key.prefix, prefix);
+                assert_eq!(generation, first_generation);
+            }
+            _ => panic!("expected unsubscribe command"),
+        }
+    }
+
+    #[test]
+    fn recreated_interest_uses_a_new_generation() {
+        let (commands, mut receiver) = mpsc::unbounded_channel();
+        let manager = UpstreamNamespaces::from_sender(commands);
+        let context = SessionContext::public(None);
+        let prefix = TrackNamespacePrefix::from_utf8_path("foo");
+
+        let first = manager
+            .subscribe(&context, prefix.clone())
+            .expect("first lease");
+        let first_generation = match receiver.try_recv().expect("first subscribe") {
+            Command::Subscribe { generation, .. } => generation,
+            _ => panic!("expected subscribe command"),
+        };
+        drop(first);
+        let _ = receiver.try_recv().expect("first unsubscribe");
+
+        let _second = manager.subscribe(&context, prefix).expect("second lease");
+        let second_generation = match receiver.try_recv().expect("second subscribe") {
+            Command::Subscribe { generation, .. } => generation,
+            _ => panic!("expected subscribe command"),
+        };
+
+        assert_ne!(first_generation, second_generation);
+    }
+
+    #[test]
+    fn relay_upgrades_progress_independently() {
+        let relay_a = relay("a");
+        let relay_b = relay("b");
+        let relay_c = relay("c");
+        let (old_pulls, relays) = plan_relay_transitions(
+            [
+                (10, RelayKey::from(&relay_a)),
+                (20, RelayKey::from(&relay_b)),
+            ],
+            [
+                (30, relay_a.clone()),
+                (30, relay_b.clone()),
+                (30, relay_c.clone()),
+            ],
+        );
+        let mut transition = Transition {
+            removed: HashSet::new(),
+            old_pulls,
+            relays,
+        };
+
+        let ready = take_ready_targets(&mut transition);
+        assert_eq!(ready.len(), 1);
+        assert_eq!(RelayKey::from(&ready[0].1), RelayKey::from(&relay_c));
+
+        complete_old_pull(&mut transition, 10);
+        let ready = take_ready_targets(&mut transition);
+        assert_eq!(ready.len(), 1);
+        assert_eq!(RelayKey::from(&ready[0].1), RelayKey::from(&relay_a));
+
+        assert!(take_ready_targets(&mut transition).is_empty());
+        complete_old_pull(&mut transition, 20);
+        let ready = take_ready_targets(&mut transition);
+        assert_eq!(ready.len(), 1);
+        assert_eq!(RelayKey::from(&ready[0].1), RelayKey::from(&relay_b));
+    }
+
+    #[test]
+    fn relay_downgrade_starts_all_non_overlapping_roots_together() {
+        let relay = relay("origin");
+        let (old_pulls, relays) = plan_relay_transitions(
+            [(10, RelayKey::from(&relay))],
+            [(20, relay.clone()), (30, relay)],
+        );
+        let mut transition = Transition {
+            removed: HashSet::new(),
+            old_pulls,
+            relays,
+        };
+
+        assert!(take_ready_targets(&mut transition).is_empty());
+        complete_old_pull(&mut transition, 10);
+        let mut roots = take_ready_targets(&mut transition)
+            .into_iter()
+            .map(|(root_id, _)| root_id)
+            .collect::<Vec<_>>();
+        roots.sort_unstable();
+        assert_eq!(roots, vec![20, 30]);
+    }
+
+    #[test]
+    fn only_pre_subscription_failures_are_retried() {
+        assert!(is_retryable(PullOutcome::Rejected));
+        assert!(is_retryable(PullOutcome::OpenFailed));
+        assert!(!is_retryable(PullOutcome::Ended));
+        assert!(!is_retryable(PullOutcome::Intentional { timed_out: false }));
+        assert!(!is_retryable(PullOutcome::Intentional { timed_out: true }));
+    }
+
+    #[test]
+    fn backoff_doubles_and_saturates_at_max() {
+        let mut backoff = INITIAL_RETRY_BACKOFF;
+        let mut seen = Vec::new();
+        for _ in 0..20 {
+            seen.push(backoff);
+            backoff = next_backoff(backoff);
+        }
+
+        for pair in seen.windows(2) {
+            assert!(pair[1] >= pair[0], "backoff must be monotonic");
+        }
+        assert!(seen.iter().all(|delay| *delay <= MAX_RETRY_BACKOFF));
+        assert_eq!(backoff, MAX_RETRY_BACKOFF);
+        assert_eq!(next_backoff(MAX_RETRY_BACKOFF), MAX_RETRY_BACKOFF);
+    }
+}

--- a/moq-sub/CHANGELOG.md
+++ b/moq-sub/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.14](https://github.com/cloudflare/moq-rs/compare/moq-sub-v0.4.13...moq-sub-v0.4.14) - 2026-07-31
+
+### Fixed
+
+- send log output to stderr instead of stdout
+
+## [0.4.13](https://github.com/cloudflare/moq-rs/compare/moq-sub-v0.4.12...moq-sub-v0.4.13) - 2026-07-20
+
+### Other
+
+- updated the following local packages: moq-native-ietf
+
 ## [0.4.12](https://github.com/cloudflare/moq-rs/compare/moq-sub-v0.4.11...moq-sub-v0.4.12) - 2026-07-19
 
 ### Other

--- a/moq-sub/Cargo.toml
+++ b/moq-sub/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["moq-rs contributors"]
 repository = "https://github.com/cloudflare/moq-rs"
 license = "MIT OR Apache-2.0"
 
-version = "0.4.12"
+version = "0.4.14"
 edition = "2021"
 
 keywords = ["quic", "http3", "webtransport", "media", "live"]
@@ -19,7 +19,7 @@ categories = ["multimedia", "network-programming", "web-programming"]
 
 [dependencies]
 moq-transport = { path = "../moq-transport", version = "0.16" }
-moq-native-ietf = { path = "../moq-native-ietf", version = "0.9" }
+moq-native-ietf = { path = "../moq-native-ietf", version = "0.10" }
 moq-catalog = { path = "../moq-catalog", version = "0.2" }
 url = "2"
 

--- a/moq-sub/src/main.rs
+++ b/moq-sub/src/main.rs
@@ -16,7 +16,11 @@ use moq_transport::{coding::TrackNamespace, serve::Tracks};
 async fn main() -> anyhow::Result<()> {
     // Initialize tracing with env filter (respects RUST_LOG environment variable)
     // Default to info level, but suppress quinn's verbose output
+    //
+    // Logs go to stderr so they can't corrupt the fMP4 byte stream this
+    // binary writes to stdout (e.g. `moq-sub ... | ffplay -`).
     tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info,quinn=warn")),

--- a/moq-test-client/CHANGELOG.md
+++ b/moq-test-client/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.12](https://github.com/cloudflare/moq-rs/compare/moq-test-client-v0.1.11...moq-test-client-v0.1.12) - 2026-07-31
+
+### Fixed
+
+- send log output to stderr instead of stdout
+
+## [0.1.11](https://github.com/cloudflare/moq-rs/compare/moq-test-client-v0.1.10...moq-test-client-v0.1.11) - 2026-07-20
+
+### Other
+
+- updated the following local packages: moq-native-ietf
+
 ## [0.1.10](https://github.com/cloudflare/moq-rs/compare/moq-test-client-v0.1.9...moq-test-client-v0.1.10) - 2026-07-19
 
 ### Other

--- a/moq-test-client/Cargo.toml
+++ b/moq-test-client/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["moq-rs contributors"]
 repository = "https://github.com/cloudflare/moq-rs"
 license = "MIT OR Apache-2.0"
 
-version = "0.1.10"
+version = "0.1.12"
 edition = "2021"
 
 keywords = ["quic", "webtransport", "moqt", "testing", "interop"]
@@ -20,7 +20,7 @@ path = "src/main.rs"
 
 [dependencies]
 moq-transport = { path = "../moq-transport", version = "0.16" }
-moq-native-ietf = { path = "../moq-native-ietf", version = "0.9" }
+moq-native-ietf = { path = "../moq-native-ietf", version = "0.10" }
 web-transport = { workspace = true }
 
 bytes = "1"

--- a/moq-test-client/src/main.rs
+++ b/moq-test-client/src/main.rs
@@ -79,9 +79,10 @@ pub enum TestCase {
     SubscribeBeforePublishNamespace,
     /// T0.6: Send PUBLISH_NAMESPACE, receive REQUEST_OK, send PUBLISH_NAMESPACE_DONE
     PublishNamespaceDone,
-    // NOTE: publish-track tests (outbound direct PUBLISH) are deferred — the
-    // draft-18 bidi core (2bf720c) does not yet include the outbound PUBLISH
-    // session state (published.rs). Re-add once PUBLISH is ported onto bidi.
+    /// T0.7: Publisher sends PUBLISH for one track, receives PUBLISH_OK, then completes
+    PublishTrackOnly,
+    /// T0.8: Publisher sends PUBLISH for one track, subscriber receives it through relay routing
+    PublishTrackSubscribe,
 }
 
 impl TestCase {
@@ -93,6 +94,8 @@ impl TestCase {
             TestCase::PublishNamespaceSubscribe,
             TestCase::SubscribeBeforePublishNamespace,
             TestCase::PublishNamespaceDone,
+            TestCase::PublishTrackOnly,
+            TestCase::PublishTrackSubscribe,
         ]
     }
 
@@ -104,6 +107,8 @@ impl TestCase {
             TestCase::PublishNamespaceSubscribe => "publish-namespace-subscribe",
             TestCase::SubscribeBeforePublishNamespace => "subscribe-before-publish-namespace",
             TestCase::PublishNamespaceDone => "publish-namespace-done",
+            TestCase::PublishTrackOnly => "publish-track-only",
+            TestCase::PublishTrackSubscribe => "publish-track-subscribe",
         }
     }
 }
@@ -155,6 +160,8 @@ async fn run_test(args: &Args, test_case: TestCase) -> TestResult {
             scenarios::test_subscribe_before_publish_namespace(args).await
         }
         TestCase::PublishNamespaceDone => scenarios::test_publish_namespace_done(args).await,
+        TestCase::PublishTrackOnly => scenarios::test_publish_track_only(args).await,
+        TestCase::PublishTrackSubscribe => scenarios::test_publish_track_subscribe(args).await,
     };
 
     let duration = start.elapsed();
@@ -222,7 +229,11 @@ fn print_tap_result(test_number: usize, result: &TestResult, verbose: bool) {
 async fn main() -> Result<()> {
     // Initialize tracing with env filter (respects RUST_LOG environment variable)
     // Default to info level, but suppress quinn's verbose output
+    //
+    // Logs go to stderr so they can't corrupt the TAP report this binary
+    // writes to stdout.
     tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info,quinn=warn")),

--- a/moq-test-client/src/scenarios.rs
+++ b/moq-test-client/src/scenarios.rs
@@ -10,10 +10,15 @@
 //! for correlation with relay-side mlog files.
 
 use anyhow::{Context, Result};
+use bytes::Bytes;
 use tokio::time::{timeout, Duration};
 
 use moq_native_ietf::quic;
-use moq_transport::{coding::TrackNamespace, serve::Tracks, session::Session};
+use moq_transport::{
+    coding::{KeyValuePairs, TrackNamespace},
+    serve::{Track, TrackReaderMode, TrackWriter, Tracks},
+    session::Session,
+};
 
 use crate::Args;
 
@@ -25,6 +30,12 @@ const TEST_NAMESPACE: &str = "moq-test/interop";
 
 /// Track name used for test operations
 const TEST_TRACK: &str = "test-track";
+
+/// Namespace used for direct PUBLISH test operations
+const PUBLISH_NAMESPACE: &str = "moq-test/publish";
+
+/// Track name used for direct PUBLISH test operations
+const PUBLISH_TRACK: &str = "published-track";
 
 /// Helper to connect to a relay and establish a session
 /// Returns (session, connection_id, transport) so we can report CIDs for mlog correlation
@@ -52,6 +63,17 @@ impl TestConnectionIds {
     pub fn add(&mut self, cid: String) {
         self.cids.push(cid);
     }
+}
+
+fn write_test_subgroup(track: TrackWriter, payload: &'static [u8]) -> Result<()> {
+    let mut subgroups = track.subgroups().context("failed to enter subgroup mode")?;
+    let mut subgroup = subgroups.append(128).context("failed to create subgroup")?;
+    subgroup
+        .write(Bytes::from_static(payload))
+        .context("failed to write subgroup object")?;
+    drop(subgroup);
+    drop(subgroups);
+    Ok(())
 }
 
 /// T0.1: Setup Only
@@ -294,6 +316,158 @@ pub async fn test_publish_namespace_done(args: &Args) -> Result<TestConnectionId
 
         tokio::time::sleep(Duration::from_millis(100)).await;
         tracing::info!("PUBLISH_NAMESPACE_DONE sent successfully");
+        Ok(cids)
+    })
+    .await
+    .context("test timed out")?
+}
+
+/// T0.7: Publish Track Only
+///
+/// Publisher sends direct PUBLISH for one track, receives PUBLISH_OK, serves one
+/// object, and completes with PUBLISH_DONE.
+pub async fn test_publish_track_only(args: &Args) -> Result<TestConnectionIds> {
+    timeout(TEST_TIMEOUT, async {
+        let (session, cid, transport) = connect(args)
+            .await
+            .context("publisher failed to connect to relay")?;
+        let mut cids = TestConnectionIds::default();
+        cids.add(cid);
+
+        let (session, mut publisher, _subscriber) = Session::connect(session, None, transport)
+            .await
+            .context("publisher SETUP failed")?;
+
+        let namespace = TrackNamespace::from_utf8_path(PUBLISH_NAMESPACE);
+        let (track_writer, track_reader) = Track::new(namespace.clone(), PUBLISH_TRACK).produce();
+
+        tracing::info!(
+            namespace = %namespace,
+            track = PUBLISH_TRACK,
+            "Publisher sending direct PUBLISH"
+        );
+
+        let result: Result<()> = tokio::select! {
+            res = async {
+                let mut published = publisher
+                    .publish(track_reader, KeyValuePairs::default())
+                    .await
+                    .context("failed to send PUBLISH")?;
+                published.ok().await.context("PUBLISH was rejected")?;
+                tracing::info!(namespace = %namespace, track = PUBLISH_TRACK, "PUBLISH accepted");
+
+                write_test_subgroup(track_writer, b"publish-track-only")?;
+                published.serve().await.context("failed serving PUBLISH track")?;
+                tracing::info!(namespace = %namespace, track = PUBLISH_TRACK, "PUBLISH completed");
+                Ok(())
+            } => res,
+            res = session.run() => {
+                res.context("publisher session error")?;
+                anyhow::bail!("publisher session ended before PUBLISH completed");
+            }
+        };
+
+        result?;
+        Ok(cids)
+    })
+    .await
+    .context("test timed out")?
+}
+
+/// T0.8: Publish Track + Subscribe
+///
+/// Publisher sends direct PUBLISH for one track; after PUBLISH_OK, a subscriber
+/// subscribes to the exact track and receives the relayed object stream.
+pub async fn test_publish_track_subscribe(args: &Args) -> Result<TestConnectionIds> {
+    timeout(TEST_TIMEOUT, async {
+        let mut cids = TestConnectionIds::default();
+
+        let (pub_session, pub_cid, pub_transport) = connect(args)
+            .await
+            .context("publisher failed to connect")?;
+        cids.add(pub_cid);
+        let (pub_session, mut publisher, _pub_subscriber) =
+            Session::connect(pub_session, None, pub_transport)
+                .await
+                .context("publisher SETUP failed")?;
+
+        let (sub_session, sub_cid, sub_transport) = connect(args)
+            .await
+            .context("subscriber failed to connect")?;
+        cids.add(sub_cid);
+        let (sub_session, _sub_publisher, mut subscriber) =
+            Session::connect(sub_session, None, sub_transport)
+                .await
+                .context("subscriber SETUP failed")?;
+
+        let namespace = TrackNamespace::from_utf8_path(PUBLISH_NAMESPACE);
+        let (track_writer, track_reader) = Track::new(namespace.clone(), PUBLISH_TRACK).produce();
+        let (mut sub_tracks, _, mut sub_reader) = Tracks::new(namespace.clone()).produce();
+        let sub_track = sub_tracks
+            .create(PUBLISH_TRACK)
+            .ok_or_else(|| anyhow::anyhow!("failed to create subscriber track"))?;
+        let received_track = sub_reader
+            .get_track_reader(&namespace, PUBLISH_TRACK)
+            .ok_or_else(|| anyhow::anyhow!("failed to read subscriber track"))?;
+
+        tracing::info!(
+            namespace = %namespace,
+            track = PUBLISH_TRACK,
+            "Publisher sending direct PUBLISH before subscriber subscribes"
+        );
+
+        let result: Result<()> = tokio::select! {
+            res = async {
+                let mut published = publisher
+                    .publish(track_reader, KeyValuePairs::default())
+                    .await
+                    .context("failed to send PUBLISH")?;
+                published.ok().await.context("PUBLISH was rejected")?;
+                tracing::info!(namespace = %namespace, track = PUBLISH_TRACK, "PUBLISH accepted; starting subscriber");
+
+                let subscribe = async {
+                    subscriber
+                        .subscribe(sub_track)
+                        .await
+                        .context("subscriber failed to receive direct PUBLISH track")
+                };
+
+                let receive = async {
+                    let mut subgroups = match received_track.mode().await.context("subscriber track mode failed")? {
+                        TrackReaderMode::Subgroups(subgroups) => subgroups,
+                        _ => anyhow::bail!("subscriber track used non-subgroup delivery"),
+                    };
+                    let mut subgroup = subgroups.next().await.context("subscriber subgroup failed")?
+                        .ok_or_else(|| anyhow::anyhow!("subscriber did not receive a subgroup"))?;
+                    let payload = subgroup.read_next().await.context("subscriber object failed")?
+                        .ok_or_else(|| anyhow::anyhow!("subscriber did not receive an object"))?;
+                    if payload.as_ref() != b"publish-track-subscribe" {
+                        anyhow::bail!("subscriber received unexpected payload");
+                    }
+                    Ok(())
+                };
+
+                let publish = async {
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                    write_test_subgroup(track_writer, b"publish-track-subscribe")?;
+                    published.serve().await.context("failed serving PUBLISH track")
+                };
+
+                tokio::try_join!(subscribe, receive, publish)?;
+                tracing::info!(namespace = %namespace, track = PUBLISH_TRACK, "Subscriber received direct PUBLISH track");
+                Ok(())
+            } => res,
+            res = pub_session.run() => {
+                res.context("publisher session error")?;
+                anyhow::bail!("publisher session ended before PUBLISH/subscriber flow completed");
+            },
+            res = sub_session.run() => {
+                res.context("subscriber session error")?;
+                anyhow::bail!("subscriber session ended before PUBLISH/subscriber flow completed");
+            }
+        };
+
+        result?;
         Ok(cids)
     })
     .await

--- a/moq-transport/src/coding/track_namespace.rs
+++ b/moq-transport/src/coding/track_namespace.rs
@@ -27,13 +27,19 @@ fn namespace_fields_byte_len(fields: &[TupleField]) -> usize {
     fields.iter().map(|f| f.value.len()).sum()
 }
 
-fn namespace_path(fields: &[TupleField]) -> String {
-    let mut path = String::new();
+/// Stream a `/`-separated namespace path straight into a formatter.
+///
+/// Writing through the formatter keeps `Display` allocation-free, which matters
+/// because namespaces are used as `tracing` fields on hot relay paths: with `%ns`
+/// the path is only rendered when the subscriber actually records the event, and
+/// even then nothing is allocated. `String::from_utf8_lossy` borrows for valid
+/// UTF-8, so only genuinely invalid fields allocate a replacement string.
+fn write_namespace_path(fields: &[TupleField], f: &mut fmt::Formatter<'_>) -> fmt::Result {
     for field in fields {
-        path.push('/');
-        path.push_str(&String::from_utf8_lossy(&field.value));
+        f.write_str("/")?;
+        f.write_str(&String::from_utf8_lossy(&field.value))?;
     }
-    path
+    Ok(())
 }
 
 fn decode_namespace_fields<R: bytes::Buf>(
@@ -268,8 +274,12 @@ impl TrackNamespace {
         ns
     }
 
+    /// Render as a `/`-separated UTF-8 path.
+    ///
+    /// Allocates. Prefer the [`fmt::Display`] impl (e.g. `%namespace` in a
+    /// `tracing` field) when a `String` is not actually needed.
     pub fn to_utf8_path(&self) -> String {
-        namespace_path(&self.fields)
+        self.to_string()
     }
 
     /// Sum of all field lengths. Used for full-track-name limit calculation.
@@ -332,7 +342,7 @@ impl fmt::Debug for TrackNamespace {
 
 impl fmt::Display for TrackNamespace {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{0}", namespace_path(&self.fields))
+        write_namespace_path(&self.fields, f)
     }
 }
 
@@ -417,8 +427,12 @@ impl TrackNamespacePrefix {
         prefix
     }
 
+    /// Render as a `/`-separated UTF-8 path.
+    ///
+    /// Allocates. Prefer the [`fmt::Display`] impl (e.g. `%prefix` in a
+    /// `tracing` field) when a `String` is not actually needed.
     pub fn to_utf8_path(&self) -> String {
-        namespace_path(&self.fields)
+        self.to_string()
     }
 
     /// Return true when this prefix matches the beginning of `namespace`.
@@ -479,7 +493,7 @@ impl fmt::Debug for TrackNamespacePrefix {
 
 impl fmt::Display for TrackNamespacePrefix {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{0}", namespace_path(&self.fields))
+        write_namespace_path(&self.fields, f)
     }
 }
 
@@ -889,6 +903,50 @@ mod tests {
             err,
             TrackNamespaceError::NamespaceTooLarge(4097, MAX_FULL_TRACK_NAME_LEN)
         ));
+    }
+
+    // ── Display / to_utf8_path equivalence ────────────────────────────────────
+
+    /// `to_utf8_path` delegates to `Display`, which streams into the formatter
+    /// rather than building a `String`. Both must keep producing the same path,
+    /// including for fields that are not valid UTF-8 (rendered lossily).
+    #[test]
+    fn display_matches_to_utf8_path() {
+        let namespace = TrackNamespace::from_utf8_path("example.com/meeting=123");
+        assert_eq!(namespace.to_string(), namespace.to_utf8_path());
+        assert_eq!(namespace.to_utf8_path(), "/example.com/meeting=123");
+
+        let prefix = TrackNamespacePrefix::from_utf8_path("example.com");
+        assert_eq!(prefix.to_string(), prefix.to_utf8_path());
+        assert_eq!(prefix.to_utf8_path(), "/example.com");
+
+        let empty = TrackNamespacePrefix::new();
+        assert_eq!(empty.to_string(), empty.to_utf8_path());
+        assert_eq!(empty.to_utf8_path(), "");
+    }
+
+    #[test]
+    fn display_renders_non_utf8_fields_lossily() {
+        let namespace = TrackNamespace {
+            fields: vec![
+                TupleField { value: vec![0xff] },
+                TupleField::from_utf8("ok"),
+            ],
+        };
+
+        assert_eq!(namespace.to_string(), namespace.to_utf8_path());
+        assert_eq!(namespace.to_utf8_path(), "/\u{fffd}/ok");
+    }
+
+    /// `Debug` is written in terms of `Display`, so it must not regress into
+    /// printing the raw field vector.
+    #[test]
+    fn debug_matches_display() {
+        let namespace = TrackNamespace::from_utf8_path("a/b");
+        assert_eq!(format!("{namespace:?}"), format!("{namespace}"));
+
+        let prefix = TrackNamespacePrefix::from_utf8_path("a/b");
+        assert_eq!(format!("{prefix:?}"), format!("{prefix}"));
     }
 
     // ── full_track_name_len ───────────────────────────────────────────────────

--- a/moq-transport/src/serve/track.rs
+++ b/moq-transport/src/serve/track.rs
@@ -94,7 +94,7 @@ impl TrackWriter {
         // Lock state to modify it
         let mut state = self.state.lock_mut().ok_or_else(|| {
             tracing::debug!(
-                namespace = %self.info.namespace.to_utf8_path(),
+                namespace = %self.info.namespace,
                 track = %self.info.name,
                 "track state dropped (Cancel) in stream()"
             );
@@ -117,7 +117,7 @@ impl TrackWriter {
         // Lock state to modify it
         let mut state = self.state.lock_mut().ok_or_else(|| {
             tracing::debug!(
-                namespace = %self.info.namespace.to_utf8_path(),
+                namespace = %self.info.namespace,
                 track = %self.info.name,
                 "track state dropped (Cancel) in subgroups()"
             );
@@ -138,7 +138,7 @@ impl TrackWriter {
         // Lock state to modify it
         let mut state = self.state.lock_mut().ok_or_else(|| {
             tracing::debug!(
-                namespace = %self.info.namespace.to_utf8_path(),
+                namespace = %self.info.namespace,
                 track = %self.info.name,
                 "track state dropped (Cancel) in datagrams()"
             );
@@ -153,7 +153,7 @@ impl TrackWriter {
     /// Close the track with an error.
     pub fn close(self, err: ServeError) -> Result<(), ServeError> {
         tracing::debug!(
-            namespace = %self.info.namespace.to_utf8_path(),
+            namespace = %self.info.namespace,
             track = %self.info.name,
             error = %err,
             "track closing"
@@ -163,7 +163,7 @@ impl TrackWriter {
 
         let mut state = state.into_mut().ok_or_else(|| {
             tracing::debug!(
-                namespace = %self.info.namespace.to_utf8_path(),
+                namespace = %self.info.namespace,
                 track = %self.info.name,
                 "track state already dropped during close"
             );

--- a/moq-transport/src/serve/tracks.rs
+++ b/moq-transport/src/serve/tracks.rs
@@ -148,7 +148,7 @@ impl Drop for TracksRequest {
         if !pending_tracks.is_empty() {
             tracing::debug!(
                 target: "moq_transport::tracks",
-                namespace = %self.info.namespace.to_utf8_path(),
+                namespace = %self.info.namespace,
                 count = pending_tracks.len(),
                 "TracksRequest dropped with pending track requests"
             );
@@ -220,7 +220,7 @@ impl TracksReader {
                 // Track is still active, return the cached reader
                 tracing::debug!(
                     target: "moq_transport::tracks",
-                    namespace = %namespace.to_utf8_path(),
+                    namespace = %namespace,
                     track = %track_name,
                     "track cache hit (active)"
                 );
@@ -229,7 +229,7 @@ impl TracksReader {
             // Track is closed/stale, fall through to create a new one
             tracing::debug!(
                 target: "moq_transport::tracks",
-                namespace = %namespace.to_utf8_path(),
+                namespace = %namespace,
                 track = %track_name,
                 "track cache hit but stale, will evict and re-request"
             );
@@ -249,7 +249,7 @@ impl TracksReader {
         if self.queue.push(track_writer_reader.0).is_err() {
             tracing::debug!(
                 target: "moq_transport::tracks",
-                namespace = %namespace.to_utf8_path(),
+                namespace = %namespace,
                 track = %track_name,
                 "track request queue closed"
             );
@@ -263,7 +263,7 @@ impl TracksReader {
 
         tracing::debug!(
             target: "moq_transport::tracks",
-            namespace = %namespace.to_utf8_path(),
+            namespace = %namespace,
             track = %track_name,
             "track cache miss, requested from upstream"
         );

--- a/moq-transport/src/session/error.rs
+++ b/moq-transport/src/session/error.rs
@@ -138,6 +138,32 @@ impl SessionError {
     }
 
     /// Returns true when only one WebTransport stream was closed or reset.
+    /// True when this error means the peer's send half ended, cleanly or
+    /// otherwise, rather than that a message was malformed.
+    ///
+    /// Callers reading an open-ended stream use this to tell "nothing more is
+    /// coming" from "that frame was bad but the stream is still in sync".
+    pub(crate) fn is_stream_ended(&self) -> bool {
+        self.is_stream_error() || matches!(self, Self::Decode(crate::coding::DecodeError::More(_)))
+    }
+
+    /// Whether this error requires tearing down the whole session, rather than
+    /// only ending one stream or failing the one request it arose from.
+    ///
+    /// Draft-18 makes session closure mandatory for protocol violations:
+    /// duplicate track aliases, invalid request IDs, malformed messages. Two
+    /// classes must *not* take the connection down with them, because both are
+    /// ordinary events on a healthy session: a peer ending or resetting a single
+    /// request stream, and a request that legitimately fails (an unknown track,
+    /// say). Collapsing those into "close the session" would let any subscriber
+    /// kill the connection by asking for something that does not exist.
+    pub(crate) fn is_session_fatal(&self) -> bool {
+        if self.is_stream_ended() {
+            return false;
+        }
+        !matches!(self, Self::Serve(_))
+    }
+
     pub(crate) fn is_stream_error(&self) -> bool {
         #[cfg(any(not(target_arch = "wasm32"), target_os = "wasi"))]
         {
@@ -244,5 +270,37 @@ mod tests {
         assert!(reset.is_stream_error());
         assert!(stopped.is_stream_error());
         assert!(!SessionError::Internal.is_stream_error());
+    }
+
+    #[test]
+    fn protocol_violations_are_session_fatal() {
+        for err in [
+            SessionError::Duplicate,
+            SessionError::InvalidRequestId,
+            SessionError::ProtocolViolation("bad".into()),
+            SessionError::RoleViolation,
+            SessionError::WrongSize,
+        ] {
+            assert!(err.is_session_fatal(), "{err} should close the session");
+        }
+    }
+
+    #[test]
+    fn one_stream_ending_does_not_close_the_session() {
+        let reset = SessionError::WebTransport(web_transport::Error::Read(
+            web_transport::quinn::ReadError::Reset(42),
+        ));
+        let ended = SessionError::Decode(crate::coding::DecodeError::More(1));
+
+        assert!(!reset.is_session_fatal());
+        assert!(!ended.is_session_fatal());
+    }
+
+    #[test]
+    fn a_failed_request_does_not_close_the_session() {
+        // Otherwise any subscriber could drop the connection for everyone by
+        // asking for a track that does not exist.
+        let not_found = SessionError::Serve(serve::ServeError::NotFound);
+        assert!(!not_found.is_session_fatal());
     }
 }

--- a/moq-transport/src/session/mod.rs
+++ b/moq-transport/src/session/mod.rs
@@ -4,23 +4,33 @@
 
 mod error;
 mod publish_namespace;
+mod publish_received;
+mod published;
 mod published_namespace;
 mod publisher;
 mod reader;
 mod request_id;
 mod subscribe;
+mod subscribe_namespace;
 mod subscribed;
+mod subscribed_namespace;
 mod subscriber;
 mod track_status_requested;
 mod writer;
 
 pub use error::*;
 pub use publish_namespace::*;
+pub use publish_received::PublishReceived;
+pub(crate) use publish_received::PublishReceivedRecv;
+pub(crate) use published::{split_published_state, PublishedRecv, RequestStreamSink};
+pub use published::{Published, PublishedInfo};
 pub use published_namespace::*;
 pub use publisher::*;
 pub use request_id::RequestId;
 pub use subscribe::*;
+pub use subscribe_namespace::*;
 pub use subscribed::*;
+pub use subscribed_namespace::*;
 pub use subscriber::*;
 pub use track_status_requested::*;
 
@@ -49,7 +59,7 @@ type BidiResponseMap = Arc<Mutex<HashMap<u64, tokio::sync::mpsc::UnboundedSender
 /// A bidi response reader future handed from Publisher/Subscriber to
 /// `Session::run`. Boxed so the publisher and subscriber reader loops can
 /// share one channel and one `FuturesUnordered` type.
-type BidiReaderFuture = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
+type BidiReaderFuture = Pin<Box<dyn Future<Output = Result<(), SessionError>> + Send + 'static>>;
 
 /// Channel for bidi response reader futures. Publisher/Subscriber send boxed
 /// futures here; `Session::run` polls them cooperatively under structured
@@ -73,6 +83,32 @@ pub enum Transport {
     /// Raw QUIC with MoQT framing directly on QUIC streams.
     /// ALPN: "moqt-16". Path carried in SETUP PATH parameter.
     RawQuic,
+}
+
+/// Session-level configuration supplied at connect/accept time.
+///
+/// Draft-18 removed MAX_REQUEST_ID and REQUESTS_BLOCKED, so there is no longer
+/// a negotiated request budget to advertise in SETUP. `max_request_id` is
+/// retained so callers that were written against the draft-16 API (including
+/// the relay's `--max-request-id` flag) keep working, but it is not sent on the
+/// wire and does not bound anything on this branch. Inbound request IDs are
+/// still bounded per session by `request_id::MAX_REQUEST_IDS_PER_SESSION`.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct SessionConfig {
+    /// Accepted for source compatibility with draft-16 callers. Unused.
+    pub max_request_id: u64,
+}
+
+/// The draft-16 default, kept so `SessionConfig::default()` compares equal to
+/// what existing callers construct.
+const DEFAULT_MAX_REQUEST_ID: u64 = 100;
+
+impl Default for SessionConfig {
+    fn default() -> Self {
+        Self {
+            max_request_id: DEFAULT_MAX_REQUEST_ID,
+        }
+    }
 }
 
 /// Session object for managing all communications in a single QUIC connection.
@@ -484,6 +520,20 @@ impl Session {
         mlog_path: Option<PathBuf>,
         transport: Transport,
     ) -> Result<(Session, Publisher, Subscriber), SessionError> {
+        Self::connect_with_config(session, mlog_path, transport, SessionConfig::default()).await
+    }
+
+    /// Create an outbound/client QUIC connection with explicit session config.
+    ///
+    /// See [`SessionConfig`]: draft-18 has no negotiated request budget, so the
+    /// config currently carries nothing that affects the connection. The entry
+    /// point exists so callers can keep passing one.
+    pub async fn connect_with_config(
+        session: web_transport::Session,
+        mlog_path: Option<PathBuf>,
+        transport: Transport,
+        _config: SessionConfig,
+    ) -> Result<(Session, Publisher, Subscriber), SessionError> {
         let url = session.url().clone();
         let url_path = url.path();
         let path = Self::normalize_connection_path(url_path)?;
@@ -565,6 +615,18 @@ impl Session {
         session: web_transport::Session,
         mlog_path: Option<PathBuf>,
         transport: Transport,
+    ) -> Result<(Session, Option<Publisher>, Option<Subscriber>), SessionError> {
+        Self::accept_with_config(session, mlog_path, transport, SessionConfig::default()).await
+    }
+
+    /// Accept an inbound server connection with explicit session config.
+    ///
+    /// See [`SessionConfig`] for why the config is currently inert under draft-18.
+    pub async fn accept_with_config(
+        session: web_transport::Session,
+        mlog_path: Option<PathBuf>,
+        transport: Transport,
+        _config: SessionConfig,
     ) -> Result<(Session, Option<Publisher>, Option<Subscriber>), SessionError> {
         let mut mlog = mlog_path.and_then(|p| {
             mlog::MlogWriter::new(p)
@@ -654,13 +716,13 @@ impl Session {
         let result = tokio::select! {
             res = Self::run_recv(self.recver, self.publisher.clone(), self.subscriber.clone(), self.mlog.clone(), self.request_id.clone(), self.outgoing.clone()) => res,
             res = Self::run_send(self.sender, self.outgoing, self.mlog.clone(), self.bidi_response_map.clone()) => res,
-            res = Self::run_bidi_requests(self.webtransport.clone(), self.publisher.clone(), self.subscriber.clone(), self.request_id.clone(), self.bidi_response_map.clone()) => res,
+            res = Self::run_bidi_requests(self.webtransport.clone(), self.publisher.clone(), self.subscriber.clone(), self.request_id.clone(), self.bidi_response_map.clone(), self.mlog.clone()) => res,
             res = Self::run_streams(self.webtransport.clone(), self.subscriber.clone()) => res,
             res = Self::run_datagrams(self.webtransport, self.subscriber) => res,
             // Collect bidi reader futures and poll them cooperatively as part of
             // this select. They progress only while run() is polled, so they
             // cannot outlive the session (true structured concurrency).
-            () = async {
+            res = async {
                 loop {
                     tokio::select! {
                         fut = bidi_task_rx.recv() => {
@@ -669,10 +731,21 @@ impl Session {
                                 None => break, // all senders dropped
                             }
                         }
-                        Some(_) = reader_tasks.next() => {}
+                        Some(res) = reader_tasks.next() => {
+                            // A reader ending is normal; a protocol violation is not.
+                            // Surfacing the latter here is what closes the session with
+                            // the registered code instead of logging and carrying on.
+                            if let Err(err) = res {
+                                if err.is_session_fatal() {
+                                    return Err(err);
+                                }
+                                tracing::debug!(error = %err, "bidi response reader ended");
+                            }
+                        }
                     }
                 }
-            } => Ok(()),
+                Ok(())
+            } => res,
         };
 
         // Dropping reader_tasks (FuturesUnordered<BidiReaderFuture>) drops every
@@ -783,6 +856,7 @@ impl Session {
         subscriber: Option<Subscriber>,
         request_id: RequestId,
         bidi_response_map: BidiResponseMap,
+        mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
     ) -> Result<(), SessionError> {
         let mut tasks = FuturesUnordered::new();
 
@@ -794,17 +868,26 @@ impl Session {
                     let mut sub_clone = subscriber.clone();
                     let rid = request_id.clone();
                     let map = bidi_response_map.clone();
+                    let mlog = mlog.clone();
 
                     tasks.push(async move {
-                        if let Err(e) = Self::handle_bidi_request(
+                        Self::handle_bidi_request(
                             send_stream, recv_stream,
-                            &mut pub_clone, &mut sub_clone, &rid, &map,
-                        ).await {
-                            tracing::debug!(error = %e, "bidi request stream ended");
-                        }
+                            &mut pub_clone, &mut sub_clone, &rid, &map, mlog,
+                        ).await
                     });
                 }
-                Some(()) = tasks.next() => {}
+                Some(res) = tasks.next() => {
+                    // Same split as the outbound readers: an inbound request stream
+                    // ending is routine, but a peer that violated a MUST rule has to
+                    // take the session down, which cannot happen if we only log here.
+                    if let Err(err) = res {
+                        if err.is_session_fatal() {
+                            return Err(err);
+                        }
+                        tracing::debug!(error = %err, "bidi request stream ended");
+                    }
+                }
             }
         }
     }
@@ -819,6 +902,7 @@ impl Session {
         subscriber: &mut Option<Subscriber>,
         request_id: &RequestId,
         bidi_response_map: &BidiResponseMap,
+        mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
     ) -> Result<(), SessionError> {
         let mut reader = Reader::new(recv_stream);
         let mut writer = Writer::new(send_stream);
@@ -845,10 +929,31 @@ impl Session {
                 }
             };
 
+        // SUBSCRIBE_NAMESPACE owns its stream for the whole life of the request:
+        // the reply is not one terminal message but an open-ended NAMESPACE /
+        // NAMESPACE_DONE feed. Hand both halves straight to the publisher-side
+        // handler rather than routing through `bidi_response_map`, which can
+        // only key on messages that carry a Request ID — NAMESPACE does not.
+        if let Message::SubscribeNamespace(msg) = msg {
+            if let Some(ref mlog) = mlog {
+                if let Ok(mut mlog) = mlog.lock() {
+                    let time = mlog.elapsed_ms();
+                    let _ = mlog.add_event(mlog::events::subscribe_namespace_parsed(time, 0, &msg));
+                }
+            }
+
+            request_id.validate_incoming(msg.id)?;
+            let recv = publisher
+                .as_mut()
+                .ok_or(SessionError::RoleViolation)?
+                .recv_subscribe_namespace(msg)?;
+            return recv.run(writer, reader, mlog).await;
+        }
+
         // Classify the request. One-shot request/response flows are bounded in
         // the response phase below; long-lived flows (SUBSCRIBE, PUBLISH,
-        // PUBLISH_NAMESPACE, SUBSCRIBE_NAMESPACE, FETCH) may legitimately stay
-        // open until an explicit terminal message and are therefore not bounded.
+        // PUBLISH_NAMESPACE, FETCH) may legitimately stay open until an explicit
+        // terminal message and are therefore not bounded.
         let bounded_response = matches!(&msg, Message::TrackStatus(_) | Message::RequestUpdate(_));
 
         let req_id = msg.sequenced_request_id();
@@ -869,7 +974,7 @@ impl Session {
 
         // Dispatch to the appropriate role handler (same as run_recv).
         // Capture the result so cleanup runs unconditionally on error.
-        let dispatch_result = (|| -> Result<(), SessionError> {
+        let mut dispatch_result = (|| -> Result<(), SessionError> {
             let msg = match TryInto::<message::Publisher>::try_into(msg) {
                 Ok(msg) => {
                     subscriber
@@ -900,61 +1005,185 @@ impl Session {
         // Wait for responses only if dispatch succeeded; otherwise the
         // handlers didn't register anything to respond to.
         if dispatch_result.is_ok() {
-            if let Some(ref mut rx) = rx {
-                let pump = async {
-                    while let Some(response) = rx.recv().await {
-                        let is_terminal = matches!(
-                            response,
-                            Message::RequestError(_)
-                                | Message::PublishDone(_)
-                                | Message::PublishNamespaceDone(_)
-                                | Message::Unsubscribe(_)
-                        );
-                        if let Err(e) = Self::encode_bidi_response(&mut writer, &response).await {
-                            tracing::warn!(error = %e, "failed to write bidi response");
-                            break;
+            if let Some(id) = req_id {
+                if let Some(ref mut rx) = rx {
+                    let pump = async {
+                        while let Some(response) = rx.recv().await {
+                            // One-shot requests (TRACK_STATUS, REQUEST_UPDATE) get
+                            // exactly one reply, so REQUEST_OK ends them just as
+                            // REQUEST_ERROR does. Draft-18 requires the stream be
+                            // FINned after TRACK_STATUS_OK or REQUEST_ERROR
+                            // (§10.14). Treating only the error as terminal held the
+                            // handler slot until BIDI_REQUEST_TIMEOUT, so 128 cheap
+                            // TRACK_STATUS requests could occupy every slot for 30s
+                            // even when the application answered immediately.
+                            let is_terminal = matches!(
+                                response,
+                                Message::RequestError(_)
+                                    | Message::PublishDone(_)
+                                    | Message::PublishNamespaceDone(_)
+                                    | Message::Unsubscribe(_)
+                            ) || (bounded_response
+                                && matches!(response, Message::RequestOk(_)));
+                            if let Err(e) = Self::encode_bidi_response(&mut writer, &response).await
+                            {
+                                tracing::warn!(error = %e, "failed to write bidi response");
+                                break;
+                            }
+                            if is_terminal {
+                                // Give Quinn's connection driver a scheduling
+                                // opportunity to transmit the STREAM data before
+                                // the Writer is dropped (which sends FIN).
+                                tokio::time::sleep(std::time::Duration::ZERO).await;
+                                break;
+                            }
                         }
-                        if is_terminal {
-                            // Give Quinn's connection driver a scheduling
-                            // opportunity to transmit the STREAM data before
-                            // the Writer is dropped (which sends FIN).
-                            tokio::time::sleep(std::time::Duration::ZERO).await;
-                            break;
-                        }
-                    }
-                };
+                    };
 
-                // One-shot requests are bounded so a stalled peer cannot pin a
-                // slot after the request is accepted. Long-lived requests wait
-                // as long as needed; the QUIC idle timeout backstops a dead peer.
-                if bounded_response {
-                    if tokio::time::timeout(Self::BIDI_REQUEST_TIMEOUT, pump)
-                        .await
-                        .is_err()
-                    {
-                        tracing::debug!(
-                            ?req_id,
-                            "one-shot bidi request timed out awaiting response; reclaiming slot"
-                        );
-                    }
-                } else {
-                    pump.await;
+                    let follow_ups =
+                        Self::read_request_follow_ups(&mut reader, id, publisher, subscriber);
+
+                    // Whichever side finishes first ends the request, so the
+                    // other is cancelled. `follow_ups` is not cancellation-safe
+                    // (a partly-read frame is lost), which is fine only because
+                    // neither `reader` nor `writer` is used again afterwards.
+                    let both = async {
+                        tokio::select! {
+                            () = pump => Ok(()),
+                            res = follow_ups => res,
+                        }
+                    };
+
+                    // One-shot requests are bounded so a stalled peer cannot pin a
+                    // slot after the request is accepted. Long-lived requests wait
+                    // as long as needed; the QUIC idle timeout backstops a dead peer.
+                    // A protocol violation seen while reading follow-ups has to
+                    // reach the caller, which closes the session. Timing out is
+                    // not a violation: the slot is reclaimed and the session lives.
+                    dispatch_result = if bounded_response {
+                        match tokio::time::timeout(Self::BIDI_REQUEST_TIMEOUT, both).await {
+                            Ok(res) => res,
+                            Err(_) => {
+                                tracing::debug!(
+                                    ?req_id,
+                                    "one-shot bidi request timed out awaiting response; reclaiming slot"
+                                );
+                                Ok(())
+                            }
+                        }
+                    } else {
+                        both.await
+                    };
                 }
             }
         }
 
-        // Always clean up — runs on both success and error paths.
+        // The request stream is over. Release everything keyed by this request
+        // ID — a stream that dies without a terminal message would otherwise
+        // leak its state (and leave the application blocked on `closed()`) for
+        // the life of the session. Runs on both success and error paths.
         if let Some(id) = req_id {
+            if let Some(subscriber) = subscriber.as_ref() {
+                subscriber.abort_publish_received(id);
+            }
             if let Ok(mut map) = bidi_response_map.lock() {
                 map.remove(&id);
             }
         }
 
         // Explicitly finish the stream and yield for Quinn to flush.
-        writer.finish();
+        let _ = writer.finish();
         tokio::task::yield_now().await;
 
         dispatch_result
+    }
+
+    /// Read messages the requester sends after its opening request on the same
+    /// bidi stream, and dispatch them like any other inbound control message.
+    ///
+    /// Draft-18 puts the whole life of a request on one stream, so terminal
+    /// follow-ups such as PUBLISH_DONE (ending an inbound PUBLISH) and
+    /// UNSUBSCRIBE (ending an inbound SUBSCRIBE) arrive here rather than on the
+    /// control stream. Like every other message after the request, they omit
+    /// the Request ID, which is why the stream's known `request_id` is injected.
+    ///
+    /// Returns when the request ends: the requester reset the stream, or sent
+    /// something terminal. A clean FIN of the requester's send half is not an
+    /// ending, so this parks instead: this endpoint FINs its own SUBSCRIBE stream
+    /// immediately after sending the request and a conformant peer may do the
+    /// same, and the caller keeps the response side running.
+    ///
+    /// `Err` means the peer violated the protocol, which the caller turns into a
+    /// session close.
+    async fn read_request_follow_ups(
+        reader: &mut Reader,
+        request_id: u64,
+        publisher: &mut Option<Publisher>,
+        subscriber: &mut Option<Subscriber>,
+    ) -> Result<(), SessionError> {
+        loop {
+            let msg = match Self::decode_bidi_response(reader, request_id).await {
+                Ok(msg) => msg,
+                // A reset or STOP_SENDING ends the request itself, so returning
+                // here is what releases the handler slot. Parking on this would
+                // let a peer pin one slot per reset stream.
+                Err(err) if err.is_stream_error() => {
+                    tracing::debug!(request_id, error = %err, "request stream reset by peer");
+                    return Ok(());
+                }
+                // A clean FIN of the requester's send half is different: it only
+                // means no more requests are coming on this stream, not that the
+                // request is over. This endpoint FINs its own SUBSCRIBE stream
+                // right after sending, and a conformant peer may too, so parking
+                // keeps the response side alive.
+                Err(err) if err.is_stream_ended() => {
+                    tracing::trace!(request_id, error = %err, "request stream send half finished");
+                    std::future::pending::<()>().await;
+                    return Ok(());
+                }
+                // Draft-18 requires closing the session on an unknown message
+                // type, so an undecodable frame is not something to skip past.
+                Err(err) => return Err(err),
+            };
+
+            let terminal = matches!(
+                msg,
+                Message::PublishDone(_)
+                    | Message::PublishNamespaceDone(_)
+                    | Message::Unsubscribe(_)
+            );
+
+            let dispatched = match TryInto::<message::Publisher>::try_into(msg) {
+                Ok(msg) => subscriber
+                    .as_mut()
+                    .ok_or(SessionError::RoleViolation)
+                    .and_then(|s| s.recv_message(msg)),
+                Err(msg) => match TryInto::<message::Subscriber>::try_into(msg) {
+                    Ok(msg) => publisher
+                        .as_mut()
+                        .ok_or(SessionError::RoleViolation)
+                        .and_then(|p| p.recv_message(msg)),
+                    Err(msg) => {
+                        tracing::warn!(
+                            request_id,
+                            msg_type = msg.name(),
+                            "unexpected follow-up on bidi request stream"
+                        );
+                        Ok(())
+                    }
+                },
+            };
+
+            if let Err(err) = dispatched {
+                // Session::run decides: a protocol violation closes the session,
+                // anything else only ends this request.
+                return Err(err);
+            }
+
+            if terminal {
+                return Ok(());
+            }
+        }
     }
 
     /// Encode a response message to a bidi stream, omitting the Request ID
@@ -989,6 +1218,14 @@ impl Session {
             }
             // id-only messages: payload is empty (id omitted on bidi).
             Message::PublishNamespaceDone(_) | Message::Unsubscribe(_) => {}
+            // NAMESPACE / NAMESPACE_DONE never carried a Request ID, so their
+            // payload is unchanged on a bidi stream.
+            Message::Namespace(m) => {
+                m.track_namespace_suffix.encode(&mut payload)?;
+            }
+            Message::NamespaceDone(m) => {
+                m.track_namespace_suffix.encode(&mut payload)?;
+            }
             Message::PublishOk(m) => {
                 m.params.encode(&mut payload)?;
             }
@@ -1099,6 +1336,20 @@ impl Session {
             wire_id::Unsubscribe => Ok(Message::Unsubscribe(message::Unsubscribe {
                 id: request_id,
             })),
+            // NAMESPACE / NAMESPACE_DONE have no Request ID field, so nothing
+            // is injected — they decode exactly as they do on any other stream.
+            wire_id::Namespace => {
+                let track_namespace_suffix = crate::coding::TrackNamespacePrefix::decode(&mut buf)?;
+                Ok(Message::Namespace(message::Namespace {
+                    track_namespace_suffix,
+                }))
+            }
+            wire_id::NamespaceDone => {
+                let track_namespace_suffix = crate::coding::TrackNamespacePrefix::decode(&mut buf)?;
+                Ok(Message::NamespaceDone(message::NamespaceDone {
+                    track_namespace_suffix,
+                }))
+            }
             wire_id::PublishOk => {
                 let params = crate::coding::KeyValuePairs::decode(&mut buf)?;
                 Ok(Message::PublishOk(message::PublishOk {
@@ -1276,6 +1527,68 @@ impl Session {
     }
 }
 
+/// Shared helpers for session-layer unit tests.
+#[cfg(test)]
+pub(crate) mod test_support {
+    /// Establish a real `web_transport::Session` over an in-process QUIC
+    /// loopback so tests can construct a `Publisher`/`Subscriber` and exercise
+    /// the real cleanup paths.
+    ///
+    /// Most tests never send anything over it — they only touch in-memory maps
+    /// and queues — but `Publisher` and `Subscriber` hold a concrete
+    /// `web_transport::Session`, so a live connection is the only honest way to
+    /// build one. The accepted server side is parked for the lifetime of the test
+    /// to keep the client session established.
+    pub(crate) async fn loopback_session() -> web_transport::Session {
+        use web_transport::quinn::{ClientBuilder, ServerBuilder};
+
+        // Under `cargo test --workspace`, feature unification links both the
+        // `ring` and `aws-lc-rs` rustls providers, leaving no unambiguous
+        // process default. Install one explicitly (idempotent across tests).
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+        let cert = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])
+            .expect("generate self-signed certificate");
+        let cert_der = cert.cert.der().clone();
+        let key = cert
+            .key_pair
+            .serialize_der()
+            .try_into()
+            .expect("serialize private key");
+
+        let mut server = ServerBuilder::new()
+            .with_addr("127.0.0.1:0".parse().expect("server addr"))
+            .with_certificate(vec![cert_der], key)
+            .expect("build loopback server");
+        let addr = server.local_addr().expect("server local addr");
+
+        tokio::spawn(async move {
+            if let Some(request) = server.accept().await {
+                // Hold the accepted server session open for the lifetime of the
+                // test so the client side stays established; the spawned task is
+                // cancelled at runtime shutdown when the test returns.
+                if let Ok(_session) = request.ok().await {
+                    std::future::pending::<()>().await;
+                }
+            }
+        });
+
+        let client = ClientBuilder::new()
+            .dangerous()
+            .with_no_certificate_verification()
+            .expect("build loopback client");
+        let url = url::Url::parse(&format!("https://127.0.0.1:{}/", addr.port()))
+            .expect("parse loopback url");
+
+        // Fail fast rather than hang CI if the loopback handshake ever stalls.
+        tokio::time::timeout(std::time::Duration::from_secs(10), client.connect(url))
+            .await
+            .expect("loopback connect timed out")
+            .expect("connect loopback session")
+            .into()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1389,6 +1702,29 @@ mod tests {
             !bytes.contains(&99),
             "Request ID must not appear in bidi encoding"
         );
+    }
+
+    /// NAMESPACE and NAMESPACE_DONE carry no Request ID field, so their bidi
+    /// framing must be byte-identical to the ordinary message encoding.
+    #[test]
+    fn encode_bidi_namespace_matches_plain_message_encoding() {
+        for msg in [
+            Message::Namespace(message::Namespace {
+                track_namespace_suffix: crate::coding::TrackNamespacePrefix::from_utf8_path(
+                    "meeting=123",
+                ),
+            }),
+            Message::NamespaceDone(message::NamespaceDone {
+                track_namespace_suffix: crate::coding::TrackNamespacePrefix::from_utf8_path(
+                    "meeting=123",
+                ),
+            }),
+        ] {
+            let mut plain = bytes::BytesMut::new();
+            msg.encode(&mut plain).unwrap();
+
+            assert_eq!(encode_bidi_response_bytes(&msg), plain.to_vec());
+        }
     }
 
     #[test]

--- a/moq-transport/src/session/publish_received.rs
+++ b/moq-transport/src/session/publish_received.rs
@@ -1,0 +1,511 @@
+// SPDX-FileCopyrightText: 2026 Cloudflare Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Inbound PUBLISH handling: this endpoint, acting as subscriber, receives a
+//! PUBLISH from a publisher and can accept it with REQUEST_OK, reject it with
+//! REQUEST_ERROR, and then receive Objects on the resulting subscription
+//! (draft-18 §10.10 / §10.5 / §10.6).
+//!
+//! # Ownership model
+//!
+//! The transport layer retains the `TrackWriter` (inside `PublishReceivedRecv`)
+//! so the stream/datagram receive paths can write inbound Objects without
+//! application involvement. The application receives the `TrackReader` from
+//! `PublishReceived::ok`. This mirrors the outbound-SUBSCRIBE receive path
+//! where `SubscribeRecv` owns the writer.
+//!
+//! This is the inbound counterpart of `Published` (outbound PUBLISH). Both use
+//! the same `TrackOrigin` alias map in `Subscriber` for stream routing.
+
+use crate::{
+    coding::{KeyValuePairs, Location, ReasonPhrase, TrackName, TrackNamespace},
+    data,
+    message::{self, RequestErrorCode},
+    serve::{self, ServeError, TrackReader, TrackWriterMode},
+    watch::State,
+};
+
+use super::Subscriber;
+
+// ── Shared state ──────────────────────────────────────────────────────────────
+
+/// State shared between `PublishReceived` (application handle) and
+/// `PublishReceivedRecv` (transport handle).
+pub(crate) struct PublishReceivedState {
+    /// True once PUBLISH_DONE has been received from the publisher.
+    done: bool,
+    /// Terminal result; set when `done` becomes true.
+    closed: Result<(), ServeError>,
+}
+
+impl Default for PublishReceivedState {
+    fn default() -> Self {
+        Self {
+            done: false,
+            closed: Ok(()),
+        }
+    }
+}
+
+// ── Application-facing handle ─────────────────────────────────────────────────
+
+/// An inbound PUBLISH received by this endpoint acting as subscriber
+/// (draft-18 §10.10).
+///
+/// Call [`ok`](Self::ok) to accept the subscription and obtain the
+/// [`TrackReader`]. Dropping without calling `ok` sends `REQUEST_ERROR
+/// UNINTERESTED` back to the publisher.
+pub struct PublishReceived {
+    session: Subscriber,
+    state: State<PublishReceivedState>,
+    reader: Option<TrackReader>,
+
+    /// Request ID of the inbound PUBLISH.
+    request_id: u64,
+    /// Track Alias chosen by the publisher (§10.1).
+    track_alias: u64,
+    /// Full track identifier.
+    namespace: TrackNamespace,
+    name: TrackName,
+    /// Initial Forward value parsed from the PUBLISH params (§10.10).
+    initial_forward: bool,
+    /// LARGEST_OBJECT from the PUBLISH params, if present (§5.1).
+    largest_location: Option<Location>,
+
+    /// True once `ok()` has been called successfully.
+    ok: bool,
+    /// Optional override for the rejection error sent on drop.
+    error: Option<ServeError>,
+}
+
+impl PublishReceived {
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn new(
+        session: Subscriber,
+        request_id: u64,
+        track_alias: u64,
+        namespace: TrackNamespace,
+        name: TrackName,
+        initial_forward: bool,
+        largest_location: Option<Location>,
+        reader: TrackReader,
+        state: State<PublishReceivedState>,
+    ) -> Self {
+        Self {
+            session,
+            state,
+            reader: Some(reader),
+            request_id,
+            track_alias,
+            namespace,
+            name,
+            initial_forward,
+            largest_location,
+            ok: false,
+            error: None,
+        }
+    }
+
+    /// Move out the `TrackReader` before accepting.
+    ///
+    /// This lets relays register local/coordinator state before accepting the
+    /// PUBLISH. It does not answer the publisher; callers must still call
+    /// [`accept`](Self::accept) or drop this handle to reject.
+    pub fn take_reader(&mut self) -> Result<TrackReader, ServeError> {
+        self.reader.take().ok_or(ServeError::Done)
+    }
+
+    /// Accept the PUBLISH by answering REQUEST_OK (draft-18 §10.5).
+    ///
+    /// `forward` sets the initial Forward State:
+    ///   - `true` the publisher may start transmitting Objects immediately.
+    ///   - `false` the publisher pauses until Forward is later set to 1.
+    ///
+    /// Note: post-establishment `REQUEST_UPDATE` is not supported yet, so
+    /// passing `false` keeps the publisher paused for the lifetime of the
+    /// subscription in this implementation.
+    ///
+    /// Track Properties stay empty. §10.5 requires that of every REQUEST_OK
+    /// except TRACK_STATUS_OK, and sending them here would oblige the peer to
+    /// close the session with PROTOCOL_VIOLATION.
+    pub fn accept(&mut self, forward: bool) -> Result<(), ServeError> {
+        if self.ok {
+            return Err(ServeError::Duplicate);
+        }
+
+        let mut params = KeyValuePairs::default();
+        params.set_forward(forward);
+
+        self.session.send_message(message::RequestOk {
+            id: self.request_id,
+            params,
+        });
+        self.ok = true;
+
+        Ok(())
+    }
+
+    /// Accept the PUBLISH and return the `TrackReader`.
+    pub fn ok(&mut self, forward: bool) -> Result<TrackReader, ServeError> {
+        let reader = self.take_reader()?;
+        self.accept(forward)?;
+        Ok(reader)
+    }
+
+    /// Mark this track for rejection with a specific error on drop.
+    pub fn close(mut self, err: ServeError) {
+        self.error = Some(err);
+    }
+
+    /// Wait until the publisher sends PUBLISH_DONE or the session closes.
+    ///
+    /// Returns `Ok(())` on clean termination (TRACK_ENDED), or the error code
+    /// from PUBLISH_DONE on all other outcomes.
+    pub async fn closed(&self) -> Result<(), ServeError> {
+        loop {
+            {
+                let state = self.state.lock();
+                match state.closed.clone() {
+                    Ok(()) => {}
+                    Err(ServeError::Done) => return Ok(()),
+                    Err(err) => return Err(err),
+                }
+                match state.modified() {
+                    Some(notify) => notify,
+                    None => return Ok(()),
+                }
+            }
+            .await;
+        }
+    }
+
+    pub fn namespace(&self) -> &TrackNamespace {
+        &self.namespace
+    }
+
+    pub fn name(&self) -> &TrackName {
+        &self.name
+    }
+
+    pub fn track_alias(&self) -> u64 {
+        self.track_alias
+    }
+
+    pub fn initial_forward(&self) -> bool {
+        self.initial_forward
+    }
+
+    pub fn largest_location(&self) -> Option<Location> {
+        self.largest_location
+    }
+}
+
+impl Drop for PublishReceived {
+    fn drop(&mut self) {
+        if self.ok {
+            // Already accepted; nothing to send — PUBLISH_DONE arrives from the
+            // publisher to terminate.
+            return;
+        }
+
+        // Never accepted: send REQUEST_ERROR to reject the subscription (§10.6).
+        let err = self.error.clone().unwrap_or(ServeError::Cancel);
+
+        let error_code = match &err {
+            ServeError::Cancel | ServeError::Done => RequestErrorCode::Uninterested as u64,
+            ServeError::Duplicate => RequestErrorCode::DuplicateSubscription as u64,
+            ServeError::NotFound | ServeError::NotFoundWithId(_, _) => {
+                RequestErrorCode::DoesNotExist as u64
+            }
+            ServeError::NotImplemented(_) | ServeError::NotImplementedWithId(_, _) => {
+                RequestErrorCode::NotSupported as u64
+            }
+            ServeError::Internal(_) | ServeError::InternalWithId(_, _) => {
+                RequestErrorCode::InternalError as u64
+            }
+            ServeError::Closed(code) => *code,
+            _ => RequestErrorCode::InternalError as u64,
+        };
+
+        self.session.send_request_error(
+            "publish",
+            message::RequestError {
+                id: self.request_id,
+                error_code,
+                retry_interval: 0,
+                reason: ReasonPhrase("uninterested".to_string()),
+            },
+        );
+
+        // Clean up subscriber-side state for this PUBLISH.
+        self.session.remove_publish_received(self.request_id);
+    }
+}
+
+// ── Transport-facing recv handle ──────────────────────────────────────────────
+
+/// Transport-side bookkeeping for a single inbound PUBLISH.
+///
+/// Stored in `Subscriber::publishes_received`. Stream and datagram receive
+/// paths write Objects directly into the `TrackWriterMode` here.
+pub(crate) struct PublishReceivedRecv {
+    /// Shared state so both the transport and app can observe PUBLISH_DONE.
+    state: State<PublishReceivedState>,
+
+    /// Write half for inbound Objects. The transport owns this so it can push
+    /// Objects without going through the application.
+    writer: Option<TrackWriterMode>,
+}
+
+impl PublishReceivedRecv {
+    /// Create a `PublishReceived` / `PublishReceivedRecv` pair from a PUBLISH
+    /// message. Both handles share the same state.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn produce(
+        session: Subscriber,
+        request_id: u64,
+        track_alias: u64,
+        namespace: TrackNamespace,
+        name: TrackName,
+        initial_forward: bool,
+        largest_location: Option<Location>,
+        writer: serve::TrackWriter,
+        reader: TrackReader,
+    ) -> (PublishReceived, PublishReceivedRecv) {
+        let (app_state, transport_state) = State::<PublishReceivedState>::default().split();
+
+        let app = PublishReceived::new(
+            session,
+            request_id,
+            track_alias,
+            namespace,
+            name,
+            initial_forward,
+            largest_location,
+            reader,
+            app_state,
+        );
+        let recv = Self {
+            state: transport_state,
+            writer: Some(writer.into()),
+        };
+
+        (app, recv)
+    }
+
+    /// Open a subgroup writer for the given subgroup header.
+    ///
+    /// Mirrors `SubscribeRecv::subgroup` so the same subgroup receive loop can
+    /// serve both SUBSCRIBE-initiated and PUBLISH-initiated subscriptions.
+    pub fn subgroup(
+        &mut self,
+        header: data::SubgroupHeader,
+    ) -> Result<serve::SubgroupWriter, ServeError> {
+        let writer = self.writer.take().ok_or(ServeError::Done)?;
+
+        let mut subgroups = match writer {
+            TrackWriterMode::Track(track) => track.subgroups()?,
+            TrackWriterMode::Subgroups(subgroups) => subgroups,
+            _ => return Err(ServeError::Mode),
+        };
+
+        let subgroup_writer = subgroups.create(serve::Subgroup {
+            group_id: header.group_id,
+            subgroup_id: header.subgroup_id.unwrap_or(0),
+            priority: header.publisher_priority,
+        })?;
+
+        self.writer = Some(subgroups.into());
+        Ok(subgroup_writer)
+    }
+
+    /// Write a datagram Object into the track.
+    ///
+    /// Mirrors `SubscribeRecv::datagram`.
+    pub fn datagram(&mut self, datagram: data::Datagram) -> Result<(), ServeError> {
+        let writer = self.writer.take().ok_or(ServeError::Done)?;
+
+        match writer {
+            TrackWriterMode::Track(track) => {
+                let mut datagrams = track.datagrams()?;
+                datagrams.write(serve::Datagram {
+                    group_id: datagram.group_id,
+                    object_id: datagram.object_id.unwrap_or(0),
+                    priority: datagram.publisher_priority,
+                    payload: datagram.payload.unwrap_or_default(),
+                    extension_headers: datagram.extension_headers.unwrap_or_default(),
+                })?;
+                self.writer = Some(TrackWriterMode::Datagrams(datagrams));
+                Ok(())
+            }
+            TrackWriterMode::Datagrams(mut datagrams) => {
+                datagrams.write(serve::Datagram {
+                    group_id: datagram.group_id,
+                    object_id: datagram.object_id.unwrap_or(0),
+                    priority: datagram.publisher_priority,
+                    payload: datagram.payload.unwrap_or_default(),
+                    extension_headers: datagram.extension_headers.unwrap_or_default(),
+                })?;
+                self.writer = Some(TrackWriterMode::Datagrams(datagrams));
+                Ok(())
+            }
+            other => {
+                self.writer = Some(other);
+                Err(ServeError::Mode)
+            }
+        }
+    }
+
+    /// Called when PUBLISH_DONE arrives (§10.11).
+    ///
+    /// Closes the writer so the `TrackReader` sees end-of-track.
+    pub fn recv_done(&mut self, status_code: u64) {
+        if let Some(mut state) = self.state.lock_mut() {
+            state.done = true;
+            state.closed = if status_code == message::PublishDoneCode::TrackEnded as u64 {
+                Err(ServeError::Done)
+            } else {
+                Err(ServeError::Closed(status_code))
+            };
+        }
+        // Drop the writer to signal end-of-track to any downstream readers.
+        self.writer = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        coding::TrackNamespace,
+        serve::Track,
+        session::{test_support::loopback_session, RequestId},
+        watch::Queue,
+    };
+
+    async fn make_pair(
+        request_id: u64,
+    ) -> (
+        PublishReceived,
+        PublishReceivedRecv,
+        crate::session::Subscriber,
+    ) {
+        let (pr, recv, subscriber, _outgoing) = make_pair_with_outgoing(request_id).await;
+        (pr, recv, subscriber)
+    }
+
+    /// Same, but hands back the session's outgoing queue so a test can see what
+    /// went to the peer rather than only what changed in memory.
+    async fn make_pair_with_outgoing(
+        request_id: u64,
+    ) -> (
+        PublishReceived,
+        PublishReceivedRecv,
+        crate::session::Subscriber,
+        Queue<message::Message>,
+    ) {
+        let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+        let outgoing = Queue::default();
+        let subscriber = crate::session::Subscriber::new(
+            outgoing.clone(),
+            loopback_session().await,
+            None,
+            RequestId::new(0, 1),
+            bidi_task_tx,
+        );
+        let (writer, reader) =
+            Track::new(TrackNamespace::from_utf8_path("test"), "0.mp4").produce();
+        let (pr, recv) = PublishReceivedRecv::produce(
+            subscriber.clone(),
+            request_id,
+            42,
+            TrackNamespace::from_utf8_path("test"),
+            "0.mp4".into(),
+            true,
+            None,
+            writer,
+            reader,
+        );
+        (pr, recv, subscriber, outgoing)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn take_reader_returns_once() {
+        let (mut pr, _recv, _sub) = make_pair(0).await;
+        assert!(pr.take_reader().is_ok());
+        assert!(
+            pr.take_reader().is_err(),
+            "reader must only be given out once"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn recv_done_closes_writer_and_sets_state() {
+        let (_pr, mut recv, _sub) = make_pair(1).await;
+        assert!(recv.writer.is_some());
+
+        recv.recv_done(message::PublishDoneCode::TrackEnded as u64);
+
+        assert!(
+            recv.writer.is_none(),
+            "writer must be dropped after PUBLISH_DONE"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn closed_returns_ok_for_track_ended() {
+        let (pr, mut recv, _sub) = make_pair(3).await;
+
+        recv.recv_done(message::PublishDoneCode::TrackEnded as u64);
+
+        assert_eq!(pr.closed().await, Ok(()));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn closed_returns_error_for_non_track_ended() {
+        let (pr, mut recv, _sub) = make_pair(4).await;
+
+        recv.recv_done(message::PublishDoneCode::Expired as u64);
+
+        assert!(matches!(
+            pr.closed().await,
+            Err(ServeError::Closed(code)) if code == message::PublishDoneCode::Expired as u64
+        ));
+    }
+
+    /// Draft-18 removed the dedicated PUBLISH_OK type and made REQUEST_OK the
+    /// response to PUBLISH (§10.5). Answering with the old type left direct
+    /// PUBLISH unable to interoperate: a conforming peer rejects it, and its own
+    /// REQUEST_OK was routed to the PUBLISH_NAMESPACE handler, so the publish
+    /// never resolved.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn accept_answers_with_request_ok() {
+        let (mut pr, _recv, _sub, mut outgoing) = make_pair_with_outgoing(6).await;
+
+        pr.accept(false).expect("accept a fresh PUBLISH");
+
+        let sent = outgoing
+            .pop()
+            .await
+            .expect("acceptance is sent to the peer");
+        let message::Message::RequestOk(msg) = sent else {
+            panic!(
+                "PUBLISH must be accepted with REQUEST_OK, got {}",
+                sent.name()
+            );
+        };
+        assert_eq!(msg.id, 6, "the response carries the request it answers");
+        assert_eq!(
+            msg.params.forward().unwrap(),
+            Some(false),
+            "the Forward state asked for is carried on the acceptance"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn publish_received_drop_without_ok_does_not_panic() {
+        let (pr, _recv, _sub) = make_pair(5).await;
+        // Drop without calling ok() — should send REQUEST_ERROR, not panic.
+        drop(pr);
+    }
+}

--- a/moq-transport/src/session/published.rs
+++ b/moq-transport/src/session/published.rs
@@ -1,0 +1,400 @@
+// SPDX-FileCopyrightText: 2026 Cloudflare Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Outbound PUBLISH handling: a publisher sends PUBLISH, receives PUBLISH_OK
+//! or REQUEST_ERROR, serves Objects, and terminates with PUBLISH_DONE.
+//!
+//! The data-plane serving path is shared with SUBSCRIBE serving through
+//! `ObjectForwarder`; PUBLISH-specific state stays in `Published`.
+//!
+//! Draft-18: the request and everything that follows it live on one bidi
+//! stream, so PUBLISH_DONE goes out through `stream` (the request stream's
+//! sink) rather than the session's control-stream queue.
+
+use std::ops;
+
+use crate::{
+    coding::{Location, ReasonPhrase, TrackName, TrackNamespace},
+    message::{self, Message},
+    serve::{ServeError, TrackReader},
+    watch::State,
+};
+
+use super::{DeliveryFilter, ObjectForwarder, Publisher, SessionError};
+
+/// Sink for messages this endpoint writes on its own PUBLISH request stream.
+pub(crate) type RequestStreamSink = tokio::sync::mpsc::UnboundedSender<Message>;
+
+#[derive(Debug, Clone)]
+pub struct PublishedInfo {
+    pub id: u64,
+    pub track_namespace: TrackNamespace,
+    pub track_name: TrackName,
+    pub track_alias: u64,
+    pub forward: bool,
+    pub largest_location: Option<Location>,
+}
+
+#[derive(Debug)]
+pub(crate) struct PublishedState {
+    ok: bool,
+    forward: bool,
+    unsubscribed: bool,
+    closed: Result<(), ServeError>,
+    /// Subgroup streams opened while serving, recorded when the forwarder
+    /// finishes so `Drop` can report it. Draft-18 requires PUBLISH_DONE to carry
+    /// the exact count, because the subscriber uses it to know how many streams
+    /// may still arrive; reporting 0 tells it to discard state immediately and
+    /// drop objects that were legitimately sent.
+    stream_count: u64,
+}
+
+impl PublishedState {
+    fn new(forward: bool) -> Self {
+        Self {
+            ok: false,
+            forward,
+            unsubscribed: false,
+            closed: Ok(()),
+            stream_count: 0,
+        }
+    }
+}
+
+/// Outbound PUBLISH created by [`Publisher::publish`].
+///
+/// Dropping without calling [`serve`](Self::serve) sends PUBLISH_DONE with a
+/// generic terminal status. Calling `serve` runs the shared object forwarder;
+/// dropping after the data-plane loop has stopped sends PUBLISH_DONE from this
+/// handle.
+#[must_use = "serve or drop to send PUBLISH_DONE"]
+pub struct Published {
+    publisher: Publisher,
+    stream: RequestStreamSink,
+    state: State<PublishedState>,
+    track: Option<TrackReader>,
+
+    pub info: PublishedInfo,
+}
+
+impl Published {
+    pub(super) fn new(
+        publisher: Publisher,
+        stream: RequestStreamSink,
+        info: PublishedInfo,
+        state: State<PublishedState>,
+        track: TrackReader,
+    ) -> Self {
+        Self {
+            publisher,
+            stream,
+            state,
+            track: Some(track),
+            info,
+        }
+    }
+
+    /// Wait until the subscriber accepts, which draft-18 answers with
+    /// REQUEST_OK (§10.5).
+    pub async fn ok(&mut self) -> Result<(), ServeError> {
+        loop {
+            {
+                let state = self.state.lock();
+                state.closed.clone()?;
+                if state.ok {
+                    return Ok(());
+                }
+                match state.modified() {
+                    Some(notify) => notify,
+                    None => return Err(ServeError::Done),
+                }
+            }
+            .await;
+        }
+    }
+
+    /// Wait until this PUBLISH is closed or rejected.
+    pub async fn closed(&self) -> Result<(), ServeError> {
+        loop {
+            {
+                let state = self.state.lock();
+                state.closed.clone()?;
+                match state.modified() {
+                    Some(notify) => notify,
+                    None => return Ok(()),
+                }
+            }
+            .await;
+        }
+    }
+
+    /// Serve Objects for this PUBLISH using the same data-plane path as
+    /// SUBSCRIBE serving.
+    ///
+    /// This waits for PUBLISH_OK before serving. The draft allows serving
+    /// before PUBLISH_OK but does not require it; waiting keeps the first cut
+    /// simple.
+    pub async fn serve(mut self) -> Result<(), SessionError> {
+        let res = self.serve_inner().await;
+        if let Err(err) = &res {
+            self.close_state(err.clone().into())?;
+        }
+
+        res
+    }
+
+    async fn serve_inner(&mut self) -> Result<(), SessionError> {
+        self.ok().await?;
+
+        let forward = self.state.lock().forward;
+        if !forward {
+            let track = self.track.take().ok_or(SessionError::Internal)?;
+            let res = tokio::select! {
+                res = track.closed() => res,
+                res = self.closed() => res,
+            };
+            return match res {
+                Ok(()) | Err(ServeError::Done | ServeError::Cancel) => Ok(()),
+                Err(err) => Err(err.into()),
+            };
+        }
+
+        let track = self.track.take().ok_or(SessionError::Internal)?;
+        let (mut forwarder, recv) =
+            ObjectForwarder::new(self.publisher.clone(), self.info.track_alias, None);
+        self.publisher
+            .register_published_subscription(self.info.id, recv)?;
+
+        let largest_location = track.largest_location();
+        forwarder.set_largest_location(largest_location)?;
+        let delivery_filter = DeliveryFilter {
+            forward,
+            start_location: None,
+            end_group_id: None,
+        };
+
+        let result = match forwarder.serve(track, delivery_filter).await {
+            Err(SessionError::Serve(ServeError::Cancel)) => Ok(()),
+            res => res,
+        };
+
+        // Record the count before the forwarder goes out of scope; `Drop` needs
+        // it for PUBLISH_DONE and has no other way to reach it.
+        self.record_stream_count(forwarder.stream_count());
+
+        result
+    }
+
+    /// Store the number of subgroup streams opened, for PUBLISH_DONE on drop.
+    fn record_stream_count(&self, stream_count: u64) {
+        let Ok(state) = self.state.try_lock() else {
+            tracing::error!(
+                request_id = self.info.id,
+                "published state lock poisoned; PUBLISH_DONE will under-report stream count"
+            );
+            return;
+        };
+        if let Some(mut state) = state.into_mut() {
+            state.stream_count = stream_count;
+        }
+    }
+
+    pub fn close(self, err: ServeError) -> Result<(), ServeError> {
+        self.close_state(err)
+    }
+
+    fn close_state(&self, err: ServeError) -> Result<(), ServeError> {
+        let state = self
+            .state
+            .try_lock()
+            .map_err(|_| ServeError::internal_ctx("published state lock poisoned"))?;
+        state.closed.clone()?;
+
+        let mut state = state.into_mut().ok_or(ServeError::Done)?;
+        state.closed = Err(err);
+
+        Ok(())
+    }
+}
+
+impl ops::Deref for Published {
+    type Target = PublishedInfo;
+
+    fn deref(&self) -> &Self::Target {
+        &self.info
+    }
+}
+
+impl Drop for Published {
+    fn drop(&mut self) {
+        let state = match self.state.try_lock() {
+            Ok(state) => state,
+            Err(_) => {
+                tracing::error!(
+                    request_id = self.info.id,
+                    "published state lock poisoned while dropping PUBLISH"
+                );
+                return;
+            }
+        };
+        let Some(err) = publish_done_error_on_drop(&state) else {
+            return;
+        };
+        let stream_count = state.stream_count;
+        drop(state);
+
+        self.publisher.drop_published(self.info.id);
+
+        if self
+            .stream
+            .send(
+                message::PublishDone {
+                    id: self.info.id,
+                    status_code: publish_done_code(&err),
+                    stream_count,
+                    reason: ReasonPhrase("publish ended".to_string()),
+                }
+                .into(),
+            )
+            .is_err()
+        {
+            tracing::debug!(
+                request_id = self.info.id,
+                "PUBLISH request stream already closed; PUBLISH_DONE not sent"
+            );
+        }
+    }
+}
+
+pub(crate) struct PublishedRecv {
+    state: State<PublishedState>,
+}
+
+impl PublishedRecv {
+    pub fn new(state: State<PublishedState>) -> Self {
+        Self { state }
+    }
+
+    pub fn recv_ok(&mut self, msg: &message::RequestOk) -> Result<(), ServeError> {
+        let forward = msg
+            .params
+            .forward()
+            .map_err(|_| ServeError::internal_ctx("invalid FORWARD in PUBLISH acceptance"))?;
+
+        if let Some(mut state) = self.state.lock_mut() {
+            state.ok = true;
+            if let Some(forward) = forward {
+                state.forward = forward;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn recv_error(&mut self, err: ServeError) -> Result<(), ServeError> {
+        if let Some(mut state) = self.state.lock_mut() {
+            state.closed = Err(err);
+        }
+        Ok(())
+    }
+
+    pub fn recv_unsubscribe(&mut self) -> Result<(), ServeError> {
+        let state = self.state.lock();
+        state.closed.clone()?;
+
+        if let Some(mut state) = state.into_mut() {
+            state.unsubscribed = true;
+            state.closed = Err(ServeError::Cancel);
+        }
+
+        Ok(())
+    }
+}
+
+pub(crate) fn split_published_state(
+    forward: bool,
+) -> (State<PublishedState>, State<PublishedState>) {
+    State::new(PublishedState::new(forward)).split()
+}
+
+fn publish_done_code(err: &ServeError) -> u64 {
+    match err {
+        ServeError::Done => message::PublishDoneCode::TrackEnded as u64,
+        ServeError::Closed(code) => *code,
+        _ => message::PublishDoneCode::InternalError as u64,
+    }
+}
+
+fn publish_done_error_on_drop(state: &PublishedState) -> Option<ServeError> {
+    // If the subscriber rejected the PUBLISH with REQUEST_ERROR before it
+    // became established, the request is already terminal (§5.1). If the
+    // subscriber sent UNSUBSCRIBE, it already terminated its side.
+    if state.unsubscribed || (!state.ok && state.closed.is_err()) {
+        return None;
+    }
+
+    Some(
+        state
+            .closed
+            .as_ref()
+            .err()
+            .cloned()
+            .unwrap_or(ServeError::Done),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::coding::KeyValuePairs;
+
+    #[test]
+    fn recv_ok_sets_forward_when_present() {
+        let (_send, recv_state) = split_published_state(true);
+        let mut recv = PublishedRecv::new(recv_state);
+        let mut params = KeyValuePairs::default();
+        params.set_forward(false);
+
+        recv.recv_ok(&message::RequestOk { id: 0, params }).unwrap();
+
+        assert!(!recv.state.lock().forward);
+        assert!(recv.state.lock().ok);
+    }
+
+    #[test]
+    fn publish_done_code_maps_done_to_track_ended() {
+        assert_eq!(
+            publish_done_code(&ServeError::Done),
+            message::PublishDoneCode::TrackEnded as u64
+        );
+    }
+
+    #[test]
+    fn drop_terminal_error_sends_done_after_accepted_normal_completion() {
+        let mut state = PublishedState::new(true);
+        state.ok = true;
+
+        assert_eq!(publish_done_error_on_drop(&state), Some(ServeError::Done));
+    }
+
+    #[test]
+    fn drop_terminal_error_skips_pre_accept_rejection() {
+        let mut state = PublishedState::new(true);
+        state.closed = Err(ServeError::Closed(123));
+
+        assert_eq!(publish_done_error_on_drop(&state), None);
+    }
+
+    #[test]
+    fn recv_unsubscribe_marks_unsubscribed_and_closes() {
+        let (_send, recv_state) = split_published_state(true);
+        let mut recv = PublishedRecv::new(recv_state);
+
+        recv.recv_unsubscribe().unwrap();
+
+        let state = recv.state.lock();
+        assert!(state.unsubscribed);
+        assert!(matches!(state.closed, Err(ServeError::Cancel)));
+        assert_eq!(publish_done_error_on_drop(&state), None);
+    }
+}

--- a/moq-transport/src/session/publisher.rs
+++ b/moq-transport/src/session/publisher.rs
@@ -10,19 +10,46 @@ use std::{
 use futures::{stream::FuturesUnordered, StreamExt};
 
 use crate::{
-    coding::TrackNamespace,
+    coding::{KeyValuePairs, TrackNamespace, TrackNamespacePrefix},
     message::{self, Message},
     mlog,
-    serve::{FullTrackName, ServeError, TracksReader},
+    serve::{FullTrackName, ServeError, TrackReader, TracksReader},
 };
 
 use crate::watch::Queue;
 
 use super::{
-    PublishNamespace, PublishNamespaceRecv, RequestId, Session, SessionError, Subscribed,
-    SubscribedRecv, TrackStatusRequested,
+    split_published_state, ObjectForwarderRecv, PublishNamespace, PublishNamespaceRecv, Published,
+    PublishedInfo, PublishedRecv, RequestId, Session, SessionError, Subscribed,
+    SubscribedNamespace, SubscribedNamespaceInfo, SubscribedNamespaceRecv, TrackStatusRequested,
 };
 use crate::message::RequestErrorCode;
+
+/// Publisher-side state for one outbound PUBLISH.
+///
+/// The forwarder half only exists once serving starts, so UNSUBSCRIBE has to
+/// cancel both the request state and (if present) the data-plane loop.
+struct PublishedEntry {
+    recv: PublishedRecv,
+    forwarder: Option<ObjectForwarderRecv>,
+}
+
+impl PublishedEntry {
+    fn new(recv: PublishedRecv) -> Self {
+        Self {
+            recv,
+            forwarder: None,
+        }
+    }
+
+    fn recv_unsubscribe(&mut self) -> Result<(), ServeError> {
+        self.recv.recv_unsubscribe()?;
+        if let Some(forwarder) = &mut self.forwarder {
+            forwarder.recv_unsubscribe()?;
+        }
+        Ok(())
+    }
+}
 
 // TODO remove Clone.
 #[derive(Clone)]
@@ -32,9 +59,16 @@ pub struct Publisher {
     /// Active outbound PUBLISH_NAMESPACE requests, keyed by namespace.
     publish_namespaces: Arc<Mutex<HashMap<TrackNamespace, PublishNamespaceRecv>>>,
 
+    /// Active outbound PUBLISH requests, keyed by request id.
+    publisheds: Arc<Mutex<HashMap<u64, PublishedEntry>>>,
+
+    /// Active outbound PUBLISHes keyed by Full Track Name, for the §5.1
+    /// same-role duplicate-subscription check.
+    published_names: Arc<Mutex<HashMap<FullTrackName, u64>>>,
+
     /// When a Subscribe is received and we have a matching publish_namespace entry, the
     /// subscription is routed to that PublishNamespaceRecv.  Otherwise it goes here.
-    subscribeds: Arc<Mutex<HashMap<u64, SubscribedRecv>>>,
+    subscribeds: Arc<Mutex<HashMap<u64, ObjectForwarderRecv>>>,
 
     /// Active inbound SUBSCRIBEs keyed by Full Track Name.
     subscribed_names: Arc<Mutex<HashMap<FullTrackName, u64>>>,
@@ -44,6 +78,12 @@ pub struct Publisher {
 
     /// TRACK_STATUS requests for namespaces that have no matching PUBLISH_NAMESPACE.
     unknown_track_status_requested: Queue<TrackStatusRequested>,
+
+    /// Active inbound SUBSCRIBE_NAMESPACE prefixes, keyed by Request ID.
+    subscribed_namespace_prefixes: Arc<Mutex<HashMap<u64, TrackNamespacePrefix>>>,
+
+    /// SUBSCRIBE_NAMESPACE requests surfaced to the application.
+    unknown_subscribed_namespace: Queue<SubscribedNamespace>,
 
     /// Queue for outbound control messages; processed by the session run_send task.
     outgoing: Queue<Message>,
@@ -75,10 +115,14 @@ impl Publisher {
         Self {
             webtransport,
             publish_namespaces: Default::default(),
+            publisheds: Default::default(),
+            published_names: Default::default(),
             subscribeds: Default::default(),
             subscribed_names: Default::default(),
             unknown_subscribed: Default::default(),
             unknown_track_status_requested: Default::default(),
+            subscribed_namespace_prefixes: Default::default(),
+            unknown_subscribed_namespace: Default::default(),
             outgoing,
             request_id,
             mlog,
@@ -145,7 +189,7 @@ impl Publisher {
             if let Ok(mut ns) = self.publish_namespaces.lock() {
                 ns.remove(&tracks.namespace);
             }
-            return Err(e.into());
+            return Err(e);
         }
 
         // Hand a reader future for responses on this bidi stream to
@@ -160,16 +204,13 @@ impl Publisher {
                 match Session::decode_bidi_response(&mut reader, bidi_request_id).await {
                     Ok(msg) => {
                         if let Ok(sub_msg) = TryInto::<message::Subscriber>::try_into(msg) {
-                            if let Err(e) = this.recv_message(sub_msg) {
-                                tracing::warn!(error = %e, "error handling bidi response");
-                                break;
-                            }
+                            // Propagate instead of logging: Session::run closes the
+                            // session for protocol violations and ignores the rest.
+                            this.recv_message(sub_msg)?;
                         }
                     }
-                    Err(e) => {
-                        tracing::debug!(error = %e, bidi_request_id, "bidi response reader ended");
-                        break;
-                    }
+                    Err(err) if err.is_stream_ended() => return Ok(()),
+                    Err(err) => return Err(err),
                 }
             }
         }));
@@ -221,6 +262,249 @@ impl Publisher {
                 Some(res) = status_tasks.next() => res,
                 else => return Ok(()),
             }
+        }
+    }
+
+    /// Offer a single track to the peer with PUBLISH (draft-18 §10.13).
+    ///
+    /// The request gets its own bidi stream: PUBLISH goes out on it, PUBLISH_OK
+    /// / REQUEST_ERROR / UNSUBSCRIBE come back on it, and PUBLISH_DONE is
+    /// written on it when the returned handle is dropped. `Session::run` must
+    /// be driven concurrently, since it polls the stream's reader.
+    ///
+    /// `Published::ok()` is unbounded, matching `Subscriber::subscribe_open`.
+    /// A peer that accepts the stream and never answers is caught only by the
+    /// QUIC idle timeout, so a caller that needs a tighter bound must impose
+    /// its own.
+    pub async fn publish(
+        &mut self,
+        track: TrackReader,
+        mut params: KeyValuePairs,
+    ) -> Result<Published, SessionError> {
+        let full_name = FullTrackName {
+            namespace: track.namespace.clone(),
+            name: track.name.clone(),
+        };
+
+        if let Some(largest) = track.largest_location() {
+            params
+                .set_largest_object(largest)
+                .map_err(|_| SessionError::Internal)?;
+        }
+
+        let forward = params
+            .forward()
+            .map_err(SessionError::Decode)?
+            .unwrap_or(true);
+        let largest_location = params.largest_object().map_err(SessionError::Decode)?;
+
+        // §5.1: this endpoint can have at most one publisher-role subscription
+        // per track. Inbound SUBSCRIBE and outbound PUBLISH both make us the
+        // publisher, so the duplicate check spans both maps and stays atomic
+        // with the name reservation.
+        let request_id = {
+            let subscribed_names = self
+                .subscribed_names
+                .lock()
+                .map_err(|_| SessionError::Internal)?;
+            let mut published_names = self
+                .published_names
+                .lock()
+                .map_err(|_| SessionError::Internal)?;
+            if subscribed_names.contains_key(&full_name) || published_names.contains_key(&full_name)
+            {
+                return Err(SessionError::Serve(ServeError::Duplicate));
+            }
+
+            let request_id = self.request_id.allocate()?;
+            published_names.insert(full_name, request_id);
+            request_id
+        };
+
+        // The request ID doubles as the Track Alias, matching SUBSCRIBE serving.
+        let track_alias = request_id;
+
+        let info = PublishedInfo {
+            id: request_id,
+            track_namespace: track.namespace.clone(),
+            track_name: track.name.clone(),
+            track_alias,
+            forward,
+            largest_location,
+        };
+
+        let (published_state, recv_state) = split_published_state(forward);
+
+        // Register response state before the PUBLISH goes out so a fast
+        // PUBLISH_OK / REQUEST_ERROR has somewhere to land.
+        match self.publisheds.lock() {
+            Ok(mut publisheds) => {
+                publisheds.insert(
+                    request_id,
+                    PublishedEntry::new(PublishedRecv::new(recv_state)),
+                );
+            }
+            Err(_) => {
+                self.drop_published_name(request_id);
+                return Err(SessionError::Internal);
+            }
+        }
+
+        let msg = message::Publish {
+            id: request_id,
+            track_namespace: info.track_namespace.clone(),
+            track_name: info.track_name.clone(),
+            track_alias,
+            params,
+            track_extensions: Default::default(),
+        };
+
+        let stream = match self.open_publish_stream(request_id, msg).await {
+            Ok(stream) => stream,
+            Err(err) => {
+                self.drop_published(request_id);
+                return Err(err);
+            }
+        };
+
+        Ok(Published::new(
+            self.clone(),
+            stream,
+            info,
+            published_state,
+            track,
+        ))
+    }
+
+    /// Open the PUBLISH request stream and hand its reader/writer pump to
+    /// `Session::run`.
+    ///
+    /// Returns the sink used to write follow-up messages (PUBLISH_DONE) on the
+    /// same stream. The pump is polled by `run` under structured concurrency,
+    /// so it cannot outlive the session.
+    async fn open_publish_stream(
+        &mut self,
+        request_id: u64,
+        msg: message::Publish,
+    ) -> Result<super::RequestStreamSink, SessionError> {
+        let (send_stream, recv_stream) = self.webtransport.open_bi().await?;
+        let mut writer = super::Writer::new(send_stream);
+        writer.encode(&Message::Publish(msg)).await?;
+
+        let (stream_tx, mut stream_rx) = tokio::sync::mpsc::unbounded_channel::<Message>();
+        let mut this = self.clone();
+
+        if self
+            .bidi_task_tx
+            .send(Box::pin(async move {
+                let mut reader = super::Reader::new(recv_stream);
+                // The peer may finish its half as soon as it has replied
+                // PUBLISH_OK. That does not end the request, so reading stops
+                // while the write half stays open for PUBLISH_DONE.
+                let mut reading = true;
+
+                let result = loop {
+                    tokio::select! {
+                        // Messages we write on our own request stream
+                        // (PUBLISH_DONE). Draft-18 omits the Request ID here.
+                        outgoing = stream_rx.recv() => {
+                            let Some(outgoing) = outgoing else { break Ok(()) };
+                            let terminal = matches!(outgoing, Message::PublishDone(_));
+                            if let Err(err) = Session::encode_bidi_response(&mut writer, &outgoing).await {
+                                tracing::debug!(request_id, error = %err, "failed writing on PUBLISH request stream");
+                                break Ok(());
+                            }
+                            if terminal {
+                                break Ok(());
+                            }
+                        }
+                        // Not cancellation-safe: a frame half-read when the
+                        // write branch wins is lost. Safe only because that
+                        // branch always breaks out of the loop.
+                        response = Session::decode_bidi_response(&mut reader, request_id), if reading => {
+                            match response {
+                                Ok(msg) => match TryInto::<message::Subscriber>::try_into(msg) {
+                                    Ok(sub_msg) => {
+                                        if let Err(err) = this.recv_message(sub_msg) {
+                                            break Err(err);
+                                        }
+                                    }
+                                    Err(msg) => tracing::warn!(
+                                        request_id,
+                                        msg_type = msg.name(),
+                                        "unexpected message on PUBLISH request stream"
+                                    ),
+                                },
+                                Err(err) if err.is_stream_ended() => {
+                                    tracing::debug!(request_id, error = %err, "PUBLISH response reader ended");
+                                    reading = false;
+                                }
+                                // An undecodable frame is not a resynchronisation
+                                // point: draft-18 requires closing the session on an
+                                // unknown message type, so this must not be skipped.
+                                Err(err) => break Err(err),
+                            }
+                        }
+                    }
+                };
+
+                // Fail the handle if the stream died before PUBLISH_DONE, so a
+                // caller waiting on `ok()` or `closed()` is not stuck forever.
+                // Runs on every exit path, including the error ones.
+                this.abort_published(request_id);
+                let _ = writer.finish();
+                result
+            }))
+            .is_err()
+        {
+            return Err(SessionError::Internal);
+        }
+
+        Ok(stream_tx)
+    }
+
+    /// Attach the data-plane half of an outbound PUBLISH so a later
+    /// UNSUBSCRIBE can stop it.
+    pub(super) fn register_published_subscription(
+        &mut self,
+        id: u64,
+        forwarder: ObjectForwarderRecv,
+    ) -> Result<(), SessionError> {
+        let mut publisheds = self.publisheds.lock().map_err(|_| SessionError::Internal)?;
+        let entry = publisheds.get_mut(&id).ok_or(SessionError::Internal)?;
+        entry.forwarder = Some(forwarder);
+        Ok(())
+    }
+
+    pub(super) fn drop_published(&self, id: u64) {
+        let _ = self.remove_published(id);
+    }
+
+    /// Fail an outbound PUBLISH whose request stream ended without a terminal
+    /// message. A no-op once the handle has been dropped, since `Published`
+    /// removes its own entry when it sends PUBLISH_DONE.
+    fn abort_published(&self, id: u64) {
+        let Some(mut published) = self.remove_published(id) else {
+            return;
+        };
+
+        tracing::debug!(
+            request_id = id,
+            "PUBLISH request stream closed before completion"
+        );
+        if let Err(err) = published.recv.recv_error(ServeError::Cancel) {
+            tracing::debug!(request_id = id, error = %err, "failed to fail aborted PUBLISH");
+        }
+    }
+
+    fn remove_published(&self, id: u64) -> Option<PublishedEntry> {
+        self.drop_published_name(id);
+        self.publisheds.lock().ok()?.remove(&id)
+    }
+
+    fn drop_published_name(&self, id: u64) {
+        if let Ok(mut names) = self.published_names.lock() {
+            names.retain(|_, request_id| *request_id != id);
         }
     }
 
@@ -277,6 +561,61 @@ impl Publisher {
         self.unknown_track_status_requested.pop().await
     }
 
+    /// Returns the next inbound SUBSCRIBE_NAMESPACE request.
+    pub async fn subscribed_namespace(&mut self) -> Option<SubscribedNamespace> {
+        self.unknown_subscribed_namespace.pop().await
+    }
+
+    /// Accept an inbound SUBSCRIBE_NAMESPACE and surface it to the application.
+    ///
+    /// Returns the transport-side half, which the caller drives with the
+    /// request stream's writer and reader. Overlapping prefixes are rejected
+    /// without reaching the application.
+    pub(super) fn recv_subscribe_namespace(
+        &mut self,
+        msg: message::SubscribeNamespace,
+    ) -> Result<SubscribedNamespaceRecv, SessionError> {
+        let forward = msg.params.forward()?.unwrap_or(true);
+
+        {
+            let mut prefixes = self
+                .subscribed_namespace_prefixes
+                .lock()
+                .map_err(|_| SessionError::Internal)?;
+            if Self::has_subscribed_namespace_overlap(&prefixes, &msg.track_namespace_prefix) {
+                return Ok(SubscribedNamespaceRecv::rejected(
+                    msg.id,
+                    RequestErrorCode::PrefixOverlap as u64,
+                    "prefix overlap",
+                ));
+            }
+            prefixes.insert(msg.id, msg.track_namespace_prefix.clone());
+        }
+
+        let info = SubscribedNamespaceInfo {
+            request_id: msg.id,
+            namespace_prefix: msg.track_namespace_prefix,
+            subscribe_options: msg.subscribe_options,
+            forward,
+        };
+        let (mut send, recv) =
+            SubscribedNamespace::new(info, self.subscribed_namespace_prefixes.clone());
+
+        if let Err(send_back) = self.unknown_subscribed_namespace.push(send) {
+            send = send_back;
+            send.reject(RequestErrorCode::InternalError as u64, "internal error")?;
+        }
+
+        Ok(recv)
+    }
+
+    fn has_subscribed_namespace_overlap(
+        prefixes: &HashMap<u64, TrackNamespacePrefix>,
+        prefix: &TrackNamespacePrefix,
+    ) -> bool {
+        prefixes.values().any(|existing| existing.overlaps(prefix))
+    }
+
     fn add_mlog_event<F>(&self, make_event: F)
     where
         F: FnOnce(f64) -> mlog::Event,
@@ -318,10 +657,12 @@ impl Publisher {
             message::Subscriber::RequestUpdate(msg) => {
                 self.send_not_supported(msg.id, "request_update");
             }
-            // Draft-16: REQUEST_OK from subscriber is acceptance of PUBLISH_NAMESPACE.
-            message::Subscriber::RequestOk(msg) => self.recv_publish_namespace_ok(msg)?,
-            // Draft-16: REQUEST_ERROR from subscriber is rejection of PUBLISH_NAMESPACE.
-            message::Subscriber::RequestError(msg) => self.recv_publish_namespace_error(msg)?,
+            // REQUEST_OK from a subscriber accepts either our PUBLISH_NAMESPACE
+            // or our PUBLISH; the request ID says which.
+            message::Subscriber::RequestOk(msg) => self.recv_request_ok(msg)?,
+            // REQUEST_ERROR from a subscriber rejects either our PUBLISH_NAMESPACE
+            // or our PUBLISH; the request ID says which.
+            message::Subscriber::RequestError(msg) => self.recv_request_error(msg)?,
             message::Subscriber::Unsubscribe(msg) => self.recv_unsubscribe(msg)?,
             // FETCH not yet implemented — send REQUEST_ERROR NOT_SUPPORTED (§4).
             message::Subscriber::Fetch(msg) => {
@@ -343,14 +684,22 @@ impl Publisher {
             message::Subscriber::PublishNamespaceCancel(msg) => {
                 self.recv_publish_namespace_cancel(msg)?;
             }
-            // PUBLISH_OK is for publisher-initiated subscriptions, which are not
-            // yet implemented — log and ignore.
+            // Draft-18 removed the dedicated PUBLISH_OK type in favour of
+            // REQUEST_OK, so we never send it. Accepting it on receive keeps
+            // draft-16 peers working and costs nothing, since the payload is the
+            // same shape. Retiring the type belongs with the other draft-16
+            // leftovers still decoded here.
             message::Subscriber::PublishOk(msg) => {
                 tracing::debug!(
                     target: "moq_transport::control",
                     request_id = msg.id,
-                    "received PUBLISH_OK for unsupported PUBLISH — ignoring"
+                    "PUBLISH accepted with the draft-16 PUBLISH_OK type"
                 );
+                let msg = message::RequestOk {
+                    id: msg.id,
+                    params: msg.params,
+                };
+                self.recv_publish_ok(&msg)?;
             }
         }
 
@@ -378,32 +727,98 @@ impl Publisher {
         );
     }
 
-    /// Handle REQUEST_OK from subscriber — acceptance of our PUBLISH_NAMESPACE (draft-16 §9.7).
-    fn recv_publish_namespace_ok(&mut self, msg: message::RequestOk) -> Result<(), SessionError> {
-        self.log_request_ok_parsed("publish_namespace", &msg);
-        // The publish_namespaces map is keyed by namespace; we must search by request_id.
-        // TODO(itzmanish): maintain a second index keyed by request_id to make this O(1).
-        let mut namespaces = self
-            .publish_namespaces
-            .lock()
-            .map_err(|_| SessionError::Internal)?;
-        if let Some(entry) = namespaces.iter_mut().find(|(_k, v)| v.request_id == msg.id) {
-            entry.1.recv_ok()?;
+    /// Handle REQUEST_OK from a subscriber, accepting one of our requests
+    /// (draft-18 §10.5).
+    ///
+    /// One message type answers PUBLISH_NAMESPACE and PUBLISH alike, so the
+    /// request ID decides which, exactly as it does for REQUEST_ERROR. Guessing
+    /// from the type instead would resolve a PUBLISH as a namespace
+    /// registration and leave the publish waiting forever.
+    fn recv_request_ok(&mut self, msg: message::RequestOk) -> Result<(), SessionError> {
+        if self.recv_publish_namespace_ok(&msg)? {
+            return Ok(());
         }
 
+        if self.recv_publish_ok(&msg)? {
+            return Ok(());
+        }
+
+        self.log_request_ok_parsed("unknown", &msg);
+        tracing::debug!(
+            target: "moq_transport::control",
+            request_id = msg.id,
+            "received REQUEST_OK for an unknown request, ignoring"
+        );
         Ok(())
     }
 
-    /// Handle REQUEST_ERROR from subscriber — rejection of our PUBLISH_NAMESPACE (draft-16 §9.8).
-    fn recv_publish_namespace_error(
+    /// Acceptance of an outbound PUBLISH_NAMESPACE. Returns whether the request
+    /// ID matched one.
+    fn recv_publish_namespace_ok(
         &mut self,
-        msg: message::RequestError,
-    ) -> Result<(), SessionError> {
-        self.log_request_error_parsed("publish_namespace", &msg);
-        if let Some(recv) = self.drop_publish_namespace(msg.id) {
-            recv.recv_error(ServeError::Closed(msg.error_code))?;
+        msg: &message::RequestOk,
+    ) -> Result<bool, SessionError> {
+        let matched = {
+            // The publish_namespaces map is keyed by namespace; we must search by request_id.
+            // TODO(itzmanish): maintain a second index keyed by request_id to make this O(1).
+            let mut namespaces = self
+                .publish_namespaces
+                .lock()
+                .map_err(|_| SessionError::Internal)?;
+            match namespaces.iter_mut().find(|(_k, v)| v.request_id == msg.id) {
+                Some(entry) => {
+                    entry.1.recv_ok()?;
+                    true
+                }
+                None => false,
+            }
+        };
+
+        if matched {
+            self.log_request_ok_parsed("publish_namespace", msg);
         }
+        Ok(matched)
+    }
+
+    /// Handle REQUEST_ERROR from a subscriber — rejection of an outbound
+    /// PUBLISH_NAMESPACE or PUBLISH (draft-16 §9.8).
+    fn recv_request_error(&mut self, msg: message::RequestError) -> Result<(), SessionError> {
+        if let Some(recv) = self.drop_publish_namespace(msg.id) {
+            self.log_request_error_parsed("publish_namespace", &msg);
+            recv.recv_error(ServeError::Closed(msg.error_code))?;
+            return Ok(());
+        }
+
+        if let Some(mut published) = self.remove_published(msg.id) {
+            self.log_request_error_parsed("publish", &msg);
+            published
+                .recv
+                .recv_error(ServeError::Closed(msg.error_code))?;
+            return Ok(());
+        }
+
+        self.log_request_error_parsed("unknown", &msg);
         Ok(())
+    }
+
+    /// Acceptance of an outbound PUBLISH. Returns whether the request ID matched
+    /// one.
+    fn recv_publish_ok(&mut self, msg: &message::RequestOk) -> Result<bool, SessionError> {
+        let matched = {
+            let mut publisheds = self.publisheds.lock().map_err(|_| SessionError::Internal)?;
+            match publisheds.get_mut(&msg.id) {
+                Some(entry) => {
+                    entry.recv.recv_ok(msg)?;
+                    true
+                }
+                None => false,
+            }
+        };
+
+        if matched {
+            self.log_request_ok_parsed("publish", msg);
+        }
+        Ok(matched)
     }
 
     fn recv_publish_namespace_cancel(
@@ -521,25 +936,38 @@ impl Publisher {
         Ok(())
     }
 
+    /// Handle UNSUBSCRIBE, which terminates either an inbound SUBSCRIBE we are
+    /// serving or an outbound PUBLISH the peer no longer wants. The request ID
+    /// alone does not say which, so both maps are checked.
     fn recv_unsubscribe(&mut self, msg: message::Unsubscribe) -> Result<(), SessionError> {
-        {
+        let known_subscribe = {
             let mut subscribeds = self
                 .subscribeds
                 .lock()
                 .map_err(|_| SessionError::Internal)?;
-            let subscribed = subscribeds.get_mut(&msg.id).ok_or_else(|| {
-                SessionError::ProtocolViolation(format!(
-                    "UNSUBSCRIBE for unknown subscribe ID {}",
-                    msg.id
-                ))
-            })?;
+            match subscribeds.get_mut(&msg.id) {
+                Some(subscribed) => {
+                    subscribed.recv_unsubscribe()?;
+                    true
+                }
+                None => false,
+            }
+        };
 
-            subscribed.recv_unsubscribe()?;
+        if known_subscribe {
+            self.remove_subscribe(msg.id)?;
+            return Ok(());
         }
 
-        self.remove_subscribe(msg.id)?;
+        if let Some(mut published) = self.remove_published(msg.id) {
+            published.recv_unsubscribe()?;
+            return Ok(());
+        }
 
-        Ok(())
+        Err(SessionError::ProtocolViolation(format!(
+            "UNSUBSCRIBE for unknown subscribe ID {}",
+            msg.id
+        )))
     }
 
     /// Pre-send hook: clean up internal state when terminal publisher messages are enqueued.

--- a/moq-transport/src/session/subscribe.rs
+++ b/moq-transport/src/session/subscribe.rs
@@ -307,11 +307,6 @@ impl SubscribeRecv {
         Ok(())
     }
 
-    pub fn track_alias(&self) -> Option<u64> {
-        let state = self.state.lock();
-        state.track_alias
-    }
-
     pub fn error(mut self, err: ServeError) -> Result<(), ServeError> {
         if let Some(writer) = self.writer.take() {
             writer.close(err.clone())?;

--- a/moq-transport/src/session/subscribe_namespace.rs
+++ b/moq-transport/src/session/subscribe_namespace.rs
@@ -1,0 +1,669 @@
+// SPDX-FileCopyrightText: 2026 Cloudflare Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Outbound SUBSCRIBE_NAMESPACE handling.
+
+use std::{
+    collections::HashSet,
+    ops,
+    sync::{Arc, Mutex},
+};
+
+use futures::channel::oneshot;
+
+use crate::{
+    coding::{TrackNamespace, TrackNamespacePrefix},
+    message::{self, Message, SubscribeOptions},
+    mlog,
+    serve::ServeError,
+    watch::State,
+};
+
+use super::{Reader, Session, SessionError, Subscriber, Writer};
+
+/// Safety bound on the number of distinct namespaces tracked for a single
+/// SUBSCRIBE_NAMESPACE response stream. A misbehaving upstream could otherwise
+/// send unbounded NAMESPACE additions and exhaust memory; exceeding it closes the
+/// stream with a protocol violation. Chosen high enough not to affect legitimate
+/// broad-prefix discovery.
+const MAX_KNOWN_NAMESPACE_SUFFIXES: usize = 1 << 20;
+
+/// Cap on events queued for the application but not yet read. Bounds the memory a
+/// peer can make this endpoint hold by churning NAMESPACE and NAMESPACE_DONE for
+/// the same namespaces faster than the application drains them.
+const MAX_PENDING_NAMESPACE_EVENTS: usize = 1 << 16;
+
+/// Whether the response stream carries on after a message.
+///
+/// Named rather than a bool because two different questions were being answered
+/// by the same `false`: whether a message changed anything worth reporting to the
+/// application, and whether the subscription is over. Only the second may end the
+/// loop, and draft-18 §14.4 gives that meaning to a FIN or reset of the response
+/// stream, not to a message we chose to ignore.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum ResponseFlow {
+    /// Keep reading the response stream.
+    Continue,
+    /// The subscription is over: the request was refused, or nothing is left
+    /// listening for its events.
+    Ended,
+}
+
+#[derive(Debug, Clone)]
+pub struct SubscribeNamespaceInfo {
+    pub request_id: u64,
+    pub namespace_prefix: TrackNamespacePrefix,
+    pub subscribe_options: SubscribeOptions,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum NamespaceEvent {
+    Added(TrackNamespace),
+    Removed(TrackNamespace),
+}
+
+struct SubscribeNamespaceState {
+    ok: bool,
+    events: std::collections::VecDeque<NamespaceEvent>,
+    closed: Result<(), ServeError>,
+}
+
+impl Default for SubscribeNamespaceState {
+    fn default() -> Self {
+        Self {
+            ok: false,
+            events: Default::default(),
+            closed: Ok(()),
+        }
+    }
+}
+
+impl SubscribeNamespaceState {
+    /// Queue an event for the application, refusing to grow without bound.
+    ///
+    /// Suppressing duplicate additions bounds this by the active namespace count,
+    /// but a peer can still churn add/remove pairs faster than an application
+    /// drains them, so the queue needs its own limit.
+    fn queue_event(&mut self, event: NamespaceEvent) -> Result<(), SessionError> {
+        if self.events.len() >= MAX_PENDING_NAMESPACE_EVENTS {
+            return Err(SessionError::ProtocolViolation(format!(
+                "SUBSCRIBE_NAMESPACE response exceeded {} pending namespace events",
+                MAX_PENDING_NAMESPACE_EVENTS
+            )));
+        }
+        self.events.push_back(event);
+        Ok(())
+    }
+}
+
+/// Outbound SUBSCRIBE_NAMESPACE request.
+///
+/// This handle only exposes `NAMESPACE` / `NAMESPACE_DONE` updates from the
+/// request's dedicated bidirectional stream. If the request used
+/// `SubscribeOptions::Publish` or `SubscribeOptions::Both`, matching `PUBLISH`
+/// messages arrive on their own request streams and are surfaced via
+/// [`Subscriber::publish_received`].
+#[must_use = "cancels SUBSCRIBE_NAMESPACE on drop"]
+pub struct SubscribeNamespace {
+    state: State<SubscribeNamespaceState>,
+    // Keep the request half after FIN so a cancellation timeout can still reset it (§6.1).
+    writer: Option<Writer>,
+    request_finished: bool,
+    force_reset: Option<oneshot::Sender<u32>>,
+
+    pub info: SubscribeNamespaceInfo,
+}
+
+impl SubscribeNamespace {
+    pub(super) fn new(
+        subscriber: Subscriber,
+        info: SubscribeNamespaceInfo,
+        writer: Writer,
+    ) -> (Self, SubscribeNamespaceRecv) {
+        let (send_state, recv_state) = State::default().split();
+        let (force_reset, recv_force_reset) = oneshot::channel();
+        let recv = SubscribeNamespaceRecv {
+            state: recv_state,
+            request_id: info.request_id,
+            namespace_prefix: info.namespace_prefix.clone(),
+            responded: false,
+            known_suffixes: HashSet::default(),
+            max_known_suffixes: MAX_KNOWN_NAMESPACE_SUFFIXES,
+            subscriber,
+            force_reset: Some(recv_force_reset),
+        };
+        let send = Self {
+            state: send_state,
+            writer: Some(writer),
+            request_finished: false,
+            force_reset: Some(force_reset),
+            info,
+        };
+
+        (send, recv)
+    }
+
+    pub async fn ok(&self) -> Result<(), ServeError> {
+        loop {
+            {
+                let state = self.state.lock();
+                state.closed.clone()?;
+                if state.ok {
+                    return Ok(());
+                }
+
+                match state.modified() {
+                    Some(notify) => notify,
+                    None => return Err(ServeError::Done),
+                }
+            }
+            .await;
+        }
+    }
+
+    /// Cancel the request gracefully with FIN while continuing to receive its response.
+    pub fn finish_request(&mut self) -> Result<(), SessionError> {
+        if self.request_finished {
+            return Ok(());
+        }
+
+        self.request_finished = true;
+        match self.writer.as_mut() {
+            Some(writer) => writer.finish(),
+            None => Ok(()),
+        }
+    }
+
+    /// Force both halves of this request stream closed without closing the session.
+    pub fn reset_request(&mut self, code: u32) {
+        let Some(force_reset) = self.force_reset.take() else {
+            return;
+        };
+
+        let _ = force_reset.send(code);
+        if let Some(mut writer) = self.writer.take() {
+            writer.reset(code);
+        }
+    }
+
+    pub async fn next(&self) -> Result<Option<NamespaceEvent>, ServeError> {
+        loop {
+            {
+                let state = self.state.lock();
+                if !state.events.is_empty() {
+                    return Ok(state.into_mut_closed().events.pop_front());
+                }
+
+                state.closed.clone()?;
+                match state.modified() {
+                    Some(notify) => notify,
+                    None => return Ok(None),
+                }
+            }
+            .await;
+        }
+    }
+
+    pub async fn closed(&self) -> Result<(), ServeError> {
+        loop {
+            {
+                let state = self.state.lock();
+                state.closed.clone()?;
+
+                match state.modified() {
+                    Some(notify) => notify,
+                    None => return Ok(()),
+                }
+            }
+            .await;
+        }
+    }
+}
+
+impl ops::Deref for SubscribeNamespace {
+    type Target = SubscribeNamespaceInfo;
+
+    fn deref(&self) -> &Self::Target {
+        &self.info
+    }
+}
+
+pub(super) struct SubscribeNamespaceRecv {
+    state: State<SubscribeNamespaceState>,
+    request_id: u64,
+    namespace_prefix: TrackNamespacePrefix,
+    responded: bool,
+    known_suffixes: HashSet<TrackNamespacePrefix>,
+    max_known_suffixes: usize,
+    subscriber: Subscriber,
+    force_reset: Option<oneshot::Receiver<u32>>,
+}
+
+impl SubscribeNamespaceRecv {
+    pub async fn run(
+        mut self,
+        mut reader: Reader,
+        mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
+    ) -> Result<(), SessionError> {
+        let mut force_reset = self.force_reset.take().ok_or(SessionError::Internal)?;
+
+        tokio::select! {
+            biased;
+            reset = &mut force_reset => {
+                if let Ok(code) = reset {
+                    reader.stop(code);
+                }
+                Ok(())
+            }
+            result = self.run_response(&mut reader, &mlog) => {
+                match result {
+                    Err(err) if err.is_stream_error() => Ok(()),
+                    result => result,
+                }
+            }
+        }
+    }
+
+    async fn run_response(
+        &mut self,
+        reader: &mut Reader,
+        mlog: &Option<Arc<Mutex<mlog::MlogWriter>>>,
+    ) -> Result<(), SessionError> {
+        loop {
+            if self.responded && reader.done().await? {
+                return Ok(());
+            }
+
+            // Draft-18: responses on a request's own bidi stream omit the
+            // Request ID, so the stream's known request ID is injected here
+            // rather than read off the wire.
+            let msg = Session::decode_bidi_response(reader, self.request_id).await?;
+            self.emit_mlog(mlog, &msg);
+            if self.recv_message(msg)? == ResponseFlow::Ended {
+                return Ok(());
+            }
+        }
+    }
+
+    fn emit_mlog(&self, mlog: &Option<Arc<Mutex<mlog::MlogWriter>>>, msg: &Message) {
+        if let Some(mlog) = mlog {
+            if let Ok(mut mlog) = mlog.lock() {
+                let time = mlog.elapsed_ms();
+                let event = match msg {
+                    Message::RequestOk(msg) => Some(mlog::events::request_ok_parsed(
+                        time,
+                        0,
+                        "subscribe_namespace",
+                        msg,
+                    )),
+                    Message::RequestError(msg) => Some(mlog::events::request_error_parsed(
+                        time,
+                        0,
+                        "subscribe_namespace",
+                        msg,
+                    )),
+                    Message::Namespace(msg) => Some(mlog::events::namespace_parsed(time, 0, msg)),
+                    Message::NamespaceDone(msg) => {
+                        Some(mlog::events::namespace_done_parsed(time, 0, msg))
+                    }
+                    _ => None,
+                };
+                if let Some(event) = event {
+                    let _ = mlog.add_event(event);
+                }
+            }
+        }
+    }
+
+    fn recv_message(&mut self, msg: Message) -> Result<ResponseFlow, SessionError> {
+        match msg {
+            Message::RequestOk(_) if !self.responded => {
+                self.responded = true;
+                self.recv_ok();
+                Ok(ResponseFlow::Continue)
+            }
+            Message::RequestError(msg) if !self.responded => {
+                self.responded = true;
+                self.recv_error(ServeError::Closed(msg.error_code));
+                Ok(ResponseFlow::Ended)
+            }
+            Message::Namespace(msg) if self.responded => self.recv_namespace(msg),
+            Message::NamespaceDone(msg) if self.responded => self.recv_namespace_done(msg),
+            Message::RequestOk(_) | Message::RequestError(_) => {
+                Err(SessionError::ProtocolViolation(
+                    "SUBSCRIBE_NAMESPACE response stream received multiple request responses"
+                        .to_string(),
+                ))
+            }
+            other => Err(SessionError::ProtocolViolation(format!(
+                "unexpected {} on SUBSCRIBE_NAMESPACE response stream",
+                other.name()
+            ))),
+        }
+    }
+
+    fn recv_ok(&mut self) {
+        if let Some(mut state) = self.state.lock_mut() {
+            state.ok = true;
+        }
+    }
+
+    fn recv_error(&mut self, err: ServeError) {
+        if let Some(mut state) = self.state.lock_mut() {
+            state.closed = Err(err);
+        }
+    }
+
+    fn recv_namespace(&mut self, msg: message::Namespace) -> Result<ResponseFlow, SessionError> {
+        let namespace = self
+            .namespace_prefix
+            .join_suffix(&msg.track_namespace_suffix)
+            .map_err(|err| {
+                SessionError::ProtocolViolation(format!(
+                    "invalid NAMESPACE suffix for SUBSCRIBE_NAMESPACE: {}",
+                    err
+                ))
+            })?;
+
+        if !self.known_suffixes.contains(&msg.track_namespace_suffix)
+            && self.known_suffixes.len() >= self.max_known_suffixes
+        {
+            return Err(SessionError::ProtocolViolation(format!(
+                "SUBSCRIBE_NAMESPACE response exceeded {} active namespaces",
+                self.max_known_suffixes
+            )));
+        }
+
+        if !self.known_suffixes.insert(msg.track_namespace_suffix) {
+            // Already active, so nothing changed and there is nothing to report.
+            // Queuing an event per duplicate is how the active-set cap gets
+            // bypassed: the set does not grow, so the cap above never trips while
+            // `events` grows without bound. Repeating a NAMESPACE is not a
+            // violation, so the subscription carries on.
+            return Ok(ResponseFlow::Continue);
+        }
+
+        let Some(mut state) = self.state.lock_mut() else {
+            return Ok(ResponseFlow::Ended);
+        };
+        state.queue_event(NamespaceEvent::Added(namespace))?;
+        Ok(ResponseFlow::Continue)
+    }
+
+    fn recv_namespace_done(
+        &mut self,
+        msg: message::NamespaceDone,
+    ) -> Result<ResponseFlow, SessionError> {
+        if !self.known_suffixes.remove(&msg.track_namespace_suffix) {
+            return Err(SessionError::ProtocolViolation(
+                "NAMESPACE_DONE received before corresponding NAMESPACE".to_string(),
+            ));
+        }
+
+        let namespace = self
+            .namespace_prefix
+            .join_suffix(&msg.track_namespace_suffix)
+            .map_err(|err| {
+                SessionError::ProtocolViolation(format!(
+                    "invalid NAMESPACE_DONE suffix for SUBSCRIBE_NAMESPACE: {}",
+                    err
+                ))
+            })?;
+
+        let Some(mut state) = self.state.lock_mut() else {
+            return Ok(ResponseFlow::Ended);
+        };
+        state.queue_event(NamespaceEvent::Removed(namespace))?;
+        Ok(ResponseFlow::Continue)
+    }
+}
+
+impl Drop for SubscribeNamespaceRecv {
+    fn drop(&mut self) {
+        self.subscriber.remove_subscribe_namespace(self.request_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        message::RequestOk,
+        session::{test_support::loopback_session, RequestId},
+        watch::Queue,
+    };
+
+    use super::*;
+
+    async fn subscriber() -> Subscriber {
+        let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+        Subscriber::new(
+            Queue::default(),
+            loopback_session().await,
+            None,
+            RequestId::new(0, 1),
+            bidi_task_tx,
+        )
+    }
+
+    async fn recv(prefix: &str) -> SubscribeNamespaceRecv {
+        let info = SubscribeNamespaceInfo {
+            request_id: 0,
+            namespace_prefix: TrackNamespacePrefix::from_utf8_path(prefix),
+            subscribe_options: SubscribeOptions::Namespace,
+        };
+        SubscribeNamespaceRecv {
+            state: State::<SubscribeNamespaceState>::default(),
+            request_id: info.request_id,
+            namespace_prefix: info.namespace_prefix,
+            responded: false,
+            known_suffixes: HashSet::default(),
+            max_known_suffixes: MAX_KNOWN_NAMESPACE_SUFFIXES,
+            subscriber: subscriber().await,
+            force_reset: None,
+        }
+    }
+
+    async fn pair(prefix: &str) -> (SubscribeNamespace, SubscribeNamespaceRecv) {
+        let info = SubscribeNamespaceInfo {
+            request_id: 0,
+            namespace_prefix: TrackNamespacePrefix::from_utf8_path(prefix),
+            subscribe_options: SubscribeOptions::Namespace,
+        };
+        let subscriber = subscriber().await;
+        let (send_state, recv_state) = State::default().split();
+        let (force_reset, recv_force_reset) = oneshot::channel();
+
+        (
+            SubscribeNamespace {
+                state: send_state,
+                writer: None,
+                request_finished: false,
+                force_reset: Some(force_reset),
+                info: info.clone(),
+            },
+            SubscribeNamespaceRecv {
+                state: recv_state,
+                request_id: info.request_id,
+                namespace_prefix: info.namespace_prefix,
+                responded: false,
+                known_suffixes: HashSet::default(),
+                max_known_suffixes: MAX_KNOWN_NAMESPACE_SUFFIXES,
+                subscriber,
+                force_reset: Some(recv_force_reset),
+            },
+        )
+    }
+
+    fn request_ok() -> Message {
+        Message::RequestOk(RequestOk {
+            id: 0,
+            params: Default::default(),
+        })
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn queued_event_is_drained_after_response_fin() {
+        let (subscribe, mut recv) = pair("example.com").await;
+        recv.recv_message(request_ok()).unwrap();
+        recv.recv_message(Message::Namespace(message::Namespace {
+            track_namespace_suffix: TrackNamespacePrefix::from_utf8_path("meeting=123"),
+        }))
+        .unwrap();
+
+        drop(recv);
+
+        assert_eq!(
+            subscribe.next().await.unwrap(),
+            Some(NamespaceEvent::Added(TrackNamespace::from_utf8_path(
+                "example.com/meeting=123"
+            )))
+        );
+        assert_eq!(subscribe.next().await.unwrap(), None);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn graceful_finish_keeps_response_half_open() {
+        let (mut subscribe, mut recv) = pair("example.com").await;
+
+        subscribe.finish_request().unwrap();
+        subscribe.finish_request().unwrap();
+
+        assert!(subscribe.request_finished);
+        assert_eq!(recv.force_reset.as_mut().unwrap().try_recv().unwrap(), None);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn forced_reset_signals_response_half() {
+        let (mut subscribe, mut recv) = pair("example.com").await;
+        let force_reset = recv.force_reset.take().unwrap();
+
+        subscribe.reset_request(42);
+
+        assert_eq!(force_reset.await.unwrap(), 42);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn request_ok_marks_subscription_ok() {
+        let mut recv = recv("example.com").await;
+
+        assert_eq!(
+            recv.recv_message(request_ok()).unwrap(),
+            ResponseFlow::Continue
+        );
+
+        assert!(recv.state.lock().ok);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn namespace_event_reconstructs_full_namespace() {
+        let mut recv = recv("example.com/meeting=123").await;
+        recv.recv_message(request_ok()).unwrap();
+
+        recv.recv_message(Message::Namespace(message::Namespace {
+            track_namespace_suffix: TrackNamespacePrefix::from_utf8_path("participant=100"),
+        }))
+        .unwrap();
+
+        let event = recv.state.lock_mut().unwrap().events.pop_front().unwrap();
+        assert_eq!(
+            event,
+            NamespaceEvent::Added(TrackNamespace::from_utf8_path(
+                "example.com/meeting=123/participant=100"
+            ))
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn namespace_done_before_namespace_is_protocol_violation() {
+        let mut recv = recv("example.com").await;
+        recv.recv_message(request_ok()).unwrap();
+
+        let err = recv
+            .recv_message(Message::NamespaceDone(message::NamespaceDone {
+                track_namespace_suffix: TrackNamespacePrefix::from_utf8_path("meeting=123"),
+            }))
+            .unwrap_err();
+
+        assert!(matches!(err, SessionError::ProtocolViolation(_)));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn second_request_response_is_protocol_violation() {
+        let mut recv = recv("example.com").await;
+        recv.recv_message(request_ok()).unwrap();
+
+        let err = recv.recv_message(request_ok()).unwrap_err();
+
+        assert!(matches!(err, SessionError::ProtocolViolation(_)));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn namespace_additions_are_capped() {
+        let mut recv = recv("example.com").await;
+        recv.max_known_suffixes = 2;
+        recv.recv_message(request_ok()).unwrap();
+
+        for i in 0..recv.max_known_suffixes {
+            recv.recv_message(Message::Namespace(message::Namespace {
+                track_namespace_suffix: TrackNamespacePrefix::from_utf8_path(&format!(
+                    "meeting={i}"
+                )),
+            }))
+            .expect("additions up to the cap are accepted");
+        }
+
+        // A new distinct suffix beyond the cap is rejected as a protocol violation.
+        let err = recv
+            .recv_message(Message::Namespace(message::Namespace {
+                track_namespace_suffix: TrackNamespacePrefix::from_utf8_path("meeting=overflow"),
+            }))
+            .unwrap_err();
+        assert!(matches!(err, SessionError::ProtocolViolation(_)));
+
+        // Re-adding an already-tracked suffix does not grow the set, so it is allowed.
+        recv.recv_message(Message::Namespace(message::Namespace {
+            track_namespace_suffix: TrackNamespacePrefix::from_utf8_path("meeting=0"),
+        }))
+        .expect("re-adding a tracked suffix stays within the cap");
+    }
+
+    /// A duplicate NAMESPACE does not change the active set, so it must not queue
+    /// another event. Otherwise a peer repeating one NAMESPACE forever grows the
+    /// event queue without ever tripping the active-set cap.
+    ///
+    /// It must also leave the subscription running. Suppressing the event by
+    /// reporting "nothing happened" as the same value that means "the response is
+    /// over" ended the stream instead, so the relay saw discovery finish and
+    /// dropped its upstream registration, on a message the peer was entitled to
+    /// send.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn duplicate_namespace_additions_queue_one_event_and_keep_the_stream() {
+        let mut recv = recv("example.com").await;
+        recv.recv_message(request_ok()).unwrap();
+
+        let namespace = || {
+            Message::Namespace(message::Namespace {
+                track_namespace_suffix: TrackNamespacePrefix::from_utf8_path("meeting=0"),
+            })
+        };
+
+        for _ in 0..50 {
+            assert_eq!(
+                recv.recv_message(namespace()).unwrap(),
+                ResponseFlow::Continue
+            );
+        }
+
+        assert_eq!(recv.state.lock().events.len(), 1);
+
+        // Still live afterwards: a subsequent distinct namespace is reported.
+        assert_eq!(
+            recv.recv_message(Message::Namespace(message::Namespace {
+                track_namespace_suffix: TrackNamespacePrefix::from_utf8_path("meeting=1"),
+            }))
+            .unwrap(),
+            ResponseFlow::Continue
+        );
+        assert_eq!(recv.state.lock().events.len(), 2);
+    }
+}

--- a/moq-transport/src/session/subscribed.rs
+++ b/moq-transport/src/session/subscribed.rs
@@ -20,7 +20,7 @@ use super::{DeliveryFilter, Publisher, SessionError, SubscribeInfo, Writer};
 // This file defines Publisher handling of inbound Subscriptions
 
 #[derive(Debug)]
-struct SubscribedState {
+struct ObjectForwarderState {
     largest_location: Option<Location>,
     stream_count: u64,
     /// Set to true when UNSUBSCRIBE is received.  When true, Drop skips sending
@@ -29,7 +29,7 @@ struct SubscribedState {
     closed: Result<(), ServeError>,
 }
 
-impl SubscribedState {
+impl ObjectForwarderState {
     fn record_stream_opened(&mut self) {
         self.stream_count = self.stream_count.saturating_add(1);
     }
@@ -46,7 +46,7 @@ impl SubscribedState {
     }
 }
 
-impl Default for SubscribedState {
+impl Default for ObjectForwarderState {
     fn default() -> Self {
         Self {
             largest_location: None,
@@ -58,21 +58,126 @@ impl Default for SubscribedState {
 }
 
 pub struct Subscribed {
-    /// The sessions Publisher manager, used to send control messages,
-    /// create new QUIC streams, and send datagrams
-    publisher: Publisher,
-
     /// The tracknamespace and trackname for the subscription.
     pub info: SubscribeInfo,
 
-    state: State<SubscribedState>,
+    /// Data-plane half, shared with outbound PUBLISH serving.
+    forwarder: ObjectForwarder,
 
     /// Tracks if SubscribeOk has been sent yet or not. Used to send
     /// PUBLISH_DONE vs REQUEST_ERROR on drop.
     ok: bool,
+}
+
+/// Serves a track's Objects on a session, keyed by Track Alias.
+///
+/// SUBSCRIBE-initiated ([`Subscribed`]) and PUBLISH-initiated
+/// ([`super::Published`]) subscriptions differ only in how they are set up and
+/// torn down; the object-sending loop is identical, so it lives here.
+pub(super) struct ObjectForwarder {
+    /// The session's Publisher manager, used to send control messages,
+    /// create new QUIC streams, and send datagrams.
+    publisher: Publisher,
+
+    state: State<ObjectForwarderState>,
+
+    /// Track Alias carried in every subgroup header and datagram we emit.
+    track_alias: u64,
 
     /// Optional mlog writer for logging transport events
     mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
+}
+
+impl ObjectForwarder {
+    pub(super) fn new(
+        publisher: Publisher,
+        track_alias: u64,
+        mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
+    ) -> (Self, ObjectForwarderRecv) {
+        let (send, recv) = State::default().split();
+        let send = Self {
+            publisher,
+            state: send,
+            track_alias,
+            mlog,
+        };
+        let recv = ObjectForwarderRecv { state: recv };
+        (send, recv)
+    }
+
+    pub(super) fn set_largest_location(
+        &self,
+        largest_location: Option<Location>,
+    ) -> Result<(), ServeError> {
+        self.state
+            .lock_mut()
+            .ok_or(ServeError::Cancel)?
+            .largest_location = largest_location;
+        Ok(())
+    }
+
+    /// Subgroup streams opened so far. The PUBLISH path needs this separately
+    /// from [`Self::terminal_state`], because there the terminal message is sent
+    /// by `Published::drop` after the forwarder is gone.
+    pub(super) fn stream_count(&self) -> u64 {
+        self.state.lock().stream_count
+    }
+
+    /// Snapshot the fields a terminal message needs, without holding the lock
+    /// across the send that follows.
+    fn terminal_state(&self) -> (ServeError, u64, bool) {
+        let state = self.state.lock();
+        let err = state
+            .closed
+            .as_ref()
+            .err()
+            .cloned()
+            .unwrap_or(ServeError::Done);
+        (err, state.stream_count, state.unsubscribed)
+    }
+
+    fn close(&self, err: ServeError) -> Result<(), ServeError> {
+        let state = self.state.lock();
+        state.closed.clone()?;
+
+        let mut state = state.into_mut().ok_or(ServeError::Done)?;
+        state.closed = Err(err);
+
+        Ok(())
+    }
+
+    pub(super) async fn closed(&self) -> Result<(), ServeError> {
+        loop {
+            {
+                let state = self.state.lock();
+                state.closed.clone()?;
+
+                match state.modified() {
+                    Some(notify) => notify,
+                    None => return Ok(()),
+                }
+            }
+            .await;
+        }
+    }
+
+    pub(super) async fn serve(
+        &mut self,
+        track: serve::TrackReader,
+        delivery_filter: DeliveryFilter,
+    ) -> Result<(), SessionError> {
+        match track.mode().await? {
+            TrackReaderMode::Stream(_stream) => Err(SessionError::Serve(
+                ServeError::not_implemented_ctx("stream track reader mode"),
+            )),
+            TrackReaderMode::Subgroups(subgroups) => {
+                self.serve_subgroups(subgroups, delivery_filter).await
+            }
+            TrackReaderMode::Datagrams(datagrams) => {
+                self.serve_datagrams(datagrams, delivery_filter).await
+            }
+        }
+    }
 }
 
 impl Subscribed {
@@ -80,19 +185,15 @@ impl Subscribed {
         publisher: Publisher,
         msg: message::Subscribe,
         mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
-    ) -> Result<(Self, SubscribedRecv), SessionError> {
-        let (send, recv) = State::default().split();
+    ) -> Result<(Self, ObjectForwarderRecv), SessionError> {
         let info = SubscribeInfo::new_from_subscribe(&msg)?;
+        // The subscription's request ID doubles as its Track Alias.
+        let (forwarder, recv) = ObjectForwarder::new(publisher, info.id, mlog);
         let send = Self {
-            publisher,
-            state: send,
             info,
+            forwarder,
             ok: false,
-            mlog,
         };
-
-        // Prevents updates after being closed
-        let recv = SubscribedRecv { state: recv };
 
         Ok((send, recv))
     }
@@ -109,10 +210,7 @@ impl Subscribed {
     async fn serve_inner(&mut self, track: serve::TrackReader) -> Result<(), SessionError> {
         // Update largest location before sending SubscribeOk
         let largest_location = track.largest_location();
-        self.state
-            .lock_mut()
-            .ok_or(ServeError::Cancel)?
-            .largest_location = largest_location;
+        self.forwarder.set_largest_location(largest_location)?;
 
         // Send SubscribeOk using send_message_and_wait to ensure it is sent at least to the QUIC stack before
         // we start serving the track.  If a subscriber gets the stream before SubscribeOk
@@ -124,7 +222,8 @@ impl Subscribed {
                 .map_err(|_| SessionError::Internal)?;
         }
 
-        self.publisher
+        self.forwarder
+            .publisher
             .send_message_and_wait(message::SubscribeOk {
                 id: self.info.id,
                 track_alias: self.info.id, // use subscription id as track alias
@@ -137,42 +236,15 @@ impl Subscribed {
 
         let delivery_filter = self.info.delivery_filter(largest_location);
 
-        // Serve based on track mode
-        match track.mode().await? {
-            // TODO cancel track/datagrams on closed
-            TrackReaderMode::Stream(_stream) => panic!("deprecated"),
-            TrackReaderMode::Subgroups(subgroups) => {
-                self.serve_subgroups(subgroups, delivery_filter).await
-            }
-            TrackReaderMode::Datagrams(datagrams) => {
-                self.serve_datagrams(datagrams, delivery_filter).await
-            }
-        }
+        self.forwarder.serve(track, delivery_filter).await
     }
 
     pub fn close(self, err: ServeError) -> Result<(), ServeError> {
-        let state = self.state.lock();
-        state.closed.clone()?;
-
-        let mut state = state.into_mut().ok_or(ServeError::Done)?;
-        state.closed = Err(err);
-
-        Ok(())
+        self.forwarder.close(err)
     }
 
     pub async fn closed(&self) -> Result<(), ServeError> {
-        loop {
-            {
-                let state = self.state.lock();
-                state.closed.clone()?;
-
-                match state.modified() {
-                    Some(notify) => notify,
-                    None => return Ok(()),
-                }
-            }
-            .await;
-        }
+        self.forwarder.closed().await
     }
 }
 
@@ -186,16 +258,7 @@ impl ops::Deref for Subscribed {
 
 impl Drop for Subscribed {
     fn drop(&mut self) {
-        let state = self.state.lock();
-        let err = state
-            .closed
-            .as_ref()
-            .err()
-            .cloned()
-            .unwrap_or(ServeError::Done);
-        let stream_count = state.stream_count;
-        let unsubscribed = state.unsubscribed;
-        drop(state); // Important to avoid a deadlock
+        let (err, stream_count, unsubscribed) = self.forwarder.terminal_state();
 
         // Subscriber already sent UNSUBSCRIBE — no terminal message needed.
         if unsubscribed {
@@ -203,7 +266,7 @@ impl Drop for Subscribed {
         }
 
         if self.ok {
-            self.publisher.send_message(message::PublishDone {
+            self.forwarder.publisher.send_message(message::PublishDone {
                 id: self.info.id,
                 status_code: Self::publish_done_code(&err),
                 stream_count,
@@ -212,7 +275,7 @@ impl Drop for Subscribed {
         } else {
             // Draft-16 §9.8: subscription rejection uses REQUEST_ERROR, not the
             // legacy SUBSCRIBE_ERROR.
-            self.publisher.send_request_error(
+            self.forwarder.publisher.send_request_error(
                 "subscribe",
                 message::RequestError {
                     id: self.info.id,
@@ -221,7 +284,7 @@ impl Drop for Subscribed {
                     reason: ReasonPhrase(err.to_string()),
                 },
             );
-            self.publisher.drop_subscribe(self.info.id);
+            self.forwarder.publisher.drop_subscribe(self.info.id);
         };
     }
 }
@@ -259,7 +322,9 @@ impl Subscribed {
             SessionError::Serve(ServeError::Cancel | ServeError::Done)
         )
     }
+}
 
+impl ObjectForwarder {
     async fn serve_subgroups(
         &mut self,
         mut subgroups: serve::SubgroupsReader,
@@ -274,7 +339,7 @@ impl Subscribed {
                     Ok(Some(subgroup)) => {
                         let header = data::SubgroupHeader {
                             header_type: data::StreamHeaderType::SubgroupIdExt,  // SubGroupId = Yes, Extensions = Yes, ContainsEndOfGroup = No
-                            track_alias: self.info.id, // use subscription id as track_alias
+                            track_alias: self.track_alias,
                             group_id: subgroup.group_id,
                             subgroup_id: Some(subgroup.subgroup_id),
                             publisher_priority: subgroup.priority,
@@ -287,7 +352,7 @@ impl Subscribed {
 
                         tasks.push(async move {
                             if let Err(err) = Self::serve_subgroup(header, subgroup, publisher, state, mlog, delivery_filter).await {
-                                if Self::is_expected_serve_shutdown(&err) {
+                                if Subscribed::is_expected_serve_shutdown(&err) {
                                     tracing::debug!(subgroup_info = ?info, error = %err, "stopped serving subgroup");
                                 } else {
                                     tracing::warn!(subgroup_info = ?info, error = %err, "failed to serve subgroup");
@@ -300,7 +365,9 @@ impl Subscribed {
                 },
                 res = self.closed(), if done.is_none() => done = Some(res),
                 _ = tasks.next(), if !tasks.is_empty() => {},
-                else => return Ok(done.unwrap()?),
+                // Reached only once both the subgroup source and `closed()` are
+                // disabled, which requires `done` to be set.
+                else => return Ok(done.ok_or(SessionError::Internal)??),
             }
         }
     }
@@ -309,7 +376,7 @@ impl Subscribed {
         header: data::SubgroupHeader,
         mut subgroup_reader: serve::SubgroupReader,
         mut publisher: Publisher,
-        state: State<SubscribedState>,
+        state: State<ObjectForwarderState>,
         mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
         delivery_filter: DeliveryFilter,
     ) -> Result<(), SessionError> {
@@ -484,7 +551,7 @@ impl Subscribed {
 
             let encoded_datagram = data::Datagram {
                 datagram_type,
-                track_alias: self.info.id, // use subscription id as track_alias
+                track_alias: self.track_alias,
                 group_id: datagram.group_id,
                 object_id: Some(datagram.object_id),
                 publisher_priority: datagram.priority,
@@ -552,11 +619,11 @@ impl Subscribed {
     }
 }
 
-pub(super) struct SubscribedRecv {
-    state: State<SubscribedState>,
+pub(super) struct ObjectForwarderRecv {
+    state: State<ObjectForwarderState>,
 }
 
-impl SubscribedRecv {
+impl ObjectForwarderRecv {
     pub fn recv_unsubscribe(&mut self) -> Result<(), ServeError> {
         let state = self.state.lock();
         state.closed.clone()?;
@@ -576,7 +643,7 @@ mod tests {
 
     #[test]
     fn subscribed_state_counts_opened_streams() {
-        let mut state = SubscribedState::default();
+        let mut state = ObjectForwarderState::default();
         assert_eq!(state.stream_count, 0);
 
         state.record_stream_opened();
@@ -588,9 +655,9 @@ mod tests {
 
     #[test]
     fn recv_unsubscribe_marks_unsubscribed_and_closes() {
-        let state = State::<SubscribedState>::default();
+        let state = State::<ObjectForwarderState>::default();
         let (_send, recv_state) = state.split();
-        let mut recv = SubscribedRecv { state: recv_state };
+        let mut recv = ObjectForwarderRecv { state: recv_state };
 
         assert!(!recv.state.lock().unsubscribed);
 

--- a/moq-transport/src/session/subscribed_namespace.rs
+++ b/moq-transport/src/session/subscribed_namespace.rs
@@ -1,0 +1,497 @@
+// SPDX-FileCopyrightText: 2026 Cloudflare Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Inbound SUBSCRIBE_NAMESPACE handling.
+
+use std::{
+    collections::HashMap,
+    ops,
+    sync::{Arc, Mutex},
+};
+
+use crate::{
+    coding::{ReasonPhrase, TrackNamespace, TrackNamespacePrefix},
+    message::{self, Message, RequestErrorCode, SubscribeOptions},
+    mlog,
+    serve::ServeError,
+    watch::State,
+};
+
+use super::{Reader, Session, SessionError, Writer};
+
+/// Capacity of the per-subscription outbound message queue. Bounds memory when a
+/// downstream reader is slow: rather than buffering namespace updates without
+/// limit under sustained churn, a full queue tears the subscription down (the peer
+/// can re-subscribe and receive a fresh snapshot).
+const OUTGOING_QUEUE_CAPACITY: usize = 8192;
+
+#[derive(Debug, Clone)]
+pub struct SubscribedNamespaceInfo {
+    pub request_id: u64,
+    pub namespace_prefix: TrackNamespacePrefix,
+    pub subscribe_options: SubscribeOptions,
+    pub forward: bool,
+}
+
+struct SubscribedNamespaceState {
+    responded: bool,
+    closed: Result<(), ServeError>,
+    namespaces: std::collections::HashSet<TrackNamespacePrefix>,
+}
+
+impl Default for SubscribedNamespaceState {
+    fn default() -> Self {
+        Self {
+            responded: false,
+            closed: Ok(()),
+            namespaces: Default::default(),
+        }
+    }
+}
+
+#[must_use = "rejects SUBSCRIBE_NAMESPACE on drop if not accepted"]
+pub struct SubscribedNamespace {
+    state: State<SubscribedNamespaceState>,
+    outgoing: tokio::sync::mpsc::Sender<Message>,
+
+    pub info: SubscribedNamespaceInfo,
+}
+
+impl SubscribedNamespace {
+    pub(super) fn new(
+        info: SubscribedNamespaceInfo,
+        active_prefixes: Arc<Mutex<HashMap<u64, TrackNamespacePrefix>>>,
+    ) -> (Self, SubscribedNamespaceRecv) {
+        let (send_state, recv_state) = State::default().split();
+        let (send_queue, recv_queue) = tokio::sync::mpsc::channel(OUTGOING_QUEUE_CAPACITY);
+        let send = Self {
+            state: send_state,
+            outgoing: send_queue,
+            info,
+        };
+        let recv = SubscribedNamespaceRecv {
+            state: recv_state,
+            outgoing: recv_queue,
+            active_prefixes,
+            request_id: send.info.request_id,
+        };
+
+        (send, recv)
+    }
+
+    pub fn ok(&mut self) -> Result<(), ServeError> {
+        self.responded()?;
+        self.outgoing
+            .try_send(
+                message::RequestOk {
+                    id: self.info.request_id,
+                    params: Default::default(),
+                }
+                .into(),
+            )
+            .map_err(|_| ServeError::Cancel)
+    }
+
+    pub fn reject(mut self, error_code: u64, reason: &str) -> Result<(), ServeError> {
+        self.responded()?;
+        self.outgoing
+            .try_send(request_error(self.info.request_id, error_code, reason))
+            .map_err(|_| ServeError::Cancel)
+    }
+
+    pub fn namespace(&mut self, namespace: &TrackNamespace) -> Result<(), ServeError> {
+        let suffix = namespace
+            .strip_prefix(&self.info.namespace_prefix)
+            .ok_or_else(|| {
+                ServeError::internal_ctx("namespace does not match subscribed prefix")
+            })?;
+
+        {
+            let mut state = self.state.lock().into_mut().ok_or(ServeError::Cancel)?;
+            state.closed.clone()?;
+            if !state.responded {
+                return Err(ServeError::internal_ctx(
+                    "NAMESPACE before SUBSCRIBE_NAMESPACE accepted",
+                ));
+            }
+            state.namespaces.insert(suffix.clone());
+        }
+
+        self.outgoing
+            .try_send(
+                message::Namespace {
+                    track_namespace_suffix: suffix,
+                }
+                .into(),
+            )
+            .map_err(|_| ServeError::Cancel)
+    }
+
+    pub fn namespace_done(&mut self, namespace: &TrackNamespace) -> Result<(), ServeError> {
+        let suffix = namespace
+            .strip_prefix(&self.info.namespace_prefix)
+            .ok_or_else(|| {
+                ServeError::internal_ctx("namespace does not match subscribed prefix")
+            })?;
+
+        {
+            let mut state = self.state.lock().into_mut().ok_or(ServeError::Cancel)?;
+            state.closed.clone()?;
+            if !state.responded {
+                return Err(ServeError::internal_ctx(
+                    "NAMESPACE_DONE before SUBSCRIBE_NAMESPACE accepted",
+                ));
+            }
+            if !state.namespaces.remove(&suffix) {
+                return Err(ServeError::internal_ctx(
+                    "NAMESPACE_DONE before corresponding NAMESPACE",
+                ));
+            }
+        }
+
+        self.outgoing
+            .try_send(
+                message::NamespaceDone {
+                    track_namespace_suffix: suffix,
+                }
+                .into(),
+            )
+            .map_err(|_| ServeError::Cancel)
+    }
+
+    pub async fn closed(&self) -> Result<(), ServeError> {
+        loop {
+            {
+                let state = self.state.lock();
+                state.closed.clone()?;
+
+                match state.modified() {
+                    Some(notify) => notify,
+                    None => return Ok(()),
+                }
+            }
+            .await;
+        }
+    }
+
+    fn responded(&mut self) -> Result<(), ServeError> {
+        let state = self.state.lock();
+        if state.responded {
+            return Err(ServeError::Duplicate);
+        }
+        state.closed.clone()?;
+
+        let mut state = state.into_mut().ok_or(ServeError::Cancel)?;
+        state.responded = true;
+        Ok(())
+    }
+}
+
+impl Drop for SubscribedNamespace {
+    fn drop(&mut self) {
+        let should_reject = {
+            let state = self.state.lock();
+            !state.responded && state.closed.is_ok()
+        };
+
+        if should_reject {
+            let _ = self.outgoing.try_send(request_error(
+                self.info.request_id,
+                RequestErrorCode::DoesNotExist as u64,
+                "not handled",
+            ));
+        }
+    }
+}
+
+impl ops::Deref for SubscribedNamespace {
+    type Target = SubscribedNamespaceInfo;
+
+    fn deref(&self) -> &Self::Target {
+        &self.info
+    }
+}
+
+pub(super) struct SubscribedNamespaceRecv {
+    state: State<SubscribedNamespaceState>,
+    outgoing: tokio::sync::mpsc::Receiver<Message>,
+    active_prefixes: Arc<Mutex<HashMap<u64, TrackNamespacePrefix>>>,
+    request_id: u64,
+}
+
+impl SubscribedNamespaceRecv {
+    pub(super) fn rejected(request_id: u64, error_code: u64, reason: &str) -> Self {
+        let (send_queue, recv_queue) = tokio::sync::mpsc::channel(OUTGOING_QUEUE_CAPACITY);
+        let _ = send_queue.try_send(request_error(request_id, error_code, reason));
+        Self {
+            state: State::default(),
+            outgoing: recv_queue,
+            active_prefixes: Default::default(),
+            request_id,
+        }
+    }
+
+    pub async fn run(
+        mut self,
+        mut writer: Writer,
+        mut reader: Reader,
+        mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
+    ) -> Result<(), SessionError> {
+        loop {
+            tokio::select! {
+                msg = self.outgoing.recv() => {
+                    let Some(msg) = msg else {
+                        return self.finish_response(&mut writer);
+                    };
+                    if !self.send_message(&mut writer, &mlog, msg).await? {
+                        self.recv_cancel();
+                        return Ok(());
+                    }
+                }
+                done = reader.done() => {
+                    match done {
+                        Ok(true) => {
+                            self.recv_cancel();
+                            while let Some(msg) = self.outgoing.recv().await {
+                                if !self.send_message(&mut writer, &mlog, msg).await? {
+                                    return Ok(());
+                                }
+                            }
+                            return self.finish_response(&mut writer);
+                        }
+                        Ok(false) => {
+                            return Err(SessionError::ProtocolViolation(
+                                "unexpected data after SUBSCRIBE_NAMESPACE request".to_string(),
+                            ));
+                        }
+                        Err(err) => {
+                            tracing::debug!(
+                                request_id = self.request_id,
+                                error = %err,
+                                "SUBSCRIBE_NAMESPACE request stream closed with error"
+                            );
+                            self.recv_cancel();
+                            if err.is_stream_error() {
+                                return Ok(());
+                            }
+                            return Err(err);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Write one response message on the request stream.
+    ///
+    /// Draft-18: responses travel on the request's own bidi stream with the
+    /// Request ID omitted, so this goes through the shared bidi response
+    /// encoder rather than the full-message encoder.
+    async fn send_message(
+        &self,
+        writer: &mut Writer,
+        mlog: &Option<Arc<Mutex<mlog::MlogWriter>>>,
+        msg: Message,
+    ) -> Result<bool, SessionError> {
+        self.emit_mlog(mlog, &msg);
+        match Session::encode_bidi_response(writer, &msg).await {
+            Ok(()) => Ok(true),
+            Err(err) if err.is_stream_error() => Ok(false),
+            Err(err) => Err(err),
+        }
+    }
+
+    fn finish_response(&self, writer: &mut Writer) -> Result<(), SessionError> {
+        match writer.finish() {
+            Ok(()) => Ok(()),
+            Err(err) if err.is_stream_error() => Ok(()),
+            Err(err) => Err(err),
+        }
+    }
+
+    fn emit_mlog(&self, mlog: &Option<Arc<Mutex<mlog::MlogWriter>>>, msg: &Message) {
+        if let Some(mlog) = mlog {
+            if let Ok(mut mlog) = mlog.lock() {
+                let time = mlog.elapsed_ms();
+                let event = match msg {
+                    Message::RequestOk(msg) => Some(mlog::events::request_ok_created(
+                        time,
+                        0,
+                        "subscribe_namespace",
+                        msg,
+                    )),
+                    Message::RequestError(msg) => Some(mlog::events::request_error_created(
+                        time,
+                        0,
+                        "subscribe_namespace",
+                        msg,
+                    )),
+                    Message::Namespace(msg) => Some(mlog::events::namespace_created(time, 0, msg)),
+                    Message::NamespaceDone(msg) => {
+                        Some(mlog::events::namespace_done_created(time, 0, msg))
+                    }
+                    _ => None,
+                };
+                if let Some(event) = event {
+                    let _ = mlog.add_event(event);
+                }
+            }
+        }
+    }
+
+    fn recv_cancel(&mut self) {
+        if let Some(mut state) = self.state.lock_mut() {
+            state.closed = Err(ServeError::Cancel);
+        }
+        self.outgoing.close();
+    }
+
+    fn remove_active_prefix(&self) {
+        if let Ok(mut prefixes) = self.active_prefixes.lock() {
+            prefixes.remove(&self.request_id);
+        }
+    }
+}
+
+impl Drop for SubscribedNamespaceRecv {
+    fn drop(&mut self) {
+        self.remove_active_prefix();
+    }
+}
+
+fn request_error(id: u64, error_code: u64, reason: &str) -> Message {
+    message::RequestError {
+        id,
+        error_code,
+        retry_interval: 0,
+        reason: ReasonPhrase(reason.to_string()),
+    }
+    .into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn info() -> SubscribedNamespaceInfo {
+        SubscribedNamespaceInfo {
+            request_id: 0,
+            namespace_prefix: TrackNamespacePrefix::from_utf8_path("example.com/meeting=123"),
+            subscribe_options: SubscribeOptions::Namespace,
+            forward: true,
+        }
+    }
+
+    fn make() -> (
+        SubscribedNamespace,
+        SubscribedNamespaceRecv,
+        Arc<Mutex<HashMap<u64, TrackNamespacePrefix>>>,
+    ) {
+        let active = Arc::new(Mutex::new(HashMap::new()));
+        active
+            .lock()
+            .unwrap()
+            .insert(0, info().namespace_prefix.clone());
+        let (send, recv) = SubscribedNamespace::new(info(), active.clone());
+        (send, recv, active)
+    }
+
+    #[tokio::test]
+    async fn ok_queues_request_ok() {
+        let (mut send, mut recv, _active) = make();
+
+        send.ok().unwrap();
+
+        assert!(matches!(
+            recv.outgoing.recv().await,
+            Some(Message::RequestOk(_))
+        ));
+    }
+
+    #[test]
+    fn ok_twice_is_duplicate() {
+        let (mut send, _recv, _active) = make();
+
+        send.ok().unwrap();
+        assert!(matches!(send.ok(), Err(ServeError::Duplicate)));
+    }
+
+    #[tokio::test]
+    async fn namespace_queues_suffix() {
+        let (mut send, mut recv, _active) = make();
+        let namespace = TrackNamespace::from_utf8_path("example.com/meeting=123/participant=100");
+
+        send.ok().unwrap();
+        let _ = recv.outgoing.recv().await;
+        send.namespace(&namespace).unwrap();
+
+        let Some(Message::Namespace(msg)) = recv.outgoing.recv().await else {
+            panic!("expected NAMESPACE");
+        };
+        assert_eq!(
+            msg.track_namespace_suffix.to_utf8_path(),
+            "/participant=100"
+        );
+    }
+
+    #[test]
+    fn namespace_done_before_namespace_is_error() {
+        let (mut send, _recv, _active) = make();
+        let namespace = TrackNamespace::from_utf8_path("example.com/meeting=123/participant=100");
+
+        assert!(send.namespace_done(&namespace).is_err());
+    }
+
+    #[tokio::test]
+    async fn drop_before_ok_queues_request_error_and_removes_prefix() {
+        let (send, mut recv, active) = make();
+
+        drop(send);
+
+        assert!(matches!(
+            recv.outgoing.recv().await,
+            Some(Message::RequestError(_))
+        ));
+        assert!(active.lock().unwrap().contains_key(&0));
+
+        drop(recv);
+        assert!(!active.lock().unwrap().contains_key(&0));
+    }
+
+    #[tokio::test]
+    async fn cancel_keeps_active_prefix_until_receiver_drops() {
+        let (send, mut recv, active) = make();
+
+        recv.recv_cancel();
+
+        assert!(matches!(send.closed().await, Err(ServeError::Cancel)));
+        assert!(active.lock().unwrap().contains_key(&0));
+
+        drop(recv);
+        assert!(!active.lock().unwrap().contains_key(&0));
+    }
+
+    #[tokio::test]
+    async fn graceful_cancel_preserves_queued_responses() {
+        let (mut send, mut recv, _active) = make();
+        let namespace = TrackNamespace::from_utf8_path("example.com/meeting=123/participant=100");
+        send.ok().unwrap();
+        send.namespace(&namespace).unwrap();
+
+        recv.recv_cancel();
+
+        assert!(matches!(
+            recv.outgoing.recv().await,
+            Some(Message::RequestOk(_))
+        ));
+        assert!(matches!(
+            recv.outgoing.recv().await,
+            Some(Message::Namespace(_))
+        ));
+        assert!(recv.outgoing.recv().await.is_none());
+        assert!(matches!(
+            send.namespace(&namespace),
+            Err(ServeError::Cancel)
+        ));
+    }
+}

--- a/moq-transport/src/session/subscriber.rs
+++ b/moq-transport/src/session/subscriber.rs
@@ -12,22 +12,148 @@ use std::{
 use tokio::sync::Notify;
 
 use crate::{
-    coding::{Decode, TrackName, TrackNamespace},
+    coding::{Decode, KeyValuePairs, TrackName, TrackNamespace, TrackNamespacePrefix},
     data,
-    message::{self, Message},
+    message::{self, Message, SubscribeOptions},
     mlog,
-    serve::{self, ServeError},
+    serve::{self, FullTrackName, ServeError},
 };
 
 use crate::watch::Queue;
 
 use super::{
-    PublishedNamespace, PublishedNamespaceRecv, Reader, RequestId, Session, SessionError,
-    Subscribe, SubscribeRecv, Writer,
+    PublishReceived, PublishReceivedRecv, PublishedNamespace, PublishedNamespaceRecv, Reader,
+    RequestId, Session, SessionError, Subscribe, SubscribeNamespace, SubscribeNamespaceInfo,
+    SubscribeRecv, Writer,
 };
 
 // Default timeout for waiting for subscribe aliases to become available via SUBSCRIBE_OK (1 second)
 const DEFAULT_ALIAS_WAIT_TIME_MS: u64 = 1000;
+
+/// Rolls back a SUBSCRIBE_NAMESPACE prefix reservation if the request never
+/// gets off the ground.
+///
+/// `subscribe_namespace()` reserves the prefix before opening the request
+/// stream so concurrent callers see the overlap immediately. If the open then
+/// fails, dropping this guard releases the reservation. On success the guard is
+/// [`disarm`](Self::disarm)ed and cleanup passes to `SubscribeNamespaceRecv`,
+/// whose `Drop` removes the entry when the subscription ends.
+struct SubscribeNamespaceCleanup {
+    subscriber: Subscriber,
+    request_id: u64,
+    active: bool,
+}
+
+impl SubscribeNamespaceCleanup {
+    fn new(subscriber: Subscriber, request_id: u64) -> Self {
+        Self {
+            subscriber,
+            request_id,
+            active: true,
+        }
+    }
+
+    fn disarm(mut self) {
+        self.active = false;
+    }
+}
+
+impl Drop for SubscribeNamespaceCleanup {
+    fn drop(&mut self) {
+        if self.active {
+            self.subscriber.remove_subscribe_namespace(self.request_id);
+        }
+    }
+}
+
+/// Which subscription owns a given Track Alias (draft-16 §10.1).
+///
+/// SUBSCRIBE and PUBLISH share one session-scoped alias namespace, so a single
+/// registry keyed by alias resolves inbound streams and datagrams to the right
+/// receiver.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TrackOrigin {
+    /// Alias belongs to an outbound SUBSCRIBE; carries the subscribe request id.
+    Subscribe(u64),
+    /// Alias belongs to an inbound PUBLISH; carries the PUBLISH request id.
+    Publish(u64),
+}
+
+impl TrackOrigin {
+    fn request_id(self) -> u64 {
+        match self {
+            Self::Subscribe(id) | Self::Publish(id) => id,
+        }
+    }
+}
+
+#[derive(Default)]
+struct TrackAliasRegistry {
+    by_alias: HashMap<u64, TrackOrigin>,
+    by_request_id: HashMap<u64, u64>,
+}
+
+impl TrackAliasRegistry {
+    fn contains_alias(&self, alias: u64) -> bool {
+        self.by_alias.contains_key(&alias)
+    }
+
+    fn get(&self, alias: u64) -> Option<TrackOrigin> {
+        self.by_alias.get(&alias).copied()
+    }
+
+    fn insert(&mut self, alias: u64, origin: TrackOrigin) -> Result<(), SessionError> {
+        if self.by_alias.contains_key(&alias) {
+            return Err(SessionError::Duplicate);
+        }
+
+        if let Some(old_alias) = self.by_request_id.insert(origin.request_id(), alias) {
+            self.by_alias.remove(&old_alias);
+        }
+        self.by_alias.insert(alias, origin);
+        Ok(())
+    }
+
+    fn remove_by_request_id(&mut self, request_id: u64) -> Option<TrackOrigin> {
+        let alias = self.by_request_id.remove(&request_id)?;
+        self.by_alias.remove(&alias)
+    }
+
+    #[cfg(test)]
+    fn is_empty(&self) -> bool {
+        self.by_alias.is_empty() && self.by_request_id.is_empty()
+    }
+}
+
+/// Tracks that this endpoint already subscribes to, whether via an outbound
+/// SUBSCRIBE or an inbound PUBLISH. Draft-16 §5.1 allows only one
+/// subscriber-role subscription per track.
+#[derive(Default)]
+struct SubscriberNameRegistry {
+    by_name: HashMap<FullTrackName, u64>,
+    by_request_id: HashMap<u64, FullTrackName>,
+}
+
+impl SubscriberNameRegistry {
+    fn contains_name(&self, name: &FullTrackName) -> bool {
+        self.by_name.contains_key(name)
+    }
+
+    fn insert(&mut self, name: FullTrackName, request_id: u64) {
+        if let Some(old_name) = self.by_request_id.insert(request_id, name.clone()) {
+            self.by_name.remove(&old_name);
+        }
+        if let Some(old_id) = self.by_name.insert(name, request_id) {
+            self.by_request_id.remove(&old_id);
+        }
+    }
+
+    fn remove_by_request_id(&mut self, request_id: u64) -> Option<FullTrackName> {
+        let name = self.by_request_id.remove(&request_id)?;
+        self.by_name.remove(&name);
+        Some(name)
+    }
+}
 
 // TODO remove Clone.
 #[derive(Clone)]
@@ -41,11 +167,26 @@ pub struct Subscriber {
     /// The currently active outbound subscribes, keyed by request id.
     subscribes: Arc<Mutex<HashMap<u64, SubscribeRecv>>>,
 
-    /// Map of track alias to subscription id for quick lookup when receiving streams/datagrams.
-    subscribe_alias_map: Arc<Mutex<HashMap<u64, u64>>>,
+    /// Prefixes of active outbound SUBSCRIBE_NAMESPACE requests, keyed by
+    /// request id. Used to reject locally-overlapping prefixes (§5.1).
+    subscribe_namespaces: Arc<Mutex<HashMap<u64, TrackNamespacePrefix>>>,
 
-    /// Notify when subscribe alias map is updated
-    subscribe_alias_notify: Arc<Notify>,
+    /// Track Alias to owning subscription, for routing inbound streams and
+    /// datagrams. Shared by outbound SUBSCRIBE and inbound PUBLISH.
+    track_alias_map: Arc<Mutex<TrackAliasRegistry>>,
+
+    /// Notify when `track_alias_map` is updated, for stream and datagram
+    /// routing that can arrive before the alias is registered.
+    track_alias_notify: Arc<Notify>,
+
+    /// Tracks this endpoint subscribes to, for the §5.1 duplicate check.
+    subscriber_names: Arc<Mutex<SubscriberNameRegistry>>,
+
+    /// Transport-side state for inbound PUBLISH requests, keyed by request id.
+    publishes_received: Arc<Mutex<HashMap<u64, PublishReceivedRecv>>>,
+
+    /// Inbound PUBLISH requests waiting to be consumed by the application.
+    publish_received_queue: Queue<PublishReceived>,
 
     /// The queue we will write any outbound control messages we want to send, the session run_send task
     /// will process the queue and send the message on the control stream.
@@ -82,12 +223,16 @@ impl Subscriber {
             published_namespaces: Default::default(),
             published_namespace_queue: Default::default(),
             subscribes: Default::default(),
-            subscribe_alias_map: Default::default(),
+            subscribe_namespaces: Default::default(),
             outgoing,
             webtransport,
             request_id,
             mlog,
-            subscribe_alias_notify: Arc::new(Notify::new()),
+            track_alias_map: Default::default(),
+            track_alias_notify: Arc::new(Notify::new()),
+            subscriber_names: Default::default(),
+            publishes_received: Default::default(),
+            publish_received_queue: Default::default(),
             bidi_task_tx,
         }
     }
@@ -214,6 +359,26 @@ impl Subscriber {
         let request_id = self
             .get_next_request_id()
             .map_err(|e| ServeError::internal_ctx(format!("request ID limit: {}", e)))?;
+
+        // §5.1: at most one subscriber-role subscription per track. Outbound
+        // SUBSCRIBE and inbound PUBLISH both make this endpoint the subscriber,
+        // so they share one registry. Reserved before the stream is opened;
+        // `remove_subscribe` releases it.
+        let full_name = FullTrackName {
+            namespace: track.namespace.clone(),
+            name: track.name.clone(),
+        };
+        {
+            let mut names = self
+                .subscriber_names
+                .lock()
+                .map_err(|_| ServeError::internal_ctx("subscriber_names lock poisoned"))?;
+            if names.contains_name(&full_name) {
+                return Err(ServeError::Duplicate);
+            }
+            names.insert(full_name, request_id);
+        }
+
         let (send, recv, subscribe) = Subscribe::new(self.clone(), request_id, track);
 
         // Open a bidi stream and send the SUBSCRIBE message BEFORE
@@ -222,12 +387,19 @@ impl Subscriber {
         // Subscribe::new, so it is not reconstructed here. The request writer
         // (send side) is held here so error paths can finish it explicitly.
         let subscribe_msg: Message = subscribe.into();
-        let (mut request_writer, mut response_reader) = self
-            .open_request_stream(&subscribe_msg)
-            .await
-            .map_err(|e| {
-                ServeError::internal_ctx(format!("failed to open request stream: {}", e))
-            })?;
+        let (mut request_writer, mut response_reader) =
+            match self.open_request_stream(&subscribe_msg).await {
+                Ok(streams) => streams,
+                Err(e) => {
+                    if let Ok(mut names) = self.subscriber_names.lock() {
+                        names.remove_by_request_id(request_id);
+                    }
+                    return Err(ServeError::internal_ctx(format!(
+                        "failed to open request stream: {}",
+                        e
+                    )));
+                }
+            };
 
         // Register the response state. If the lock is poisoned after the stream
         // is open, cleanly finish the send side (FIN) before bailing instead of
@@ -241,7 +413,10 @@ impl Subscriber {
                     request_id,
                     "subscribes lock poisoned after bidi stream open; finishing stream"
                 );
-                request_writer.finish();
+                if let Ok(mut names) = self.subscriber_names.lock() {
+                    names.remove_by_request_id(request_id);
+                }
+                let _ = request_writer.finish();
                 return Err(ServeError::internal_ctx("subscribe lock poisoned"));
             }
         }
@@ -251,22 +426,27 @@ impl Subscriber {
         // No task is spawned; the future is dropped/cancelled on session exit.
         let mut subscriber_clone = self.clone();
         let _ = self.bidi_task_tx.send(Box::pin(async move {
-            loop {
+            let result = loop {
                 match Session::decode_bidi_response(&mut response_reader, request_id).await {
                     Ok(msg) => {
                         if let Ok(pub_msg) = TryInto::<message::Publisher>::try_into(msg) {
-                            if let Err(e) = subscriber_clone.recv_message(pub_msg) {
-                                tracing::warn!(error = %e, "error handling bidi response");
-                                break;
+                            // Returning rather than breaking lets Session::run decide:
+                            // a protocol violation closes the session, anything else is
+                            // logged there and only this stream ends.
+                            if let Err(err) = subscriber_clone.recv_message(pub_msg) {
+                                break Err(err);
                             }
                         }
                     }
-                    Err(e) => {
-                        tracing::debug!(error = %e, request_id, "bidi response reader ended");
-                        break;
-                    }
+                    Err(err) if err.is_stream_ended() => break Ok(()),
+                    Err(err) => break Err(err),
                 }
-            }
+            };
+
+            // Runs on every exit path. Harmless once the subscription is
+            // established, since the entry is gone by then.
+            subscriber_clone.abort_subscribe(request_id);
+            result
         }));
 
         // Cleanly finish (FIN) the request stream's send side now that the
@@ -274,10 +454,91 @@ impl Subscriber {
         // Placed before `send.ok().await?` so the FIN is sent on every exit
         // path that holds the writer — both the happy path and a failed ack —
         // rather than letting the drop emit RESET_STREAM(0).
-        request_writer.finish();
+        if let Err(err) = request_writer.finish() {
+            tracing::debug!(request_id, error = %err, "failed to FIN SUBSCRIBE request stream");
+        }
 
         send.ok().await?;
         Ok(send)
+    }
+
+    /// Subscribe to namespace announcements under a prefix (draft-18 §10.18).
+    ///
+    /// The request gets its own bidirectional stream. REQUEST_OK / REQUEST_ERROR
+    /// and the subsequent NAMESPACE / NAMESPACE_DONE feed all arrive on that
+    /// stream, so the returned handle only progresses while `Session::run` is
+    /// being polled.
+    pub async fn subscribe_namespace(
+        &mut self,
+        namespace_prefix: TrackNamespacePrefix,
+        subscribe_options: SubscribeOptions,
+        params: KeyValuePairs,
+    ) -> Result<SubscribeNamespace, SessionError> {
+        let request_id = self.get_next_request_id()?;
+
+        {
+            let mut prefixes = self
+                .subscribe_namespaces
+                .lock()
+                .map_err(|_| SessionError::Internal)?;
+            if prefixes
+                .values()
+                .any(|existing| existing.overlaps(&namespace_prefix))
+            {
+                return Err(SessionError::Serve(ServeError::Duplicate));
+            }
+            prefixes.insert(request_id, namespace_prefix.clone());
+        }
+        let cleanup = SubscribeNamespaceCleanup::new(self.clone(), request_id);
+
+        let msg = message::SubscribeNamespace {
+            id: request_id,
+            track_namespace_prefix: namespace_prefix.clone(),
+            subscribe_options,
+            params,
+        };
+        self.add_mlog_event(|time| mlog::events::subscribe_namespace_created(time, 0, &msg));
+
+        let (writer, reader) = self
+            .open_request_stream(&Message::SubscribeNamespace(msg))
+            .await?;
+
+        let info = SubscribeNamespaceInfo {
+            request_id,
+            namespace_prefix,
+            subscribe_options,
+        };
+        let (send, recv) = SubscribeNamespace::new(self.clone(), info, writer);
+
+        // The response reader is polled by `Session::run` (structured
+        // concurrency): no task is spawned, so it cannot outlive the session.
+        let mlog = self.mlog.clone();
+        if self
+            .bidi_task_tx
+            .send(Box::pin(async move {
+                match recv.run(reader, mlog).await {
+                    Ok(()) => Ok(()),
+                    Err(err) if err.is_stream_ended() => {
+                        tracing::debug!(request_id, error = %err, "SUBSCRIBE_NAMESPACE response reader ended");
+                        Ok(())
+                    }
+                    Err(err) => Err(err),
+                }
+            }))
+            .is_err()
+        {
+            return Err(SessionError::Internal);
+        }
+
+        cleanup.disarm();
+        Ok(send)
+    }
+
+    /// Drop the prefix reservation for an outbound SUBSCRIBE_NAMESPACE.
+    pub(super) fn remove_subscribe_namespace(&self, request_id: u64) {
+        if let Ok(mut prefixes) = self.subscribe_namespaces.lock() {
+            prefixes.remove(&request_id);
+        }
     }
 
     /// Send a message to the publisher via the control stream.
@@ -302,11 +563,7 @@ impl Subscriber {
             message::Publisher::PublishNamespaceDone(msg) => {
                 self.recv_publish_namespace_done(msg)?;
             }
-            // PUBLISH (publisher-initiated subscription) not yet implemented.
-            // Send REQUEST_ERROR NOT_SUPPORTED so the publisher knows we cannot accept it.
-            message::Publisher::Publish(msg) => {
-                self.send_not_supported(msg.id, "publish");
-            }
+            message::Publisher::Publish(msg) => self.recv_publish(msg)?,
             message::Publisher::PublishDone(msg) => self.recv_publish_done(msg)?,
             message::Publisher::SubscribeOk(msg) => self.recv_subscribe_ok(msg)?,
             // Draft-16 shared responses (REQUEST_OK / REQUEST_ERROR).
@@ -323,27 +580,6 @@ impl Subscriber {
         }
 
         Ok(())
-    }
-
-    /// Send REQUEST_ERROR NOT_SUPPORTED for an incoming request we do not implement.
-    ///
-    /// Draft-16 §4: limited endpoints SHOULD respond with NOT_SUPPORTED rather
-    /// than ignoring unsupported request types.
-    fn send_not_supported(&mut self, request_id: u64, request_kind: &str) {
-        tracing::debug!(
-            target: "moq_transport::control",
-            request_id,
-            "sending REQUEST_ERROR NOT_SUPPORTED for unimplemented request"
-        );
-        self.send_request_error(
-            request_kind,
-            message::RequestError {
-                id: request_id,
-                error_code: crate::message::RequestErrorCode::NotSupported as u64,
-                retry_interval: 0,
-                reason: crate::coding::ReasonPhrase("not supported".to_string()),
-            },
-        );
     }
 
     /// Handle reception of an inbound PUBLISH_NAMESPACE from the publisher.
@@ -393,14 +629,22 @@ impl Subscriber {
             .map_err(|_| SessionError::Internal)?
             .get_mut(&msg.id)
         {
-            // Map track alias to subscription id for quick lookup when receiving streams/datagrams
-            self.subscribe_alias_map
-                .lock()
-                .map_err(|_| SessionError::Internal)?
-                .insert(msg.track_alias, msg.id);
+            // Track Aliases are session-scoped (§10.1), so the alias in
+            // SUBSCRIBE_OK must not already be bound by another SUBSCRIBE or an
+            // inbound PUBLISH.
+            {
+                let mut aliases = self
+                    .track_alias_map
+                    .lock()
+                    .map_err(|_| SessionError::Internal)?;
+                if aliases.contains_alias(msg.track_alias) {
+                    return Err(SessionError::Duplicate);
+                }
+                aliases.insert(msg.track_alias, TrackOrigin::Subscribe(msg.id))?;
+            }
 
             // Notify waiting tasks that the alias map has been updated
-            self.subscribe_alias_notify.notify_waiters();
+            self.track_alias_notify.notify_waiters();
 
             // Notify the subscribe of the successful subscription
             subscribe.ok(msg.track_alias)?;
@@ -409,23 +653,63 @@ impl Subscriber {
         Ok(())
     }
 
-    /// Remove a subscribe from our map of active subscribes, and the alias map if present.
+    /// Remove a subscribe from the active map, along with its alias and name
+    /// reservations.
     pub(super) fn remove_subscribe(&mut self, id: u64) -> Option<SubscribeRecv> {
         let subscribe = self.subscribes.lock().ok().and_then(|mut s| s.remove(&id));
-        if let Some(ref sub) = subscribe {
-            if let Some(track_alias) = sub.track_alias() {
-                if let Ok(mut alias_map) = self.subscribe_alias_map.lock() {
-                    alias_map.remove(&track_alias);
-                }
-            }
+        if let Ok(mut aliases) = self.track_alias_map.lock() {
+            aliases.remove_by_request_id(id);
+        }
+        if let Ok(mut names) = self.subscriber_names.lock() {
+            names.remove_by_request_id(id);
         }
         subscribe
     }
 
+    /// Fail an outbound SUBSCRIBE whose request stream ended before the publisher
+    /// answered. Without this an application awaiting `Subscribe::ok()` waits for
+    /// the life of the session on a request that can never be answered. A no-op
+    /// once the subscription has been established and removed by other means.
+    pub(super) fn abort_subscribe(&mut self, id: u64) {
+        let Some(subscribe) = self.remove_subscribe(id) else {
+            return;
+        };
+
+        tracing::debug!(
+            request_id = id,
+            "SUBSCRIBE request stream closed before the publisher responded"
+        );
+        if let Err(err) = subscribe.error(ServeError::Cancel) {
+            tracing::debug!(request_id = id, error = %err, "failed to fail aborted SUBSCRIBE");
+        }
+    }
+
     /// Handle the reception of a PublishDone message from the publisher.
+    ///
+    /// PUBLISH_DONE terminates either a SUBSCRIBE-created subscription or a
+    /// PUBLISH-created one. The request id alone does not say which, so both
+    /// maps are checked.
     fn recv_publish_done(&mut self, msg: &message::PublishDone) -> Result<(), SessionError> {
         if let Some(subscribe) = self.remove_subscribe(msg.id) {
             subscribe.error(ServeError::Closed(msg.status_code))?;
+            return Ok(());
+        }
+
+        let recv = self
+            .publishes_received
+            .lock()
+            .map_err(|_| SessionError::Internal)?
+            .remove(&msg.id);
+        match recv {
+            Some(mut recv) => {
+                recv.recv_done(msg.status_code);
+                self.clear_subscription_reservations(msg.id)?;
+            }
+            None => tracing::debug!(
+                target: "moq_transport::control",
+                request_id = msg.id,
+                "received PUBLISH_DONE for unknown subscription — ignoring"
+            ),
         }
 
         Ok(())
@@ -474,6 +758,206 @@ impl Subscriber {
         Ok(())
     }
 
+    /// Handle an inbound PUBLISH (draft-16 §9.13).
+    ///
+    /// This establishes a publisher-initiated subscription: the peer offers a
+    /// track and this endpoint becomes its subscriber.
+    fn recv_publish(&mut self, msg: &message::Publish) -> Result<(), SessionError> {
+        // First-cut policy: reject non-empty TrackExtensions. They are not
+        // carried through TrackReader/TrackWriter yet, so accepting them would
+        // silently drop relay-visible metadata (§8.6).
+        if !msg.track_extensions.is_empty() {
+            self.send_request_error(
+                "publish",
+                message::RequestError {
+                    id: msg.id,
+                    error_code: message::RequestErrorCode::NotSupported as u64,
+                    retry_interval: 0,
+                    reason: crate::coding::ReasonPhrase(
+                        "track extensions not supported".to_string(),
+                    ),
+                },
+            );
+            return Ok(());
+        }
+
+        let full_name = FullTrackName {
+            namespace: msg.track_namespace.clone(),
+            name: msg.track_name.clone(),
+        };
+
+        // Parse FORWARD and LARGEST_OBJECT before reserving any session state,
+        // so malformed parameters cannot leave stale alias or name entries.
+        let initial_forward = msg
+            .params
+            .forward()
+            .map_err(SessionError::Decode)?
+            .unwrap_or(true);
+        let largest_location = msg.params.largest_object().map_err(SessionError::Decode)?;
+
+        // Reserve the track name first. The duplicate-subscription check runs
+        // before the alias check on purpose: a duplicate PUBLISH for the same
+        // track is a request error, not a session-closing alias collision.
+        {
+            let mut names = self
+                .subscriber_names
+                .lock()
+                .map_err(|_| SessionError::Internal)?;
+            if names.contains_name(&full_name) {
+                drop(names);
+                self.send_request_error(
+                    "publish",
+                    message::RequestError {
+                        id: msg.id,
+                        error_code: message::RequestErrorCode::DuplicateSubscription as u64,
+                        retry_interval: 0,
+                        reason: crate::coding::ReasonPhrase("duplicate subscription".to_string()),
+                    },
+                );
+                return Ok(());
+            }
+
+            names.insert(full_name, msg.id);
+        }
+
+        // Reserve the alias without holding subscriber_names, so cleanup and
+        // inbound PUBLISH handling have no lock-order dependency.
+        let alias_result = match self.track_alias_map.lock() {
+            Ok(mut aliases) => {
+                if aliases.contains_alias(msg.track_alias) {
+                    // §9.13: a duplicate Track Alias for a different track
+                    // closes the session.
+                    Err(SessionError::Duplicate)
+                } else {
+                    aliases.insert(msg.track_alias, TrackOrigin::Publish(msg.id))
+                }
+            }
+            Err(_) => Err(SessionError::Internal),
+        };
+        if let Err(err) = alias_result {
+            if let Ok(mut names) = self.subscriber_names.lock() {
+                names.remove_by_request_id(msg.id);
+            }
+            return Err(err);
+        }
+
+        // Allocate the track. The transport owns the writer; the application
+        // gets the reader from PublishReceived::ok.
+        let (writer, reader) =
+            serve::Track::new(msg.track_namespace.clone(), msg.track_name.clone()).produce();
+
+        let (publish_received, recv) = PublishReceivedRecv::produce(
+            self.clone(),
+            msg.id,
+            msg.track_alias,
+            msg.track_namespace.clone(),
+            msg.track_name.clone(),
+            initial_forward,
+            largest_location,
+            writer,
+            reader,
+        );
+
+        // The alias is live before the handle is queued, so Object streams that
+        // race the PUBLISH (§5.1 permits delivery before PUBLISH_OK) resolve.
+        self.track_alias_notify.notify_waiters();
+
+        match self.publishes_received.lock() {
+            Ok(mut publishes_received) => {
+                publishes_received.insert(msg.id, recv);
+            }
+            Err(_) => {
+                self.clear_subscription_reservations(msg.id)?;
+                return Err(SessionError::Internal);
+            }
+        }
+
+        tracing::debug!(
+            target: "moq_transport::control",
+            request_id = msg.id,
+            track_alias = msg.track_alias,
+            namespace = %msg.track_namespace,
+            name = %msg.track_name,
+            forward = initial_forward,
+            "received PUBLISH"
+        );
+
+        // If the application is no longer listening, dropping the handle sends
+        // REQUEST_ERROR back to the publisher.
+        if self.publish_received_queue.push(publish_received).is_err() {
+            self.remove_publish_received(msg.id);
+        }
+
+        Ok(())
+    }
+
+    /// Wait for the next inbound PUBLISH from the peer, if any.
+    ///
+    /// The returned [`PublishReceived`] must be accepted with
+    /// [`PublishReceived::ok`] or dropped to reject.
+    pub async fn publish_received(&mut self) -> Option<PublishReceived> {
+        self.publish_received_queue.pop().await
+    }
+
+    /// Abandon an inbound PUBLISH whose request stream closed without
+    /// PUBLISH_DONE.
+    ///
+    /// Without this the track writer, the Track Alias, and the name
+    /// reservation would all stay held for the life of the session, and the
+    /// application's `PublishReceived::closed()` would never resolve.
+    pub(super) fn abort_publish_received(&self, request_id: u64) {
+        let recv = match self.publishes_received.lock() {
+            Ok(mut map) => map.remove(&request_id),
+            Err(_) => {
+                tracing::error!(request_id, "publishes_received lock poisoned");
+                return;
+            }
+        };
+
+        let Some(mut recv) = recv else {
+            return;
+        };
+
+        tracing::debug!(
+            request_id,
+            "PUBLISH request stream closed without PUBLISH_DONE"
+        );
+        recv.recv_done(message::PublishDoneCode::InternalError as u64);
+        if let Err(err) = self.clear_subscription_reservations(request_id) {
+            tracing::error!(request_id, error = %err, "failed to release inbound PUBLISH reservations");
+        }
+    }
+
+    /// Remove all subscriber-side state for an inbound PUBLISH.
+    ///
+    /// Called by `PublishReceived::drop` when the app did not call `ok()`.
+    pub(super) fn remove_publish_received(&self, request_id: u64) {
+        if let Err(err) = self.remove_publish_received_state(request_id) {
+            tracing::error!(request_id, error = %err, "failed to remove inbound PUBLISH state");
+        }
+    }
+
+    fn remove_publish_received_state(&self, request_id: u64) -> Result<(), SessionError> {
+        self.publishes_received
+            .lock()
+            .map_err(|_| SessionError::Internal)?
+            .remove(&request_id);
+        self.clear_subscription_reservations(request_id)
+    }
+
+    /// Release the alias and track-name reservations held by one subscription.
+    fn clear_subscription_reservations(&self, request_id: u64) -> Result<(), SessionError> {
+        self.track_alias_map
+            .lock()
+            .map_err(|_| SessionError::Internal)?
+            .remove_by_request_id(request_id);
+        self.subscriber_names
+            .lock()
+            .map_err(|_| SessionError::Internal)?
+            .remove_by_request_id(request_id);
+        Ok(())
+    }
+
     /// Map a REQUEST_ERROR to a semantic ServeError so callers see
     /// meaningful variants (e.g. NotFound) instead of opaque error codes.
     fn request_error_to_serve_error(msg: &message::RequestError) -> ServeError {
@@ -506,25 +990,25 @@ impl Subscriber {
         None
     }
 
-    /// Get a subscribe id by track alias, waiting up to the specified timeout if not present.
-    /// If timeout_ms is None, only check if already present and return None if not.
-    async fn get_subscribe_id_by_alias(
+    /// Resolve a Track Alias to its owning subscription, waiting up to the
+    /// given timeout for it to appear. With `None`, check once and return.
+    async fn get_track_origin_by_alias(
         &self,
         track_alias: u64,
         timeout_ms: Option<u64>,
-    ) -> Result<Option<u64>, SessionError> {
+    ) -> Result<Option<TrackOrigin>, SessionError> {
         // If no timeout specified, don't wait
         let timeout_ms = match timeout_ms {
             Some(ms) => ms,
             None => {
                 // Just check once
-                return match self.subscribe_alias_map.lock() {
-                    Ok(aliases) => Ok(aliases.get(&track_alias).cloned()),
+                return match self.track_alias_map.lock() {
+                    Ok(aliases) => Ok(aliases.get(track_alias)),
                     Err(_) => {
                         tracing::error!(
                             target: "moq_transport::control",
                             track_alias,
-                            "subscribe alias map lock poisoned"
+                            "track alias map lock poisoned"
                         );
                         Err(SessionError::Internal)
                     }
@@ -536,24 +1020,24 @@ impl Subscriber {
         let timeout_duration = Duration::from_millis(timeout_ms);
         tokio::time::timeout(timeout_duration, async {
             loop {
-                // Register for notification before checking map
-                let notified = self.subscribe_alias_notify.notified();
+                // Register for notification before checking, to close the
+                // window where the alias lands between check and wait.
+                let notified = self.track_alias_notify.notified();
 
-                // Check Map for alias
-                let id = match self.subscribe_alias_map.lock() {
-                    Ok(aliases) => aliases.get(&track_alias).cloned(),
+                let origin = match self.track_alias_map.lock() {
+                    Ok(aliases) => aliases.get(track_alias),
                     Err(_) => {
                         tracing::error!(
                             target: "moq_transport::control",
                             track_alias,
-                            "subscribe alias map lock poisoned"
+                            "track alias map lock poisoned"
                         );
                         return Err(SessionError::Internal);
                     }
                 };
 
-                if let Some(id) = id {
-                    return Ok(Some(id));
+                if let Some(origin) = origin {
+                    return Ok(Some(origin));
                 }
 
                 // Alias not present yet, wait for notification
@@ -562,6 +1046,39 @@ impl Subscriber {
         })
         .await
         .unwrap_or(Ok(None))
+    }
+
+    /// Open the subgroup writer for whichever subscription owns this alias.
+    fn open_subgroup_writer(
+        &self,
+        origin: TrackOrigin,
+        header: &data::SubgroupHeader,
+    ) -> Result<serve::SubgroupWriter, SessionError> {
+        match origin {
+            TrackOrigin::Subscribe(subscribe_id) => {
+                let mut map = self.subscribes.lock().map_err(|_| SessionError::Internal)?;
+                let recv = map.get_mut(&subscribe_id).ok_or_else(|| {
+                    ServeError::not_found_ctx(format!(
+                        "subscribe_id={} not found for track_alias={}",
+                        subscribe_id, header.track_alias
+                    ))
+                })?;
+                Ok(recv.subgroup(header.clone())?)
+            }
+            TrackOrigin::Publish(publish_id) => {
+                let mut map = self
+                    .publishes_received
+                    .lock()
+                    .map_err(|_| SessionError::Internal)?;
+                let recv = map.get_mut(&publish_id).ok_or_else(|| {
+                    ServeError::not_found_ctx(format!(
+                        "publish_id={} not found for track_alias={}",
+                        publish_id, header.track_alias
+                    ))
+                })?;
+                Ok(recv.subgroup(header.clone())?)
+            }
+        }
     }
 
     /// Handle reception of a new stream from the QUIC session.
@@ -612,7 +1129,9 @@ impl Subscriber {
             );
             // The writer is closed, so we should terminate.
             // TODO it would be nice to do this immediately when the Writer is closed.
-            if let Some(subscribe_id) = self.get_subscribe_id_by_alias(track_alias, None).await? {
+            if let Some(TrackOrigin::Subscribe(subscribe_id)) =
+                self.get_track_origin_by_alias(track_alias, None).await?
+            {
                 if let Some(subscribe) = self.remove_subscribe(subscribe_id) {
                     subscribe.error(err.clone())?;
                 }
@@ -635,8 +1154,8 @@ impl Subscriber {
             track_alias
         );
 
-        let Some(subscribe_id) = self
-            .get_subscribe_id_by_alias(track_alias, Some(DEFAULT_ALIAS_WAIT_TIME_MS))
+        let Some(origin) = self
+            .get_track_origin_by_alias(track_alias, Some(DEFAULT_ALIAS_WAIT_TIME_MS))
             .await?
         else {
             return Err(SessionError::Serve(ServeError::not_found_ctx(format!(
@@ -646,10 +1165,13 @@ impl Subscriber {
         };
 
         tracing::trace!("[SUBSCRIBER] recv_stream_inner: receiving subgroup data");
+        let subgroup_header = stream_header
+            .subgroup_header
+            .ok_or(SessionError::Internal)?;
         self.recv_subgroup(
             stream_header.header_type,
-            stream_header.subgroup_header.unwrap(),
-            subscribe_id,
+            subgroup_header,
+            origin,
             reader,
             mlog,
         )
@@ -667,7 +1189,7 @@ impl Subscriber {
         &mut self,
         stream_header_type: data::StreamHeaderType,
         mut subgroup_header: data::SubgroupHeader,
-        subscribe_id: u64,
+        origin: TrackOrigin,
         mut reader: Reader,
         mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
     ) -> Result<(), SessionError> {
@@ -790,15 +1312,7 @@ impl Subscriber {
                     subgroup_header.subgroup_id = Some(current_object_id);
                 }
 
-                let mut subscribes = self.subscribes.lock().map_err(|_| SessionError::Internal)?;
-                let subscribe = subscribes.get_mut(&subscribe_id).ok_or_else(|| {
-                    ServeError::not_found_ctx(format!(
-                        "subscribe_id={} not found for track_alias={}",
-                        subscribe_id, subgroup_header.track_alias
-                    ))
-                })?;
-
-                subgroup_writer = Some(subscribe.subgroup(subgroup_header.clone())?);
+                subgroup_writer = Some(self.open_subgroup_writer(origin, &subgroup_header)?);
             }
 
             // Log subgroup object parsed/received
@@ -939,38 +1453,60 @@ impl Subscriber {
             }
         }
 
-        // Look up the subscribe id for this track alias
-        if let Some(subscribe_id) = self
-            .get_subscribe_id_by_alias(datagram.track_alias, Some(DEFAULT_ALIAS_WAIT_TIME_MS))
-            .await?
-        {
-            // Look up the subscribe by id
-            if let Some(subscribe) = self
-                .subscribes
-                .lock()
-                .ok()
-                .as_mut()
-                .and_then(|s| s.get_mut(&subscribe_id))
-            {
-                tracing::trace!(
-                    "[SUBSCRIBER] recv_datagram: track_alias={}, group_id={}, object_id={}, publisher_priority={}, status={}, payload_length={}",
+        // Route to whichever subscription owns this track alias.
+        let origin = self
+            .get_track_origin_by_alias(datagram.track_alias, Some(DEFAULT_ALIAS_WAIT_TIME_MS))
+            .await?;
+
+        match origin {
+            Some(TrackOrigin::Subscribe(subscribe_id)) => {
+                if let Some(subscribe) = self
+                    .subscribes
+                    .lock()
+                    .ok()
+                    .as_mut()
+                    .and_then(|s| s.get_mut(&subscribe_id))
+                {
+                    tracing::trace!(
+                        "[SUBSCRIBER] recv_datagram (SUBSCRIBE): track_alias={}, group_id={}, object_id={}, publisher_priority={}, status={}, payload_length={}",
+                        datagram.track_alias,
+                        datagram.group_id,
+                        datagram.object_id.unwrap_or(0),
+                        datagram.publisher_priority,
+                        datagram.status.as_ref().map_or("None".to_string(), |s| format!("{:?}", s)),
+                        datagram.payload.as_ref().map_or(0, |p| p.len()));
+                    subscribe.datagram(datagram)?;
+                }
+            }
+            Some(TrackOrigin::Publish(publish_id)) => {
+                if let Some(recv) = self
+                    .publishes_received
+                    .lock()
+                    .ok()
+                    .as_mut()
+                    .and_then(|m| m.get_mut(&publish_id))
+                {
+                    tracing::trace!(
+                        "[SUBSCRIBER] recv_datagram (PUBLISH): track_alias={}, group_id={}, object_id={}, publisher_priority={}, status={}, payload_length={}",
+                        datagram.track_alias,
+                        datagram.group_id,
+                        datagram.object_id.unwrap_or(0),
+                        datagram.publisher_priority,
+                        datagram.status.as_ref().map_or("None".to_string(), |s| format!("{:?}", s)),
+                        datagram.payload.as_ref().map_or(0, |p| p.len()));
+                    recv.datagram(datagram)?;
+                }
+            }
+            None => {
+                tracing::warn!(
+                    "[SUBSCRIBER] recv_datagram: discarded due to unknown track_alias: track_alias={}, group_id={}, object_id={}, publisher_priority={}, status={}, payload_length={}",
                     datagram.track_alias,
                     datagram.group_id,
                     datagram.object_id.unwrap_or(0),
                     datagram.publisher_priority,
                     datagram.status.as_ref().map_or("None".to_string(), |s| format!("{:?}", s)),
                     datagram.payload.as_ref().map_or(0, |p| p.len()));
-                subscribe.datagram(datagram)?;
             }
-        } else {
-            tracing::warn!(
-                "[SUBSCRIBER] recv_datagram: discarded due to unknown track_alias: track_alias={}, group_id={}, object_id={}, publisher_priority={}, status={}, payload_length={}",
-                datagram.track_alias,
-                datagram.group_id,
-                datagram.object_id.unwrap_or(0),
-                datagram.publisher_priority,
-                datagram.status.as_ref().map_or("None".to_string(), |s| format!("{:?}", s)),
-                datagram.payload.as_ref().map_or(0, |p| p.len()));
         }
 
         Ok(())
@@ -980,64 +1516,7 @@ impl Subscriber {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// Establish a real `web_transport::Session` over an in-process QUIC
-    /// loopback so we can construct a `Subscriber` and exercise the actual
-    /// cleanup paths (`Subscribe::Drop` and `Subscriber::remove_subscribe`).
-    ///
-    /// The session is never dialed by these tests — the cleanup logic only
-    /// touches the in-memory maps and the outgoing queue — but `Subscriber`
-    /// holds a concrete `web_transport::Session`, so a live connection is the
-    /// only honest way to build one. The accepted server side is parked for
-    /// the lifetime of the test to keep the client session established.
-    async fn loopback_session() -> web_transport::Session {
-        use web_transport::quinn::{ClientBuilder, ServerBuilder};
-
-        // Under `cargo test --workspace`, feature unification links both the
-        // `ring` and `aws-lc-rs` rustls providers, leaving no unambiguous
-        // process default. Install one explicitly (idempotent across tests).
-        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
-
-        let cert = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])
-            .expect("generate self-signed certificate");
-        let cert_der = cert.cert.der().clone();
-        let key = cert
-            .key_pair
-            .serialize_der()
-            .try_into()
-            .expect("serialize private key");
-
-        let mut server = ServerBuilder::new()
-            .with_addr("127.0.0.1:0".parse().expect("server addr"))
-            .with_certificate(vec![cert_der], key)
-            .expect("build loopback server");
-        let addr = server.local_addr().expect("server local addr");
-
-        tokio::spawn(async move {
-            if let Some(request) = server.accept().await {
-                // Hold the accepted server session open for the lifetime of the
-                // test so the client side stays established; the spawned task is
-                // cancelled at runtime shutdown when the test returns.
-                if let Ok(_session) = request.ok().await {
-                    std::future::pending::<()>().await;
-                }
-            }
-        });
-
-        let client = ClientBuilder::new()
-            .dangerous()
-            .with_no_certificate_verification()
-            .expect("build loopback client");
-        let url = url::Url::parse(&format!("https://127.0.0.1:{}/", addr.port()))
-            .expect("parse loopback url");
-
-        // Fail fast rather than hang CI if the loopback handshake ever stalls.
-        tokio::time::timeout(std::time::Duration::from_secs(10), client.connect(url))
-            .await
-            .expect("loopback connect timed out")
-            .expect("connect loopback session")
-            .into()
-    }
+    use crate::session::test_support::loopback_session;
 
     fn test_subscriber(session: web_transport::Session) -> Subscriber {
         let outgoing = Queue::default().split().0;
@@ -1087,7 +1566,7 @@ mod tests {
         );
     }
 
-    /// `remove_subscribe` must clear both `subscribes` and `subscribe_alias_map`.
+    /// `remove_subscribe` must clear the subscribes map and release the alias.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn remove_subscribe_clears_alias_map() {
         let mut subscriber = test_subscriber(loopback_session().await);
@@ -1108,10 +1587,11 @@ mod tests {
             .unwrap()
             .insert(request_id, recv);
         subscriber
-            .subscribe_alias_map
+            .track_alias_map
             .lock()
             .unwrap()
-            .insert(track_alias, request_id);
+            .insert(track_alias, TrackOrigin::Subscribe(request_id))
+            .unwrap();
 
         let removed = subscriber.remove_subscribe(request_id);
 
@@ -1128,12 +1608,194 @@ mod tests {
             "remove_subscribe should clear the subscribes map"
         );
         assert!(
+            subscriber.track_alias_map.lock().unwrap().is_empty(),
+            "remove_subscribe should release the track alias"
+        );
+    }
+
+    /// An inbound PUBLISH must claim its Track Alias so racing Object streams
+    /// route to the PUBLISH receiver, not to a SUBSCRIBE.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn recv_publish_registers_alias_and_queues_handle() {
+        let mut subscriber = test_subscriber(loopback_session().await);
+
+        subscriber
+            .recv_publish(&message::Publish {
+                id: 1,
+                track_namespace: TrackNamespace::from_utf8_path("test/ns"),
+                track_name: "video".into(),
+                track_alias: 7,
+                params: Default::default(),
+                track_extensions: Default::default(),
+            })
+            .unwrap();
+
+        assert_eq!(
+            subscriber.track_alias_map.lock().unwrap().get(7),
+            Some(TrackOrigin::Publish(1))
+        );
+        assert!(subscriber
+            .publishes_received
+            .lock()
+            .unwrap()
+            .contains_key(&1));
+
+        let publish = subscriber.publish_received().await.expect("queued PUBLISH");
+        assert_eq!(publish.track_alias(), 7);
+        assert_eq!(publish.name(), &TrackName::from("video"));
+    }
+
+    /// A second PUBLISH for a track we already subscribe to is rejected as a
+    /// request error, leaving the first subscription intact (§5.1).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn duplicate_publish_for_same_track_is_rejected() {
+        let mut subscriber = test_subscriber(loopback_session().await);
+        let publish = |id, alias| message::Publish {
+            id,
+            track_namespace: TrackNamespace::from_utf8_path("test/ns"),
+            track_name: "video".into(),
+            track_alias: alias,
+            params: Default::default(),
+            track_extensions: Default::default(),
+        };
+
+        subscriber.recv_publish(&publish(1, 7)).unwrap();
+        subscriber.recv_publish(&publish(3, 9)).unwrap();
+
+        assert!(
             !subscriber
-                .subscribe_alias_map
+                .publishes_received
                 .lock()
                 .unwrap()
-                .contains_key(&track_alias),
-            "remove_subscribe should clear the subscribe_alias_map"
+                .contains_key(&3),
+            "duplicate PUBLISH must not create a second subscription"
         );
+        assert_eq!(subscriber.track_alias_map.lock().unwrap().get(9), None);
+    }
+
+    /// A PUBLISH request stream that dies without PUBLISH_DONE must still
+    /// release its state, or the track writer, alias, and name reservation
+    /// leak for the life of the session and `closed()` never resolves.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn aborting_inbound_publish_releases_state_and_unblocks_closed() {
+        let mut subscriber = test_subscriber(loopback_session().await);
+        subscriber
+            .recv_publish(&message::Publish {
+                id: 1,
+                track_namespace: TrackNamespace::from_utf8_path("test/ns"),
+                track_name: "video".into(),
+                track_alias: 7,
+                params: Default::default(),
+                track_extensions: Default::default(),
+            })
+            .unwrap();
+        let publish = subscriber.publish_received().await.expect("queued PUBLISH");
+
+        subscriber.abort_publish_received(1);
+
+        assert!(subscriber.publishes_received.lock().unwrap().is_empty());
+        assert!(subscriber.track_alias_map.lock().unwrap().is_empty());
+        assert!(
+            publish.closed().await.is_err(),
+            "an aborted PUBLISH must surface as a failure, not a clean end"
+        );
+    }
+
+    /// An outbound SUBSCRIBE claims the track name, so a PUBLISH offering the
+    /// same track is rejected rather than creating a second subscriber-role
+    /// subscription for it (§5.1).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn publish_for_already_subscribed_track_is_rejected() {
+        let mut subscriber = test_subscriber(loopback_session().await);
+        subscriber.subscriber_names.lock().unwrap().insert(
+            FullTrackName {
+                namespace: TrackNamespace::from_utf8_path("test/ns"),
+                name: "video".into(),
+            },
+            0,
+        );
+
+        subscriber
+            .recv_publish(&message::Publish {
+                id: 1,
+                track_namespace: TrackNamespace::from_utf8_path("test/ns"),
+                track_name: "video".into(),
+                track_alias: 7,
+                params: Default::default(),
+                track_extensions: Default::default(),
+            })
+            .unwrap();
+
+        assert!(subscriber.publishes_received.lock().unwrap().is_empty());
+        assert_eq!(subscriber.track_alias_map.lock().unwrap().get(7), None);
+    }
+
+    /// Track Aliases are session-scoped (§10.1), so a second PUBLISH reusing a
+    /// live alias for a different track is a session-closing condition, not a
+    /// per-request error. Draft-18 assigns DUPLICATE_TRACK_ALIAS (0x5).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn duplicate_track_alias_closes_the_session() {
+        let mut subscriber = test_subscriber(loopback_session().await);
+
+        subscriber
+            .recv_publish(&message::Publish {
+                id: 1,
+                track_namespace: TrackNamespace::from_utf8_path("test/ns"),
+                track_name: "first".into(),
+                track_alias: 7,
+                params: Default::default(),
+                track_extensions: Default::default(),
+            })
+            .unwrap();
+
+        let err = subscriber
+            .recv_publish(&message::Publish {
+                id: 2,
+                track_namespace: TrackNamespace::from_utf8_path("test/ns"),
+                track_name: "second".into(),
+                track_alias: 7,
+                params: Default::default(),
+                track_extensions: Default::default(),
+            })
+            .expect_err("reusing a live alias must be rejected");
+
+        assert!(matches!(err, SessionError::Duplicate));
+        assert!(err.is_session_fatal());
+        assert_eq!(err.code(), 0x5);
+
+        // The collision must not disturb the binding that already owned the alias.
+        assert_eq!(
+            subscriber.track_alias_map.lock().unwrap().get(7),
+            Some(TrackOrigin::Publish(1))
+        );
+    }
+
+    /// PUBLISH_DONE must tear down the inbound PUBLISH state, including its
+    /// alias and name reservations.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn publish_done_clears_inbound_publish_state() {
+        let mut subscriber = test_subscriber(loopback_session().await);
+        subscriber
+            .recv_publish(&message::Publish {
+                id: 1,
+                track_namespace: TrackNamespace::from_utf8_path("test/ns"),
+                track_name: "video".into(),
+                track_alias: 7,
+                params: Default::default(),
+                track_extensions: Default::default(),
+            })
+            .unwrap();
+
+        subscriber
+            .recv_publish_done(&message::PublishDone {
+                id: 1,
+                status_code: message::PublishDoneCode::TrackEnded as u64,
+                stream_count: 0,
+                reason: crate::coding::ReasonPhrase(String::new()),
+            })
+            .unwrap();
+
+        assert!(subscriber.publishes_received.lock().unwrap().is_empty());
+        assert!(subscriber.track_alias_map.lock().unwrap().is_empty());
     }
 }

--- a/moq-transport/src/session/writer.rs
+++ b/moq-transport/src/session/writer.rs
@@ -91,7 +91,15 @@ impl Writer {
     }
 
     /// Signal that no more data will be written (sends QUIC FIN).
-    pub fn finish(&mut self) {
-        let _ = self.stream.finish();
+    pub fn finish(&mut self) -> Result<(), SessionError> {
+        self.stream.finish()?;
+        Ok(())
+    }
+
+    /// Abort the send half with RESET_STREAM, discarding unsent data.
+    ///
+    /// Used to tear down a single request stream without closing the session.
+    pub fn reset(&mut self, code: u32) {
+        self.stream.reset(code);
     }
 }

--- a/moq-transport/src/watch/state.rs
+++ b/moq-transport/src/watch/state.rs
@@ -63,6 +63,31 @@ pub enum StateError {
     Poisoned,
 }
 
+/// Take the inner lock, recovering if a previous holder panicked.
+///
+/// Poisoning means another task panicked while holding this state, which has
+/// already failed whatever that task was doing. One `State` is shared by every
+/// subscription, track reader and waiter hanging off it, so propagating the
+/// poison would turn one failed request into a panic in every unrelated task that
+/// later touches the same state. Recovering keeps the damage where it started.
+///
+/// The state may be a half-finished update, which is why this is logged rather
+/// than passed over in silence. The poison flag is cleared so the log records one
+/// line per incident instead of one per access for the rest of the process's life.
+///
+/// Callers that would rather decide for themselves have [`State::try_lock`] and
+/// [`State::try_lock_mut`], which still report [`StateError::Poisoned`].
+fn lock_recovering<T>(state: &Mutex<StateInner<T>>) -> MutexGuard<'_, StateInner<T>> {
+    match state.lock() {
+        Ok(lock) => lock,
+        Err(poisoned) => {
+            state.clear_poison();
+            tracing::error!("recovered a poisoned watch state: a task panicked while holding it");
+            poisoned.into_inner()
+        }
+    }
+}
+
 impl<T> State<T> {
     pub fn new(initial: T) -> Self {
         let state = Arc::new(Mutex::new(StateInner::new(initial)));
@@ -77,7 +102,7 @@ impl<T> State<T> {
         StateRef {
             state: self.state.clone(),
             drop: self.drop.clone(),
-            lock: self.state.lock().unwrap(),
+            lock: lock_recovering(&self.state),
         }
     }
 
@@ -91,7 +116,7 @@ impl<T> State<T> {
     }
 
     pub fn lock_mut(&self) -> Option<StateMut<'_, T>> {
-        let lock = self.state.lock().unwrap();
+        let lock = lock_recovering(&self.state);
         lock.dropped?;
         Some(StateMut {
             lock,
@@ -244,7 +269,7 @@ impl<T> Future for StateChanged<T> {
 
     fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
         // TODO is there an API we can make that doesn't drop this lock?
-        let mut state = self.state.lock().unwrap();
+        let mut state = lock_recovering(&self.state);
 
         if state.epoch > self.epoch {
             task::Poll::Ready(())
@@ -285,11 +310,93 @@ struct StateDrop<T> {
 
 impl<T> Drop for StateDrop<T> {
     fn drop(&mut self) {
-        let Ok(mut state) = self.state.lock() else {
-            tracing::error!("watch state lock poisoned while dropping state");
-            return;
-        };
+        // Recovering rather than bailing out: skipping the notify below would
+        // leave every task awaiting this state parked forever, so one panic
+        // elsewhere would hang the subscriptions built on it.
+        let mut state = lock_recovering(&self.state);
         state.dropped = None;
         state.notify();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Run `f` on another thread and let it panic there, returning once the panic
+    /// has unwound. The state's mutex is poisoned from then on.
+    fn panic_while_holding(f: impl FnOnce() + Send + 'static) {
+        let previous = std::panic::take_hook();
+        // The panic is the point of the test, so keep its backtrace out of the
+        // test output.
+        std::panic::set_hook(Box::new(|_| {}));
+        let joined = std::thread::spawn(f).join();
+        std::panic::set_hook(previous);
+        assert!(joined.is_err(), "the helper thread was supposed to panic");
+    }
+
+    /// A panic while holding the state used to poison the mutex and turn every
+    /// later access into a panic of its own. One state is shared by every reader
+    /// and waiter built on it, so that spread a single failed request across all
+    /// of them.
+    #[test]
+    fn a_panic_under_the_lock_does_not_spread() {
+        let state = State::new(1u32);
+
+        let poisoner = state.clone();
+        panic_while_holding(move || {
+            let mut guard = poisoner.lock_mut().expect("state is live");
+            *guard = 2;
+            panic!("while holding the state");
+        });
+
+        assert_eq!(*state.lock(), 2, "the completed write is still visible");
+
+        let mut guard = state.lock_mut().expect("mutation still works afterwards");
+        *guard = 3;
+        drop(guard);
+        assert_eq!(*state.lock(), 3);
+    }
+
+    /// Callers that want to know are still told, which is what `queue.rs` and the
+    /// PUBLISH paths rely on. Only the first recovery clears the flag, so this
+    /// runs before anything calls `lock`.
+    #[test]
+    fn try_lock_still_reports_poisoning() {
+        let state = State::new(1u32);
+
+        let poisoner = state.clone();
+        panic_while_holding(move || {
+            let _guard = poisoner.lock_mut().expect("state is live");
+            panic!("while holding the state");
+        });
+
+        assert_eq!(state.try_lock().err(), Some(StateError::Poisoned));
+    }
+
+    /// Dropping the state has to wake its waiters even when the lock was
+    /// poisoned first. Bailing out of the drop instead skipped the notify, so
+    /// anything awaiting the state waited for a change that could never come.
+    ///
+    /// The panic here holds a shared `StateRef` on purpose. A `StateMut` notifies
+    /// as it unwinds, which wakes the waiter for an unrelated reason and would
+    /// let this pass either way.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn dropping_a_poisoned_state_still_wakes_waiters() {
+        let (writer, reader) = State::new(1u32).split();
+
+        let changed = reader.lock().modified().expect("state is live");
+
+        let poisoner = reader.clone();
+        panic_while_holding(move || {
+            let _guard = poisoner.lock();
+            panic!("while holding the state");
+        });
+
+        drop(writer);
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), changed)
+            .await
+            .expect("dropping the state wakes the waiter");
     }
 }


### PR DESCRIPTION
The draft-18-dev branch got mangled and only contained wire format changes, so this restores the other relay changes from main ~identically, apart from reapplying draft-18's ALPN negotiation. This also ports the session APIs they call, which landed on main after the fork: SUBSCRIBE_NAMESPACE, direct PUBLISH and SessionConfig, adapted to one bidi stream per request. The last change also stops State::lock unwrapping a poisoned mutex, so one panic no longer spreads to every later access of that state.