### PR TITLE
fix: treat peer-forwarded PUBLISH_NAMESPACE as discovery-only

### DIFF
--- a/moq-relay-ietf/src/consumer.rs
+++ b/moq-relay-ietf/src/consumer.rs
@@ -13,7 +13,8 @@ use moq_transport::{
 use tokio::sync::Semaphore;
 
 use crate::{
-    metrics::GaugeGuard, Coordinator, Locals, Producer, RemoteManager, SessionContext, TrackRequest,
+    metrics::GaugeGuard, Coordinator, Locals, Producer, RemoteManager, SessionContext,
+    SessionInterface, TrackRequest,
 };
 
 const MAX_INBOUND_PUBLISH_TRACKS_PER_SESSION: usize = 1024;
@@ -104,6 +105,71 @@ impl Consumer {
         }
     }
 
+    /// Serve a PUBLISH_NAMESPACE forwarded by a peer relay: advertise it for
+    /// discovery, and route nothing through this session.
+    ///
+    /// The peer that forwarded this is not the origin, it is relaying on the
+    /// origin's behalf, so this relay must not present itself as a source. It
+    /// registers the namespace the same way the SUBSCRIBE_NAMESPACE pull path
+    /// does — visible to `list_namespaces_matching`, absent from
+    /// `route_namespace` — so a downstream SUBSCRIBE misses locally and resolves
+    /// through the coordinator to whoever actually owns it.
+    ///
+    /// Deliberately absent, each for its own reason:
+    ///
+    /// * **No coordinator registration.** Ownership is the origin's. Claiming it
+    ///   here races the origin for one key and loses, and the losing path
+    ///   unwinds the local registration it had already published — which
+    ///   downstream reads as the namespace being withdrawn milliseconds after
+    ///   it appeared, while the publisher is still live.
+    ///
+    /// * **No request queue.** With no local route nothing can queue against
+    ///   this session, so there is no queue to strand and no need to drain one.
+    ///
+    /// * **No subscribe reaching this session.** That matters twice over: the
+    ///   forwarding peer publishes a placeholder track container whose request
+    ///   channel is closed at creation, and that publication takes priority
+    ///   over the peer's own unknown-subscribe fall-through — so a subscribe
+    ///   arriving there answers "does not exist" even though the peer holds a
+    ///   working route. And a dialed session has no `Producer` draining
+    ///   `subscribed()` at all, so it could not be served even if the
+    ///   placeholder were gone.
+    ///
+    /// * **No onward fan-out.** The coordinator already returns no subscriber
+    ///   relays for an internal context; not asking is one fewer way to
+    ///   propagate a forwarded announce into a loop.
+    async fn serve_proxied(
+        self,
+        mut published_ns: PublishedNamespace,
+    ) -> Result<(), anyhow::Error> {
+        let ns = published_ns.namespace.to_utf8_path();
+
+        let _registration = match self
+            .locals
+            .register_remote_namespace(self.context.scope(), published_ns.namespace.clone())
+        {
+            Ok(registration) => registration,
+            Err(err) => {
+                metrics::counter!("moq_relay_announce_errors_total", "phase" => "remote_register")
+                    .increment(1);
+                return Err(err);
+            }
+        };
+        tracing::debug!(namespace = %ns, "registered proxied namespace for discovery");
+
+        if let Err(err) = published_ns.ok() {
+            metrics::counter!("moq_relay_announce_errors_total", "phase" => "send_ok").increment(1);
+            return Err(err.into());
+        }
+        metrics::counter!("moq_relay_announce_ok_total", "kind" => "proxied").increment(1);
+        tracing::info!(namespace = %ns, "serving proxied PUBLISH_NAMESPACE from peer relay");
+
+        published_ns.closed().await?;
+        tracing::info!(namespace = %ns, "proxied PUBLISH_NAMESPACE closed");
+
+        Ok(())
+    }
+
     /// Serve an inbound PUBLISH_NAMESPACE.
     async fn serve(mut self, mut published_ns: PublishedNamespace) -> Result<(), anyhow::Error> {
         // Track active publishers - decrements when this function returns.
@@ -113,6 +179,12 @@ impl Consumer {
             futures::future::BoxFuture<'static, Result<(), anyhow::Error>>,
         > = FuturesUnordered::new();
         let ns = published_ns.namespace.to_utf8_path();
+
+        // A namespace forwarded by a peer relay is proxied, not ours, so it is
+        // advertised for discovery and nothing more.
+        if self.context.interface == SessionInterface::Internal {
+            return self.serve_proxied(published_ns).await;
+        }
 
         // Register namespace routing metadata locally. This does not register
         // any media tracks; it only creates a request queue used when a
@@ -159,13 +231,16 @@ impl Consumer {
             return Err(err.into());
         }
         tracing::debug!(namespace = %ns, "sent REQUEST_OK for PUBLISH_NAMESPACE");
-        metrics::counter!("moq_relay_announce_ok_total").increment(1);
+        metrics::counter!("moq_relay_announce_ok_total", "kind" => "client").increment(1);
 
         // Forward the namespace upstream, if configured.
         if let Some(mut forward) = self.forward {
-            // The forwarding API still uses the moq-transport Tracks helper.
-            // This helper is not the relay-local registry; it is only an
-            // adapter for the outgoing publish_namespace API.
+            // Same advertise-only container as the peer fan-out below, and the
+            // same defect: dropping the request half here means the `--announce`
+            // upstream cannot route a subscribe back down this session either.
+            // Latent rather than fixed — no deployment sets `--announce` today,
+            // and giving it a real route is the same work as making dialed
+            // sessions serve subscribes, which is deliberately out of scope.
             let (_, _forward_request, forward_reader) =
                 Tracks::new(published_ns.namespace.clone()).produce();
             tasks.push(
@@ -219,6 +294,15 @@ impl Consumer {
             // The forwarding API uses the moq-transport Tracks helper as an
             // adapter for the outgoing publish_namespace call; it is not the
             // relay-local registry.
+            // Advertise-only container. Its writer and request halves are
+            // dropped here, which closes the request channel at creation, so
+            // the reader can carry the namespace outward but can never answer a
+            // subscribe. That is load-bearing and fragile: on the receiving
+            // peer this publication takes priority over the unknown-subscribe
+            // fall-through, so any subscribe routed back down this session gets
+            // "does not exist" rather than the peer's real route. Nothing must
+            // route a subscribe here — see `serve_proxied`, and the guard test
+            // `fanout_adapter_accepts_a_subscribe_it_can_never_serve`.
             let (_, _request, reader) = Tracks::new(published_ns.namespace.clone()).produce();
             tasks.push(
                 async move {
@@ -406,5 +490,57 @@ impl Consumer {
         tracing::info!(namespace = %namespace, track = %track_name, "PUBLISH closed");
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::FutureExt;
+    use moq_transport::serve::Tracks;
+
+    fn ns(path: &str) -> moq_transport::coding::TrackNamespace {
+        moq_transport::coding::TrackNamespace::try_from(path).expect("valid namespace")
+    }
+
+    /// Pins the defect in the fan-out adapter so it stays visible.
+    ///
+    /// `serve()` builds this container to carry a namespace outward and drops
+    /// its writer and request halves immediately, which closes the request
+    /// channel before anything can use it. The container is therefore incapable
+    /// of answering a subscribe — and on the receiving peer it takes priority
+    /// over the unknown-subscribe fall-through, so a subscribe routed to it is
+    /// answered "does not exist" rather than being served from the peer's real
+    /// route.
+    ///
+    /// The fix keeps subscribes away from it rather than repairing it, which
+    /// makes this a property nothing enforces at the type level. If a future
+    /// change routes a subscribe onto a fan-out session, this test is the
+    /// warning that the destination is a dead end.
+    #[test]
+    fn fanout_adapter_accepts_a_subscribe_it_can_never_serve() {
+        let namespace = ns("room/123");
+
+        // Note what it does NOT do: refuse. It accepts the subscribe and hands
+        // back a track, having pushed the matching writer onto a queue that has
+        // no consumer. The subscribe is answered, then never served.
+        let (_, _request, mut reader) = Tracks::new(namespace.clone()).produce();
+        assert!(
+            reader.subscribe(namespace.clone(), "video").is_some(),
+            "expected the advertise-only container to accept a subscribe it \
+             cannot serve; if it now refuses outright, the hazard has changed \
+             shape and the comments at both Tracks::produce call sites need \
+             revisiting"
+        );
+
+        // With the request half alive the same container does serve, which is
+        // what makes dropping it the whole defect rather than an incidental
+        // detail. Keeping both cases in one test stops the assertion above from
+        // being read as "this container is simply broken".
+        let (_, mut request, mut wired) = Tracks::new(namespace.clone()).produce();
+        assert!(wired.subscribe(namespace, "video").is_some());
+        assert!(
+            request.next().now_or_never().flatten().is_some(),
+            "a wired container must deliver the writer to its requester"
+        );
     }
 }

--- a/moq-relay-ietf/src/local.rs
+++ b/moq-relay-ietf/src/local.rs
@@ -143,13 +143,84 @@ pub struct UpstreamReadyTx {
 impl UpstreamReadyTx {
     /// Report that the upstream publisher acknowledged the SUBSCRIBE.
     pub fn established(&self) {
-        // Fails only when every downstream subscriber has already gone away.
-        let _ = self.state.send(UpstreamState::Established);
+        self.resolve(UpstreamState::Established);
     }
 
     /// Report that the upstream subscription could not be established.
     pub fn failed(&self, err: ServeError) {
-        let _ = self.state.send(UpstreamState::Failed(err));
+        self.resolve(UpstreamState::Failed(err));
+    }
+
+    /// Record the outcome, whether or not anyone is currently waiting.
+    ///
+    /// `watch::Sender::send` refuses to update once the last receiver is gone,
+    /// which would leave the state on `Pending` forever and make a resolved
+    /// subscription indistinguishable from an abandoned one. The outcome is
+    /// what [`Drop`] keys off, so it has to be recorded unconditionally.
+    fn resolve(&self, outcome: UpstreamState) {
+        self.state.send_replace(outcome);
+    }
+}
+
+/// Resolve the gate on drop so abandonment is never silent.
+///
+/// Most ways this sender dies are not calls to [`UpstreamReadyTx::established`]
+/// or [`UpstreamReadyTx::failed`]: the owning session can return early, be torn
+/// down mid-handshake, or have its task dropped while parked on the upstream
+/// SUBSCRIBE. In every one of those cases the publisher really is gone, so
+/// failing the gate is the correct outcome and not merely a better log line —
+/// waiting subscribers must be released rather than left until the response
+/// timeout.
+///
+/// Without this, the sender's disappearance was only observable as a closed
+/// channel, which surfaced downstream as an unattributable internal error with
+/// no indication of which session gave up or why.
+impl Drop for UpstreamReadyTx {
+    fn drop(&mut self) {
+        // Fast path: already resolved. Checked before building the error so a
+        // successful subscription's teardown neither allocates nor takes the
+        // write lock.
+        //
+        // This must stay an `if` around `matches!`. The condition of an `if` is
+        // a temporary scope, so the read guard is released before the body
+        // runs; `if let` is not, and would hold it across the write lock below
+        // and self-deadlock every abandoned request.
+        if !matches!(&*self.state.borrow(), UpstreamState::Pending) {
+            return;
+        }
+
+        // Deliberately not `ServeError::internal_ctx`: that mints a UUID, and
+        // `Uuid::new_v4` panics rather than degrading when the OS entropy
+        // source is unavailable (seccomp-blocked `getrandom`, an exhausted fd
+        // table with no `/dev/urandom`). A `Drop` must not make a fallible
+        // syscall — and this one especially must not, because it runs *during*
+        // unwinding: a panic here while another panic is in flight aborts the
+        // process, turning one failed task into a dead relay.
+        //
+        // Nothing is logged here either. The waiting subscriber already reports
+        // this at its own site, with the namespace and track attached, so the
+        // reason only has to be carried in the error itself. Spelling it out
+        // rather than hiding it behind a correlation id makes that report
+        // self-explanatory and gives the downstream REQUEST_ERROR an honest
+        // reason phrase; there is nothing sensitive in "the publisher left".
+        //
+        // Built out here rather than in the closure so the allocation stays off
+        // the write lock, and so the closure cannot do anything but match and
+        // move — `send_if_modified` re-raises a panicking closure.
+        let err = ServeError::Internal(
+            "upstream publisher went away before the subscription was established".to_string(),
+        );
+
+        // Re-check under the lock so a concurrently recorded outcome always
+        // wins over this fallback; the sender is never cloned, so this is
+        // belt-and-braces rather than a live race.
+        self.state.send_if_modified(|state| match state {
+            UpstreamState::Pending => {
+                *state = UpstreamState::Failed(err);
+                true
+            }
+            _ => false,
+        });
     }
 }
 
@@ -1739,9 +1810,177 @@ mod tests {
             .established()
             .await
             .expect_err("an abandoned request must not leave subscribers waiting forever");
+        // The reason is spelled out rather than reported as an opaque internal
+        // error: abandonment used to be indistinguishable from any other
+        // internal fault once it reached the subscriber.
         assert!(
-            matches!(err, ServeError::InternalWithId(_, _)),
+            matches!(&err, ServeError::Internal(reason) if reason.contains("upstream publisher went away")),
             "unexpected error: {err}"
+        );
+    }
+
+    /// The production strand: the owning session gives up *before* it ever
+    /// drains its request queue, so the request is destroyed while still
+    /// buffered in the channel rather than after being received.
+    ///
+    /// This is `Consumer::serve` returning early — a failed coordinator
+    /// registration, or the session being torn down — after
+    /// `register_namespace` has already published the route source. Distinct
+    /// from `abandoned_request_releases_waiting_subscribers`, which drops a
+    /// request that was successfully received.
+    #[tokio::test]
+    async fn requests_stranded_in_the_queue_release_waiting_subscribers() {
+        let mut locals = Locals::new();
+        let namespace = ns("room/123");
+        let (_registration, requests) = locals
+            .register_namespace(None, namespace.clone())
+            .await
+            .expect("namespace source should register");
+
+        // A downstream SUBSCRIBE lands in the window between the route source
+        // being published and the owning session reaching its drain loop.
+        let upstream = locals
+            .get_or_request_track(None, namespace.clone(), "video")
+            .await
+            .expect("missing track should be requested")
+            .upstream
+            .expect("cached track should hand back a gate");
+
+        // The session aborts without ever calling `requests.recv()`.
+        drop(requests);
+
+        let err = tokio::time::timeout(Duration::from_secs(5), upstream.established())
+            .await
+            .expect("a stranded request must not leave subscribers waiting")
+            .expect_err("a stranded request is not an established subscription");
+        assert!(
+            matches!(&err, ServeError::Internal(reason) if reason.contains("upstream publisher went away")),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// A resolved gate must survive the sender's drop.
+    ///
+    /// The sender outlives `established()` by the whole lifetime of the
+    /// upstream subscription, so if its `Drop` overwrote the outcome, every
+    /// subscriber arriving after a track stopped would be told the upstream
+    /// failed when it had in fact succeeded.
+    #[tokio::test]
+    async fn dropping_a_resolved_sender_does_not_overwrite_the_outcome() {
+        let mut locals = Locals::new();
+        let namespace = ns("room/123");
+        let (_registration, mut requests) = locals
+            .register_namespace(None, namespace.clone())
+            .await
+            .expect("namespace source should register");
+
+        let upstream = locals
+            .get_or_request_track(None, namespace.clone(), "video")
+            .await
+            .expect("missing track should be requested")
+            .upstream
+            .expect("cached track should hand back a gate");
+
+        let request = requests.recv().await.expect("source should get a request");
+        request.upstream.established();
+        drop(request);
+
+        tokio::time::timeout(Duration::from_secs(5), upstream.established())
+            .await
+            .expect("a resolved gate must not block")
+            .expect("dropping the sender must not turn success into failure");
+    }
+
+    /// The same guarantee for an explicit failure: the reported reason must not
+    /// be replaced by the generic drop fallback.
+    #[tokio::test]
+    async fn dropping_a_failed_sender_preserves_the_reported_reason() {
+        let mut locals = Locals::new();
+        let namespace = ns("room/123");
+        let (_registration, mut requests) = locals
+            .register_namespace(None, namespace.clone())
+            .await
+            .expect("namespace source should register");
+
+        let upstream = locals
+            .get_or_request_track(None, namespace.clone(), "video")
+            .await
+            .expect("missing track should be requested")
+            .upstream
+            .expect("cached track should hand back a gate");
+
+        let request = requests.recv().await.expect("source should get a request");
+        request.upstream.failed(ServeError::NotFound);
+        drop(request);
+
+        let err = tokio::time::timeout(Duration::from_secs(5), upstream.established())
+            .await
+            .expect("a resolved gate must not block")
+            .expect_err("the upstream failure should surface");
+        assert!(
+            matches!(err, ServeError::NotFound),
+            "drop fallback overwrote the real reason: {err}"
+        );
+    }
+
+    /// Resolving with every receiver already gone must still be recorded.
+    ///
+    /// `watch::Sender::send` refuses to update once the last receiver drops,
+    /// which would leave a successfully established subscription sitting on
+    /// `Pending` — indistinguishable from abandonment, and so reported as a
+    /// spurious failure by the `Drop` fallback.
+    ///
+    /// Driven against the sender directly: in the registry the cache entry
+    /// holds its own receiver, so the last-receiver case cannot be staged
+    /// through `get_or_request_track`.
+    #[test]
+    fn outcome_is_recorded_after_the_last_receiver_is_gone() {
+        let (state_tx, state_rx) = watch::channel(UpstreamState::Pending);
+        let tx = UpstreamReadyTx { state: state_tx };
+
+        drop(state_rx);
+        tx.established();
+
+        assert!(
+            matches!(&*tx.state.borrow(), UpstreamState::Established),
+            "the outcome must be recorded even with no receivers left"
+        );
+    }
+
+    /// With the outcome recorded, `Drop` must leave it alone — otherwise the
+    /// fallback would rewrite a success into a failure.
+    #[test]
+    fn drop_does_not_rewrite_an_outcome_recorded_without_receivers() {
+        let (state_tx, state_rx) = watch::channel(UpstreamState::Pending);
+        let tx = UpstreamReadyTx { state: state_tx };
+
+        // Genuinely zero receivers at the moment the outcome is reported; the
+        // observer re-attaches only afterwards, standing in for a subscriber
+        // that arrives while the track is still cached.
+        drop(state_rx);
+        tx.established();
+        let observer = tx.state.subscribe();
+        drop(tx);
+
+        assert!(
+            matches!(&*observer.borrow(), UpstreamState::Established),
+            "drop must not overwrite a recorded success"
+        );
+    }
+
+    /// An unresolved sender must fail the gate on drop rather than leaving it
+    /// pending: that is what releases subscribers when a session is torn down
+    /// while parked on the upstream SUBSCRIBE.
+    #[test]
+    fn drop_resolves_an_unreported_outcome_as_failed() {
+        let (state_tx, state_rx) = watch::channel(UpstreamState::Pending);
+        let tx = UpstreamReadyTx { state: state_tx };
+
+        drop(tx);
+
+        assert!(
+            matches!(&*state_rx.borrow(), UpstreamState::Failed(_)),
+            "an unresolved sender must fail the gate on drop"
         );
     }
 

--- a/moq-relay-ietf/src/metrics.rs
+++ b/moq-relay-ietf/src/metrics.rs
@@ -24,8 +24,8 @@
 //! | `moq_relay_connections_closed_total` | - | Total connections that have closed (graceful or error) |
 //! | `moq_relay_connection_errors_total` | `stage` | Connection failures (stage: session_accept, session_run) |
 //! | `moq_relay_publishers_total` | - | Total publishers (PUBLISH_NAMESPACE requests) received |
-//! | `moq_relay_announce_ok_total` | - | Successful REQUEST_OK responses sent for PUBLISH_NAMESPACE |
-//! | `moq_relay_announce_errors_total` | `phase` | PUBLISH_NAMESPACE failures (phase: coordinator_register, local_register, send_ok) |
+//! | `moq_relay_announce_ok_total` | `kind` | Successful REQUEST_OK responses sent for PUBLISH_NAMESPACE (kind: client, proxied) |
+//! | `moq_relay_announce_errors_total` | `phase` | PUBLISH_NAMESPACE failures (phase: local_register, remote_register, coordinator_register, coordinator_lookup, send_ok, forward, peer_fanout) |
 //! | `moq_relay_subscribers_total` | - | Total subscribers (SUBSCRIBE requests) received |
 //! | `moq_relay_subscribe_not_found_total` | - | Track not found after checking all sources |
 //! | `moq_relay_subscribe_route_errors_total` | - | Infrastructure failure when routing to remote |
@@ -91,11 +91,14 @@ pub fn describe_metrics() {
     );
     describe_counter!(
         "moq_relay_announce_ok_total",
-        "Successful REQUEST_OK responses sent for PUBLISH_NAMESPACE"
+        "Successful REQUEST_OK responses sent for PUBLISH_NAMESPACE, by kind \
+         (client: published to this relay; proxied: forwarded by a peer relay \
+         and advertised for discovery only)"
     );
     describe_counter!(
         "moq_relay_announce_errors_total",
-        "PUBLISH_NAMESPACE failures by phase (coordinator_register, local_register, send_ok)"
+        "PUBLISH_NAMESPACE failures by phase (local_register, remote_register, \
+         coordinator_register, coordinator_lookup, send_ok, forward, peer_fanout)"
     );
     describe_counter!(
         "moq_relay_subscribers_total",

--- a/moq-relay-ietf/src/relay.rs
+++ b/moq-relay-ietf/src/relay.rs
@@ -13,7 +13,8 @@ use url::Url;
 use crate::upstream_namespaces::{UpstreamNamespaces, UpstreamNamespacesRunner};
 use crate::{
     metrics::GaugeGuard, ConnectionMeta, ConnectionTagger, Consumer, Coordinator, Locals, Producer,
-    RelayInfo, RemoteManager, Session, SessionContext, DEFAULT_CACHE_IDLE_TIMEOUT,
+    RelayInfo, RemoteManager, Session, SessionContext, SessionInterface,
+    DEFAULT_CACHE_IDLE_TIMEOUT,
 };
 
 // A type alias for boxed future
@@ -409,6 +410,43 @@ impl Relay {
                                 }
                                 None => SessionContext::public(scope),
                             };
+
+                            // The resolved interface decides whether a
+                            // PUBLISH_NAMESPACE on this session is treated as
+                            // ours or as proxied for a peer, and until now
+                            // nothing recorded it. Classification depends on
+                            // `local_ip` being populated, which is a platform
+                            // property rather than a configured one: if it is
+                            // absent, every peer relay silently classifies as a
+                            // public client and the proxied path is never taken.
+                            // That failure mode is invisible without this line —
+                            // the behaviour degrades to exactly what it was
+                            // before, with no error anywhere.
+                            //
+                            // Emitted for every accepted session so the
+                            // precondition is observable in production rather
+                            // than inferred, but only peer sessions are worth
+                            // info: they are rare and they are the ones whose
+                            // classification changes behaviour. Clients are the
+                            // bulk of the traffic and would drown it out, so
+                            // they stay at debug and remain available when a
+                            // misclassification is what is being investigated.
+                            match context.interface {
+                                SessionInterface::Internal => tracing::info!(
+                                    interface = ?context.interface,
+                                    local_ip = ?local_ip,
+                                    remote_addr = %remote_addr,
+                                    tagger = connection_tagger.is_some(),
+                                    "session accepted"
+                                ),
+                                SessionInterface::Public => tracing::debug!(
+                                    interface = ?context.interface,
+                                    local_ip = ?local_ip,
+                                    remote_addr = %remote_addr,
+                                    tagger = connection_tagger.is_some(),
+                                    "session accepted"
+                                ),
+                            }
 
                             if let Some(ref info) = scope_info {
                                 tracing::debug!(


### PR DESCRIPTION
In multi-relay deployments that use a Coordinator implementation for coordination, when relay A fans a `PUBLISH_NAMESPACE` out to relay B, B now registers the namespace for discovery only — visible to `list_namespaces_matching`, absent from `route_namespace`, with no coordinator ownership claim and no local route. This matches the existing behavior in the `SUBSCRIBE_NAMESPACE` pull path.

Previously, peer-forwarded announces went through the same registration path as client announces, which incorrectly claimed coordinator ownership of a namespace already owned by the originating relay and created a local routing entry that could not serve subscriptions. A downstream `SUBSCRIBE` now resolves through the coordinator to the originating relay as expected.

A unit test pins the discovery-only contract on the unservable path so that future routing changes produce an explicit failure rather than a silent `DoesNotExist`.

Also in this PR:

**`impl Drop for UpstreamReadyTx`** — when an upstream session ends before acknowledging a forwarded `SUBSCRIBE`, the readiness gate now resolves with a diagnostic error instead of closing silently. The check is gated on the pre-write state so it does not fire on gates that have already resolved.

**`session accepted` log** — records the session's internal/public classification at the point it is determined. That classification controls whether a peer's `PUBLISH_NAMESPACE` is treated as proxied or as a local client announce.
