### PR TITLE
fix(moq-transport): fix TrackName test assertions to use TrackName::from

### DIFF
--- a/moq-transport/src/serve/subgroup.rs
+++ b/moq-transport/src/serve/subgroup.rs
@@ -80,19 +80,14 @@ impl SubgroupsWriter {
 
     // Helper to increment the group by one.
     pub fn append(&mut self, priority: u8) -> Result<SubgroupWriter, ServeError> {
-        let group_id;
-        let subgroup_id;
-
         // TODO: refactor here... For now, every subgroup is mapped to a new group...
         let start_new_group = true;
 
-        if start_new_group {
-            group_id = self.next_group_id;
-            subgroup_id = 0;
+        let (group_id, subgroup_id) = if start_new_group {
+            (self.next_group_id, 0)
         } else {
-            group_id = self.last_group_id;
-            subgroup_id = self.next_subgroup_id;
-        }
+            (self.last_group_id, self.next_subgroup_id)
+        };
 
         self.create(Subgroup {
             group_id,
@@ -934,7 +929,8 @@ mod tests {
         })
         .await;
 
-        let latest_sub = result.expect("higher_subgroup_id_updates_latest timed out after 5 seconds");
+        let latest_sub =
+            result.expect("higher_subgroup_id_updates_latest timed out after 5 seconds");
         assert_eq!(latest_sub.unwrap().subgroup_id, 1);
     }
 

--- a/moq-transport/src/serve/tracks.rs
+++ b/moq-transport/src/serve/tracks.rs
@@ -304,10 +304,8 @@ mod tests {
                     let gid = subgroup.group_id;
                     while let Ok(Some(mut obj)) = subgroup.next().await {
                         let oid = obj.object_id;
-                        let data: Bytes = obj
-                            .read_all()
-                            .await
-                            .expect("obj.read_all() should succeed");
+                        let data: Bytes =
+                            obj.read_all().await.expect("obj.read_all() should succeed");
                         received.push((gid, oid, data));
                     }
                 }
@@ -498,7 +496,7 @@ mod tests {
         let pub_handle = tokio::spawn(async move {
             let track_writer = request.next().await.expect("should receive track request");
 
-            assert_eq!(track_writer.name, track_name);
+            assert_eq!(track_writer.name, TrackName::from(track_name));
 
             let mut subgroups = track_writer.subgroups().unwrap();
             let mut sg = subgroups.append(0).unwrap();

--- a/moq-transport/src/watch/queue.rs
+++ b/moq-transport/src/watch/queue.rs
@@ -78,6 +78,7 @@ impl<T> Queue<T> {
     /// Push an item and wait until it is popped.
     /// Returns Ok(()) if the item was successfully popped.
     /// Returns Err(()) if the queue was closed before the item could be confirmed popped.
+    #[allow(clippy::result_unit_err)]
     pub async fn push_and_wait_until_popped(&mut self, item: T) -> Result<(), ()> {
         // Create a oneshot channel
         let (tx, rx) = oneshot::channel();


### PR DESCRIPTION
The unit tests added in #156 compare `track_writer.name` (type `TrackName`) directly against `&str` literals. `TrackName` derives `PartialEq<TrackName>` only; there is no `PartialEq<str>` impl, so the comparison fails.

Wrap the bare string literal in `TrackName::from()` at the one failing call site. The other `assert_eq!` calls in the same file that look similar (lines 353, 392) already use `TrackName::from()`; this brings line 501 into line with the existing convention.

`TrackName` remains an opaque distinct type. No changes to its API surface.