### PR TITLE
draft-18: fix(moq-transport): correct draft-18 error code registry (swapped TOO_FAR_BEHIND/EXPIRED, missing codes)

### DIFF
--- a/moq-transport/src/error.rs
+++ b/moq-transport/src/error.rs
@@ -104,6 +104,11 @@ impl MoqError for SubscribeError {
 }
 
 /// An error that causes the subscribe to be terminated.
+///
+/// Unused legacy table. Its values predate draft-18 and disagree with the
+/// §15.10.3 PUBLISH_DONE registry from 0x2 upwards, so converting a wire status
+/// code through it yields the wrong variant. Use
+/// [`PublishDoneCode`](crate::message::PublishDoneCode) instead.
 #[derive(thiserror::Error, Debug)]
 pub enum SubscribeDone {
     // Official error codes

--- a/moq-transport/src/message/publish_done.rs
+++ b/moq-transport/src/message/publish_done.rs
@@ -3,7 +3,7 @@
 
 use crate::coding::{Decode, DecodeError, Encode, EncodeError, ReasonPhrase};
 
-/// Draft-16 §13.4.3 PUBLISH_DONE codes.
+/// PUBLISH_DONE codes from the draft-18 §15.10.3 IANA registry.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(u64)]
 pub enum PublishDoneCode {
@@ -12,9 +12,10 @@ pub enum PublishDoneCode {
     TrackEnded = 0x2,
     SubscriptionEnded = 0x3,
     GoingAway = 0x4,
-    Expired = 0x5,
-    TooFarBehind = 0x6,
+    TooFarBehind = 0x5,
+    Expired = 0x6,
     UpdateFailed = 0x8,
+    ExcessiveLoad = 0x9,
     MalformedTrack = 0x12,
 }
 
@@ -85,5 +86,22 @@ mod tests {
         msg.encode(&mut buf).unwrap();
         let decoded = PublishDone::decode(&mut buf).unwrap();
         assert_eq!(decoded, msg);
+    }
+
+    /// The wire values come from the draft-18 §15.10.3 registry (Table 19).
+    /// TOO_FAR_BEHIND and EXPIRED are adjacent and were previously swapped, so
+    /// pin every code rather than only the pair that was wrong.
+    #[test]
+    fn codes_match_the_iana_registry() {
+        assert_eq!(PublishDoneCode::InternalError as u64, 0x0);
+        assert_eq!(PublishDoneCode::Unauthorized as u64, 0x1);
+        assert_eq!(PublishDoneCode::TrackEnded as u64, 0x2);
+        assert_eq!(PublishDoneCode::SubscriptionEnded as u64, 0x3);
+        assert_eq!(PublishDoneCode::GoingAway as u64, 0x4);
+        assert_eq!(PublishDoneCode::TooFarBehind as u64, 0x5);
+        assert_eq!(PublishDoneCode::Expired as u64, 0x6);
+        assert_eq!(PublishDoneCode::UpdateFailed as u64, 0x8);
+        assert_eq!(PublishDoneCode::ExcessiveLoad as u64, 0x9);
+        assert_eq!(PublishDoneCode::MalformedTrack as u64, 0x12);
     }
 }

--- a/moq-transport/src/message/request_error.rs
+++ b/moq-transport/src/message/request_error.rs
@@ -33,9 +33,10 @@ pub enum RequestErrorCode {
     /// Property (types 0x4000-0x7FFF) carried by PUBLISH, SUBSCRIBE_OK or
     /// FETCH_OK.
     UnsupportedExtension = 0x33,
-    /// §10.6.2 requires a trailing Redirect structure whenever this code is
-    /// used, which [`RequestError`] cannot encode yet. Recognise it on receive;
-    /// do not send it until the structure is implemented.
+    /// §10.6.2 requires a trailing Redirect structure (defined in §10.6.1)
+    /// whenever this code is used, which [`RequestError`] cannot encode yet.
+    /// Recognise it on receive; do not send it until the structure is
+    /// implemented.
     Redirect = 0x34,
 }
 

--- a/moq-transport/src/message/request_error.rs
+++ b/moq-transport/src/message/request_error.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024-2026 Cloudflare Inc.
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! REQUEST_ERROR message (draft-ietf-moq-transport-16 §9.8).
+//! REQUEST_ERROR message (draft-ietf-moq-transport-18 §10.6).
 //!
 //! Sent in response to any request (SUBSCRIBE, FETCH, PUBLISH,
 //! SUBSCRIBE_NAMESPACE, PUBLISH_NAMESPACE, TRACK_STATUS, REQUEST_UPDATE).
@@ -9,7 +9,7 @@
 
 use crate::coding::{Decode, DecodeError, Encode, EncodeError, ReasonPhrase};
 
-/// Draft-16 §13.4.2 REQUEST_ERROR codes.
+/// REQUEST_ERROR codes from the draft-18 §15.10.2 IANA registry.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(u64)]
 pub enum RequestErrorCode {
@@ -19,13 +19,24 @@ pub enum RequestErrorCode {
     NotSupported = 0x3,
     MalformedAuthToken = 0x4,
     ExpiredAuthToken = 0x5,
+    GoingAway = 0x6,
+    ExcessiveLoad = 0x9,
     DoesNotExist = 0x10,
     InvalidRange = 0x11,
     MalformedTrack = 0x12,
     DuplicateSubscription = 0x19,
     Uninterested = 0x20,
     PrefixOverlap = 0x30,
+    NamespaceTooLarge = 0x31,
     InvalidJoiningRequestId = 0x32,
+    /// Required by §2.5.1 when a peer does not understand a Mandatory Track
+    /// Property (types 0x4000-0x7FFF) carried by PUBLISH, SUBSCRIBE_OK or
+    /// FETCH_OK.
+    UnsupportedExtension = 0x33,
+    /// §10.6.2 requires a trailing Redirect structure whenever this code is
+    /// used, which [`RequestError`] cannot encode yet. Recognise it on receive;
+    /// do not send it until the structure is implemented.
+    Redirect = 0x34,
 }
 
 impl From<RequestErrorCode> for u64 {
@@ -113,6 +124,29 @@ mod tests {
         msg.encode(&mut buf).unwrap();
         let decoded = RequestError::decode(&mut buf).unwrap();
         assert_eq!(decoded, msg);
+    }
+
+    /// The wire values come from the draft-18 §15.10.2 registry (Table 18).
+    #[test]
+    fn codes_match_the_iana_registry() {
+        assert_eq!(RequestErrorCode::InternalError as u64, 0x0);
+        assert_eq!(RequestErrorCode::Unauthorized as u64, 0x1);
+        assert_eq!(RequestErrorCode::Timeout as u64, 0x2);
+        assert_eq!(RequestErrorCode::NotSupported as u64, 0x3);
+        assert_eq!(RequestErrorCode::MalformedAuthToken as u64, 0x4);
+        assert_eq!(RequestErrorCode::ExpiredAuthToken as u64, 0x5);
+        assert_eq!(RequestErrorCode::GoingAway as u64, 0x6);
+        assert_eq!(RequestErrorCode::ExcessiveLoad as u64, 0x9);
+        assert_eq!(RequestErrorCode::DoesNotExist as u64, 0x10);
+        assert_eq!(RequestErrorCode::InvalidRange as u64, 0x11);
+        assert_eq!(RequestErrorCode::MalformedTrack as u64, 0x12);
+        assert_eq!(RequestErrorCode::DuplicateSubscription as u64, 0x19);
+        assert_eq!(RequestErrorCode::Uninterested as u64, 0x20);
+        assert_eq!(RequestErrorCode::PrefixOverlap as u64, 0x30);
+        assert_eq!(RequestErrorCode::NamespaceTooLarge as u64, 0x31);
+        assert_eq!(RequestErrorCode::InvalidJoiningRequestId as u64, 0x32);
+        assert_eq!(RequestErrorCode::UnsupportedExtension as u64, 0x33);
+        assert_eq!(RequestErrorCode::Redirect as u64, 0x34);
     }
 
     #[test]

--- a/moq-transport/src/serve/error.rs
+++ b/moq-transport/src/serve/error.rs
@@ -43,9 +43,17 @@ pub enum ServeError {
 }
 
 impl ServeError {
-    /// Returns error codes for per-request/per-track errors.
-    /// These codes are used in SUBSCRIBE_ERROR, PUBLISH_DONE, FETCH_ERROR, etc.
-    /// Error codes are based on draft-ietf-moq-transport-14 Section 13.1.x
+    /// Legacy per-request/per-track error codes.
+    ///
+    /// These predate draft-18 and do **not** match its registries: `NotFound`
+    /// answers 0x4 where §15.10.2 assigns DOES_NOT_EXIST 0x10, and `Done`
+    /// answers 0x0 where the PUBLISH_DONE path in `session::subscribed` uses
+    /// TRACK_ENDED 0x2. The only wire user left is PUBLISH_NAMESPACE_CANCEL.
+    ///
+    /// New code should map to [`RequestErrorCode`](crate::message::RequestErrorCode)
+    /// or [`PublishDoneCode`](crate::message::PublishDoneCode) directly.
+    ///
+    /// TODO: retire this in favour of the registry enums.
     pub fn code(&self) -> u64 {
         match self {
             // Special case: 0 typically means successful completion or internal error depending on context

--- a/moq-transport/src/serve/error.rs
+++ b/moq-transport/src/serve/error.rs
@@ -48,7 +48,15 @@ impl ServeError {
     /// These predate draft-18 and do **not** match its registries: `NotFound`
     /// answers 0x4 where §15.10.2 assigns DOES_NOT_EXIST 0x10, and `Done`
     /// answers 0x0 where the PUBLISH_DONE path in `session::subscribed` uses
-    /// TRACK_ENDED 0x2. The only wire user left is PUBLISH_NAMESPACE_CANCEL.
+    /// TRACK_ENDED 0x2.
+    ///
+    /// The only direct in-workspace wire user is PUBLISH_NAMESPACE_CANCEL. Note
+    /// also that the public
+    /// [`SessionError::code`](crate::session::SessionError::code) delegates here
+    /// for its `Serve` variant: nothing in this workspace calls it, but an
+    /// embedder can, and its result is measured against the §15.10.1
+    /// session-termination registry — a third registry these values were never
+    /// designed for. Both callers need addressing to retire this.
     ///
     /// New code should map to [`RequestErrorCode`](crate::message::RequestErrorCode)
     /// or [`PublishDoneCode`](crate::message::PublishDoneCode) directly.


### PR DESCRIPTION
`PublishDoneCode` had TOO\_FAR\_BEHIND and EXPIRED transposed against the §15.10.3 registry (Table 19), which assigns TOO\_FAR\_BEHIND 0x5 and EXPIRED 0x6. A peer told a subscription had fallen too far behind would have read it as expired, and vice versa. EXCESSIVE\_LOAD (0x9) was absent.

`RequestErrorCode` was missing five codes from the §15.10.2 registry (Table 18): GOING\_AWAY 0x6, EXCESSIVE\_LOAD 0x9, NAMESPACE\_TOO\_LARGE 0x31, UNSUPPORTED\_EXTENSION 0x33 and REDIRECT 0x34. UNSUPPORTED\_EXTENSION is the notable one: §2.5.1 requires it when a peer does not understand a Mandatory Track Property (0x4000-0x7FFF) on PUBLISH, SUBSCRIBE\_OK or FETCH\_OK, and we had no way to signal it.

Both enums now pin every registry entry with a test, so a future transposition fails rather than reaching the wire.

Neither transposed variant had a production caller — every use is an `as u64` cast and no code compares the raw values — so this changes no behaviour today. It is a definitional fix that would otherwise have surfaced as a silent interop failure the first time either code was sent.

Two adjacent problems are documented rather than changed, to keep this scoped:

* `ServeError::code` predates draft-18 and matches neither registry (`NotFound` answers 0x4 where DOES\_NOT\_EXIST is 0x10; `Done` answers 0x0 where the PUBLISH\_DONE path uses TRACK\_ENDED). Its one remaining wire user is PUBLISH\_NAMESPACE\_CANCEL. The comment now says so instead of claiming a conformance the body does not have.
* `error::SubscribeDone` is an unused but public legacy table whose `From<u64>` disagrees with §15.10.3 from 0x2 up. Deleting it is a breaking API change, so it is documented as wrong and left for a follow-up.

REDIRECT is marked receive-only: §10.6.2 requires a trailing Redirect structure that `RequestError` cannot encode yet.

Spec: draft-ietf-moq-transport-18 §15.10.2, §15.10.3, §2.5.1, §10.6.2 <https://www.ietf.org/archive/id/draft-ietf-moq-transport-18.html>