### PR TITLE
draft-18: fix(moq-native-ietf): explain WebTransport CONNECT rejections

### DIFF
--- a/moq-native-ietf/src/quic.rs
+++ b/moq-native-ietf/src/quic.rs
@@ -18,6 +18,7 @@ use socket2::{Domain, Protocol, Socket, Type};
 use url::Url;
 
 use moq_transport::session::Transport;
+use quinn::VarInt;
 
 use crate::tls;
 
@@ -114,6 +115,10 @@ fn bind_smart(addr: net::SocketAddr) -> anyhow::Result<(net::UdpSocket, bool)> {
 ///
 /// This is used both for the base endpoint config and when creating
 /// per-connection configs with qlog enabled.
+/// How long a rejected WebTransport CONNECT is given to reach the peer before
+/// the connection is closed underneath it.
+const REJECT_FLUSH_TIMEOUT: time::Duration = time::Duration::from_millis(250);
+
 fn build_transport_config() -> quinn::TransportConfig {
     let mut transport = quinn::TransportConfig::default();
     transport.max_idle_timeout(Some(time::Duration::from_secs(10).try_into().unwrap()));
@@ -518,6 +523,11 @@ impl Server {
 
         let alpn_bytes = alpn.as_bytes();
         let (session, transport) = if alpn_bytes == web_transport_quinn::ALPN.as_bytes() {
+            // `Request::accept` takes the connection, so keep a handle for the
+            // rejection path: closing with a reason tells the peer why, which a
+            // bare drop does not.
+            let conn_for_reject = conn.clone();
+
             // Wait for the WebTransport CONNECT request (includes H3 SETTINGS exchange).
             let request = web_transport_quinn::Request::accept(conn)
                 .await
@@ -526,8 +536,58 @@ impl Server {
             // Negotiate the MoQT version from the client's offered protocols. Rejecting here
             // rather than accepting without a protocol keeps a non-MoQT WebTransport client
             // from getting a successful CONNECT only to fail later at MoQT SETUP.
-            let selected = moq_transport::setup::negotiate_version(&request.protocols)
-                .context("no mutually supported MoQT version in WT-Available-Protocols")?;
+            //
+            // draft-18 §3.1.3 has the client put its MoQT protocol identifiers in
+            // WT-Available-Protocols; draft-ietf-webtrans-http3 §3.3 lets the server
+            // "reject the request if the client did not include a suitable protocol".
+            let selected = match moq_transport::setup::negotiate_version(&request.protocols) {
+                Some(selected) => selected,
+                None => {
+                    // `reject` consumes the request, so keep the offer for the log
+                    // and the error.
+                    let offered = request.protocols.clone();
+
+                    // Answer the CONNECT instead of dropping the connection, so the
+                    // peer learns why, and record what it offered: without this the
+                    // peer sees an abrupt close and the log names no cause.
+                    tracing::warn!(
+                        cid = %connection_id_hex,
+                        ip = %remote_address,
+                        offered = ?offered,
+                        supported = ?moq_transport::setup::SUPPORTED_ALPNS,
+                        "rejecting WebTransport CONNECT: no mutually supported MoQT version in WT-Available-Protocols"
+                    );
+
+                    // 406: the client's offer could not be satisfied.
+                    if let Err(err) = request
+                        .reject(web_transport_quinn::http::StatusCode::NOT_ACCEPTABLE)
+                        .await
+                    {
+                        tracing::debug!(cid = %connection_id_hex, error = %err, "failed to reject WebTransport CONNECT");
+                    }
+
+                    // `reject` only queues the response, and both `close` and
+                    // dropping the connection stop sending immediately, which
+                    // would truncate it. Give the peer a bounded moment to read
+                    // the 406 and close, then close with a reason so its logs
+                    // name the cause rather than a truncated H3 exchange.
+                    if tokio::time::timeout(REJECT_FLUSH_TIMEOUT, conn_for_reject.closed())
+                        .await
+                        .is_err()
+                    {
+                        conn_for_reject.close(
+                            VarInt::from_u32(0),
+                            b"no mutually supported MoQT version in WT-Available-Protocols",
+                        );
+                    }
+
+                    anyhow::bail!(
+                        "no mutually supported MoQT version in WT-Available-Protocols (offered: {:?}, supported: {:?})",
+                        offered,
+                        moq_transport::setup::SUPPORTED_ALPNS,
+                    );
+                }
+            };
             let response =
                 web_transport_quinn::proto::ConnectResponse::OK.with_protocol(selected.to_string());
 
@@ -550,7 +610,12 @@ impl Server {
             );
             (session, Transport::RawQuic)
         } else {
-            anyhow::bail!("unsupported ALPN: {}", alpn)
+            anyhow::bail!(
+                "unsupported ALPN: {} (supported: {:?} or {})",
+                alpn,
+                moq_transport::setup::SUPPORTED_ALPNS,
+                web_transport_quinn::ALPN,
+            )
         };
 
         let info = ConnInfo {

--- a/moq-native-ietf/src/quic.rs
+++ b/moq-native-ietf/src/quic.rs
@@ -3,7 +3,7 @@
 
 use std::{
     collections::HashSet,
-    fmt,
+    fmt::{self, Write as _},
     fs::File,
     io::BufWriter,
     net::{self, IpAddr},
@@ -111,14 +111,33 @@ fn bind_smart(addr: net::SocketAddr) -> anyhow::Result<(net::UdpSocket, bool)> {
     Ok((socket.into(), is_dual_stack))
 }
 
-/// Build a TransportConfig with our standard settings
+/// HTTP/3 `H3_NO_ERROR` ([RFC 9114] §8.1): the H3 layer completed normally, the
+/// request was simply refused.
 ///
-/// This is used both for the base endpoint config and when creating
-/// per-connection configs with qlog enabled.
+/// Wire hygiene rather than a behaviour fix — §8 already requires an unknown
+/// code to be read as H3_NO_ERROR, so a conformant peer read the previous 0
+/// the same way. `H3_REQUEST_REJECTED` would be wrong here: §4.1.1 reserves it
+/// for requests the server did not process, and this one was answered with 406.
+///
+/// [RFC 9114]: https://www.rfc-editor.org/rfc/rfc9114.html#section-8.1
+const H3_NO_ERROR: u32 = 0x100;
+
 /// How long a rejected WebTransport CONNECT is given to reach the peer before
 /// the connection is closed underneath it.
 const REJECT_FLUSH_TIMEOUT: time::Duration = time::Duration::from_millis(250);
 
+/// Caps the offered protocol identifiers logged when a CONNECT is rejected.
+///
+/// The list is peer-controlled on a pre-authentication path. H3 bounds the
+/// whole header block to 64 KiB, but that is still ~104 KiB of decoded text in
+/// one entry, so both the entry count and each entry's length are capped.
+const MAX_LOGGED_PROTOCOLS: usize = 16;
+const MAX_LOGGED_PROTOCOL_LEN: usize = 64;
+
+/// Build a TransportConfig with our standard settings
+///
+/// This is used both for the base endpoint config and when creating
+/// per-connection configs with qlog enabled.
 fn build_transport_config() -> quinn::TransportConfig {
     let mut transport = quinn::TransportConfig::default();
     transport.max_idle_timeout(Some(time::Duration::from_secs(10).try_into().unwrap()));
@@ -543,9 +562,26 @@ impl Server {
             let selected = match moq_transport::setup::negotiate_version(&request.protocols) {
                 Some(selected) => selected,
                 None => {
-                    // `reject` consumes the request, so keep the offer for the log
-                    // and the error.
-                    let offered = request.protocols.clone();
+                    // `reject` consumes the request, so render the offer now,
+                    // bounded in both directions: the peer chooses how many
+                    // entries it sends and how long each one is.
+                    let offered = {
+                        let total = request.protocols.len();
+                        let shown: Vec<String> = request
+                            .protocols
+                            .iter()
+                            .take(MAX_LOGGED_PROTOCOLS)
+                            .map(|p| match p.char_indices().nth(MAX_LOGGED_PROTOCOL_LEN) {
+                                Some((cut, _)) => format!("{}…", &p[..cut]),
+                                None => p.clone(),
+                            })
+                            .collect();
+                        let mut rendered = format!("{shown:?}");
+                        if total > MAX_LOGGED_PROTOCOLS {
+                            let _ = write!(rendered, " (+{} more)", total - MAX_LOGGED_PROTOCOLS);
+                        }
+                        rendered
+                    };
 
                     // Answer the CONNECT instead of dropping the connection, so the
                     // peer learns why, and record what it offered: without this the
@@ -553,7 +589,7 @@ impl Server {
                     tracing::warn!(
                         cid = %connection_id_hex,
                         ip = %remote_address,
-                        offered = ?offered,
+                        offered = %offered,
                         supported = ?moq_transport::setup::SUPPORTED_ALPNS,
                         "rejecting WebTransport CONNECT: no mutually supported MoQT version in WT-Available-Protocols"
                     );
@@ -575,14 +611,16 @@ impl Server {
                         .await
                         .is_err()
                     {
+                        // H3_NO_ERROR: the H3 layer did its job and answered the
+                        // CONNECT; 0 is not a defined HTTP/3 error code.
                         conn_for_reject.close(
-                            VarInt::from_u32(0),
+                            VarInt::from_u32(H3_NO_ERROR),
                             b"no mutually supported MoQT version in WT-Available-Protocols",
                         );
                     }
 
                     anyhow::bail!(
-                        "no mutually supported MoQT version in WT-Available-Protocols (offered: {:?}, supported: {:?})",
+                        "no mutually supported MoQT version in WT-Available-Protocols (offered: {}, supported: {:?})",
                         offered,
                         moq_transport::setup::SUPPORTED_ALPNS,
                     );


### PR DESCRIPTION
When a WebTransport client offered no MoQT version we understood, the relay logged "no mutually supported MoQT version in WT-Available-Protocols" and dropped the connection without saying what the peer had actually offered, or answering the CONNECT at all. Diagnosing a rejected peer meant reading its source: the log named the failure but none of the evidence.

Log the offered list next to our supported list, and answer the CONNECT with 406. draft-18 §3.1.3 has the client advertise MoQT identifiers in WT-Available-Protocols, and draft-ietf-webtrans-http3 §3.3 permits the server to "reject the request if the client did not include a suitable protocol", so rejecting stays correct; only the diagnostics change.

Answering takes a little care: `reject` merely queues the response, and both closing the connection and dropping it stop sending immediately, so a naive reject-then-close truncates the very response it just wrote. The connection is therefore held (a handle is cloned before `Request::accept` consumes it) for a bounded 250ms while the peer reads the 406, and only then closed with a reason phrase. Without that window the peer reports a truncated H3 exchange; with it, it reports the status:

before: failed to exchange h3 connect: protocol error: unexpected end of input after: failed to exchange h3 connect: protocol error: expected 200, got: Some(406)

The raw-QUIC branch's "unsupported ALPN" error now names the ALPNs we accept for the same reason.

Verified against a relay from this branch: a client offering "moqt-17" now produces

WARN rejecting WebTransport CONNECT: no mutually supported MoQT version in WT-Available-Protocols cid=... ip=... offered=["moqt-17"] supported=["moqt-18"]

and the WebTransport and raw-QUIC happy paths are unchanged.

Spec: draft-ietf-moq-transport-18 §3.1, §3.1.3; draft-ietf-webtrans-http3 §3.3 <https://www.ietf.org/archive/id/draft-ietf-moq-transport-18.html>

---

## Verification

Built a relay from this branch and a client whose `SUPPORTED_ALPNS` is `["moqt-17"]`, so negotiation genuinely fails:

```
WARN rejecting WebTransport CONNECT: no mutually supported MoQT version in
     WT-Available-Protocols cid=8d67c60a... ip=127.0.0.1:56422
     offered=["moqt-17"] supported=["moqt-18"]
```

and the peer now reports the status rather than a truncated exchange:

```
before: failed to exchange h3 connect: protocol error: unexpected end of input
after:  failed to exchange h3 connect: protocol error: expected 200, got: Some(406)
```

WebTransport and raw-QUIC happy paths re-run against the same relay and are unchanged. `cargo fmt --all --check` clean, no new clippy warnings.

## Why this matters

An interop run against five draft-18 relays produced four clients that our relay rejected. Diagnosing them required reading each client's source to learn what it advertised, because the log named the failure but none of the evidence. Two of those four turned out not to implement WebTransport at all, and two were offering `moqt-16`/`moqt-14`; one log line would have said so.