### PR TITLE
Add rendezvous timeout support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1344,6 +1344,8 @@ dependencies = [
  "moq-api",
  "moq-native-ietf",
  "moq-transport",
+ "rcgen",
+ "rustls 0.23.31",
  "serde",
  "serde_json",
  "thiserror 2.0.17",

--- a/moq-relay-ietf/Cargo.toml
+++ b/moq-relay-ietf/Cargo.toml
@@ -74,6 +74,9 @@ metrics-exporter-prometheus = { version = "0.16", optional = true }
 # test-util provides the paused-clock runtime used to test idle timeouts without
 # sleeping for real.
 tokio = { version = "1", features = ["full", "test-util"] }
+# Real loopback sessions exercise relay admission through the MoQT request path.
+rcgen = "0.13"
+rustls = { version = "0.23", features = ["aws_lc_rs"] }
 
 [features]
 default = []

--- a/moq-relay-ietf/src/local.rs
+++ b/moq-relay-ietf/src/local.rs
@@ -3,6 +3,7 @@
 
 use std::collections::hash_map;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, RwLock, Weak};
 use std::time::Duration;
 
@@ -10,7 +11,7 @@ use moq_transport::{
     coding::{TrackNamespace, TrackNamespacePrefix},
     serve::{FullTrackName, ServeError, Track, TrackReader, TrackWriter},
 };
-use tokio::sync::{broadcast, mpsc, watch};
+use tokio::sync::{broadcast, mpsc, watch, OwnedSemaphorePermit, Semaphore};
 
 use crate::interest::{TrackInterest, TrackInterestGuard};
 use crate::metrics::GaugeGuard;
@@ -36,6 +37,20 @@ const NAMESPACE_REQUEST_CHANNEL_CAPACITY: usize = 1024;
 /// paying a fresh upstream SUBSCRIBE round trip. Past that we stop paying to
 /// receive a track nobody is watching.
 pub const DEFAULT_CACHE_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Maximum rendezvous requests that may hold relay state at once.
+///
+/// One [`Locals`] registry is shared by every session on a relay. Matching the
+/// per-session bidirectional stream limit bounds aggregate rendezvous work to
+/// what one fully occupied session could create.
+pub(crate) const MAX_CONCURRENT_RENDEZVOUS_HOLDS: usize = 128;
+
+// REQUEST_ERROR stores the minimum delay in milliseconds plus one. The stride
+// is coprime with the spread, so one relay-wide sequence visits every delay
+// before repeating.
+const RENDEZVOUS_RETRY_INTERVAL_MIN: u64 = 1_001;
+const RENDEZVOUS_RETRY_INTERVAL_SPREAD: u64 = 1_000;
+const RENDEZVOUS_RETRY_INTERVAL_STRIDE: u64 = 577;
 
 /// Capacity of the namespace add/remove notification broadcast channel used by
 /// SUBSCRIBE_NAMESPACE handlers.
@@ -297,6 +312,37 @@ pub struct Locals {
     /// How long an unwatched pull-through cache entry is retained before its
     /// upstream subscription is released. Zero disables eviction.
     cache_idle_timeout: Duration,
+
+    /// Shared by every session using this relay-local registry. Admission never
+    /// waits because queued requests would still pin their bidirectional streams.
+    rendezvous_hold_permits: Arc<Semaphore>,
+
+    /// Shared sequence keeps overload responses from separate sessions from
+    /// choosing the same point in the retry window.
+    rendezvous_retry_sequence: Arc<AtomicU64>,
+}
+
+struct CacheGenerationCleanup {
+    locals: Locals,
+    scope_key: ScopeKey,
+    full_name: FullTrackName,
+    interest: TrackInterest,
+    armed: bool,
+}
+
+impl CacheGenerationCleanup {
+    fn disarm(mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for CacheGenerationCleanup {
+    fn drop(&mut self) {
+        if self.armed {
+            self.locals
+                .remove_cache_generation(&self.scope_key, &self.full_name, &self.interest);
+        }
+    }
 }
 
 impl Default for Locals {
@@ -315,6 +361,16 @@ impl Locals {
     /// A zero timeout disables idle eviction, holding upstream subscriptions for
     /// as long as the upstream session lives.
     pub fn with_cache_idle_timeout(cache_idle_timeout: Duration) -> Self {
+        Self::with_cache_idle_timeout_and_rendezvous_capacity(
+            cache_idle_timeout,
+            MAX_CONCURRENT_RENDEZVOUS_HOLDS,
+        )
+    }
+
+    fn with_cache_idle_timeout_and_rendezvous_capacity(
+        cache_idle_timeout: Duration,
+        rendezvous_capacity: usize,
+    ) -> Self {
         let (namespace_changes, _) = broadcast::channel(NAMESPACE_CHANGE_CHANNEL_CAPACITY);
         let (track_changes, _) = broadcast::channel(TRACK_CHANGE_CHANNEL_CAPACITY);
         Self {
@@ -323,7 +379,33 @@ impl Locals {
             namespace_changes,
             track_changes,
             cache_idle_timeout,
+            rendezvous_hold_permits: Arc::new(Semaphore::new(rendezvous_capacity)),
+            rendezvous_retry_sequence: Arc::new(AtomicU64::new(0)),
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_rendezvous_capacity(rendezvous_capacity: usize) -> Self {
+        Self::with_cache_idle_timeout_and_rendezvous_capacity(
+            DEFAULT_CACHE_IDLE_TIMEOUT,
+            rendezvous_capacity,
+        )
+    }
+
+    pub(crate) fn try_acquire_rendezvous_hold(&self) -> Option<OwnedSemaphorePermit> {
+        self.rendezvous_hold_permits
+            .clone()
+            .try_acquire_owned()
+            .ok()
+    }
+
+    pub(crate) fn rendezvous_overload_retry_interval(&self) -> u64 {
+        let sequence = self
+            .rendezvous_retry_sequence
+            .fetch_add(1, Ordering::Relaxed);
+        RENDEZVOUS_RETRY_INTERVAL_MIN
+            + sequence.wrapping_mul(RENDEZVOUS_RETRY_INTERVAL_STRIDE)
+                % RENDEZVOUS_RETRY_INTERVAL_SPREAD
     }
 
     pub fn subscribe_namespace_changes(&self) -> broadcast::Receiver<NamespaceChange> {
@@ -789,6 +871,13 @@ impl Locals {
             full_name: full_name.clone(),
             interest: interest.clone(),
         };
+        let cleanup = CacheGenerationCleanup {
+            locals: self.clone(),
+            scope_key: scope_key.clone(),
+            full_name: full_name.clone(),
+            interest: interest.clone(),
+            armed: true,
+        };
 
         if source
             .requests
@@ -800,12 +889,10 @@ impl Locals {
             .await
             .is_err()
         {
-            // The source is gone, so nothing will ever fill this reader. Remove
-            // the slot we claimed, but only if it is still ours: a concurrent
-            // caller may already have replaced it with a live generation.
-            self.remove_cache_generation(&scope_key, &full_name, &interest);
             return None;
         }
+
+        cleanup.disarm();
 
         Some(LocalTrack {
             reader,
@@ -1024,6 +1111,44 @@ mod tests {
         let change =
             tokio::time::timeout(std::time::Duration::from_millis(50), changes.recv()).await;
         assert!(change.is_err(), "unexpected namespace change: {change:?}");
+    }
+
+    #[test]
+    fn rendezvous_hold_capacity_is_shared_across_sessions() {
+        let locals = Locals::with_rendezvous_capacity(2);
+        let other_session = locals.clone();
+        let mut permits = (0..2)
+            .map(|_| {
+                locals
+                    .try_acquire_rendezvous_hold()
+                    .expect("capacity should admit the configured number of holds")
+            })
+            .collect::<Vec<_>>();
+
+        assert!(other_session.try_acquire_rendezvous_hold().is_none());
+
+        permits.pop();
+        assert!(other_session.try_acquire_rendezvous_hold().is_some());
+    }
+
+    #[test]
+    fn overload_retries_use_one_relay_wide_sequence() {
+        let locals = Locals::new();
+        let other_session = locals.clone();
+        let intervals = (0..1_000)
+            .map(|index| {
+                if index % 2 == 0 {
+                    locals.rendezvous_overload_retry_interval()
+                } else {
+                    other_session.rendezvous_overload_retry_interval()
+                }
+            })
+            .collect::<std::collections::HashSet<_>>();
+
+        assert_eq!(intervals.len(), 1_000);
+        assert!(intervals
+            .iter()
+            .all(|interval| (1_001..=2_000).contains(interval)));
     }
 
     #[tokio::test]
@@ -1247,6 +1372,64 @@ mod tests {
         assert!(
             no_second_request.is_err(),
             "cache hit should not request again"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelled_track_request_removes_cache_generation() {
+        let mut locals = Locals::new();
+        let namespace = ns("room/cancelled");
+        let (requests, _request_reader) = mpsc::channel(1);
+        locals
+            .namespaces
+            .write()
+            .unwrap()
+            .entry(UNSCOPED.to_string())
+            .or_default()
+            .insert(
+                namespace.clone(),
+                NamespaceEntry {
+                    local: Some(NamespaceSource { requests }),
+                    remote: Weak::new(),
+                },
+            );
+
+        // Fill the source channel so the next miss is cancelled while sending
+        // its TrackRequest, after reserving a cache generation.
+        let _first = locals
+            .get_or_request_track(None, namespace.clone(), "first")
+            .await
+            .expect("first request should fill the source channel");
+
+        let mut task_locals = locals.clone();
+        let task_namespace = namespace.clone();
+        let task = tokio::spawn(async move {
+            task_locals
+                .get_or_request_track(None, task_namespace, "cancelled")
+                .await
+        });
+        let cancelled = full(&namespace, "cancelled");
+
+        for _ in 0..10 {
+            if locals.retrieve_track(None, &cancelled).is_some() {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            locals.retrieve_track(None, &cancelled).is_some(),
+            "pending request should reserve its cache generation"
+        );
+
+        task.abort();
+        let join_error = match task.await {
+            Err(err) => err,
+            Ok(_) => panic!("request task should have been cancelled"),
+        };
+        assert!(join_error.is_cancelled());
+        assert!(
+            locals.retrieve_track(None, &cancelled).is_none(),
+            "cancelling the request must remove its cache generation"
         );
     }
 

--- a/moq-relay-ietf/src/metrics.rs
+++ b/moq-relay-ietf/src/metrics.rs
@@ -30,6 +30,8 @@
 //! | `moq_relay_subscribe_not_found_total` | - | Track not found after checking all sources |
 //! | `moq_relay_subscribe_route_errors_total` | - | Infrastructure failure when routing to remote |
 //! | `moq_relay_subscribe_upstream_errors_total` | - | Upstream subscription could not be established, so the downstream SUBSCRIBE was rejected |
+//! | `moq_relay_rendezvous_timeouts_total` | - | Rendezvous holds that ended with REQUEST_ERROR TIMEOUT |
+//! | `moq_relay_rendezvous_rejections_total` | - | Rendezvous requests rejected with EXCESSIVE_LOAD because relay or session capacity was full |
 //! | `moq_relay_upstream_errors_total` | `stage` | Upstream connection failures (stage: connect, session) |
 //! | `moq_relay_namespace_transition_timeouts_total` | - | Namespace pull streams reset after graceful transition timeout |
 //! | `moq_relay_cache_idle_evictions_total` | `source` | Unwatched cache entries evicted, releasing an upstream subscription (source: local, remote) |
@@ -43,6 +45,7 @@
 //! | `moq_relay_active_connections` | Current number of active client connections |
 //! | `moq_relay_active_publishers` | Current number of active publishers |
 //! | `moq_relay_active_subscriptions` | Current number of active subscriptions |
+//! | `moq_relay_active_rendezvous_holds` | Current SUBSCRIBE requests waiting for a publisher |
 //! | `moq_relay_active_tracks` | Current number of tracks being served |
 //! | `moq_relay_announced_namespaces` | Current number of namespaces registered via PUBLISH_NAMESPACE |
 //! | `moq_relay_upstream_connections` | Current number of upstream/origin connections |
@@ -51,7 +54,7 @@
 //!
 //! | Name | Labels | Description |
 //! |------|--------|-------------|
-//! | `moq_relay_subscribe_latency_seconds` | `source` | Time to resolve subscription (source: local, remote, not_found, route_error, upstream_error, downstream_left) |
+//! | `moq_relay_subscribe_latency_seconds` | `source` | Time to resolve subscription (source: local, remote, not_found, route_error, upstream_error, downstream_left, rendezvous_timeout, rendezvous_overloaded) |
 
 use metrics::{describe_counter, describe_gauge, describe_histogram, Unit};
 
@@ -114,6 +117,14 @@ pub fn describe_metrics() {
         "Upstream subscription could not be established, so the downstream SUBSCRIBE was rejected"
     );
     describe_counter!(
+        "moq_relay_rendezvous_timeouts_total",
+        "Rendezvous holds that ended with REQUEST_ERROR TIMEOUT"
+    );
+    describe_counter!(
+        "moq_relay_rendezvous_rejections_total",
+        "Rendezvous requests rejected with EXCESSIVE_LOAD because relay or session capacity was full"
+    );
+    describe_counter!(
         "moq_relay_upstream_errors_total",
         "Upstream connection failures by stage (connect, session)"
     );
@@ -148,6 +159,10 @@ pub fn describe_metrics() {
         "Current number of active subscriptions"
     );
     describe_gauge!(
+        "moq_relay_active_rendezvous_holds",
+        "Current SUBSCRIBE requests waiting for a publisher"
+    );
+    describe_gauge!(
         "moq_relay_active_tracks",
         "Current number of tracks being served"
     );
@@ -168,7 +183,7 @@ pub fn describe_metrics() {
     describe_histogram!(
         "moq_relay_subscribe_latency_seconds",
         Unit::Seconds,
-        "Time to resolve subscription by source (local, remote, not_found, route_error, upstream_error, downstream_left)"
+        "Time to resolve subscription by source (local, remote, not_found, route_error, upstream_error, downstream_left, rendezvous_timeout, rendezvous_overloaded)"
     );
 }
 

--- a/moq-relay-ietf/src/producer.rs
+++ b/moq-relay-ietf/src/producer.rs
@@ -2,23 +2,115 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use std::collections::HashSet;
+use std::future::Future;
 use std::sync::Arc;
 
 use futures::{stream::FuturesUnordered, FutureExt, StreamExt};
 use moq_transport::{
-    coding::{KeyValuePairs, TrackNamespace},
-    message::SubscribeOptions,
+    coding::{KeyValuePairs, TrackName, TrackNamespace},
+    message::{RequestErrorCode, SubscribeOptions},
     serve::{FullTrackName, ServeError, TrackReader, TracksReader},
-    session::{Publisher, SessionError, Subscribed, SubscribedNamespace, TrackStatusRequested},
+    session::{
+        Publisher, ServeWithDeadlineError, SessionError, Subscribed, SubscribedNamespace,
+        TrackStatusRequested,
+    },
 };
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, OwnedSemaphorePermit, Semaphore};
 
 use crate::{
+    local::MAX_CONCURRENT_RENDEZVOUS_HOLDS,
     metrics::{GaugeGuard, TimingGuard},
     upstream_namespaces::UpstreamNamespaces,
     Coordinator, Locals, NamespaceChange, RemoteManager, SessionContext, TrackChange,
     UpstreamReady,
 };
+
+/// Ceiling on how long a SUBSCRIBE is held waiting for a publisher to appear.
+///
+/// draft-18 §10.2.6 lets a relay use a shorter window than the subscriber asked
+/// for, without telling it. Each held subscribe pins a bidi stream slot and its
+/// relay-side state for the whole window. [`Locals`] separately caps concurrent
+/// holds across all sessions on the relay.
+///
+/// Hardcoded for now. The eventual source is per-scope configuration, which is
+/// the same knob the pre-spec "lingering subscribe" config carried before it was
+/// removed; 30s was its default there too.
+const MAX_RENDEZVOUS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Keep one session from consuming the relay's entire rendezvous budget. Half
+/// the relay-wide capacity remains available to other sessions.
+const MAX_CONCURRENT_RENDEZVOUS_HOLDS_PER_SESSION: usize = MAX_CONCURRENT_RENDEZVOUS_HOLDS / 2;
+
+/// How often a held SUBSCRIBE asks the coordinator again whether a publisher has
+/// turned up.
+///
+/// The broadcasts that wake a hold only carry publishers on this relay, but
+/// several relay instances serve one scope, so the publisher a subscriber is
+/// waiting for routinely lands on a different one. Its namespace goes into
+/// shared coordinator state and nothing tells this relay to look again, so
+/// without a second trigger the hold expires while the routing information sits
+/// there. Asking on an interval limits timer-driven rechecks to fifteen at the
+/// 30s ceiling. Publisher events and lagged broadcast receivers can trigger
+/// additional lookups.
+///
+/// Coordinator lookups can require network calls, so a tight interval would let
+/// a handful of holds consume routing capacity needed by other subscriptions.
+///
+/// The two costs of choosing it this way: a cross-relay publisher goes unnoticed
+/// for up to one interval after it arrives, and a window shorter than the
+/// interval expires without asking again, so those stay same-relay only.
+const RENDEZVOUS_RECHECK_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// How long to hold a SUBSCRIBE for, given what the subscriber asked for.
+///
+/// `None` means do not hold: answer immediately with DOES_NOT_EXIST, which is
+/// what draft-18 requires for both an absent parameter and an explicit 0.
+fn rendezvous_hold(
+    requested_ms: Option<u64>,
+    max: std::time::Duration,
+) -> Option<std::time::Duration> {
+    match requested_ms {
+        None | Some(0) => None,
+        Some(ms) => Some(std::time::Duration::from_millis(ms).min(max)),
+    }
+}
+
+/// Whether a newly announced namespace could serve a track in `target`.
+///
+/// `Locals` routes a track to the longest registered namespace that prefixes it,
+/// so an announcement is relevant when it prefixes the track's namespace, not
+/// only when it matches exactly.
+fn namespace_covers(announced: &TrackNamespace, target: &TrackNamespace) -> bool {
+    announced.fields.len() <= target.fields.len()
+        && announced
+            .fields
+            .iter()
+            .zip(target.fields.iter())
+            .all(|(a, b)| a == b)
+}
+
+/// How a rendezvous hold ended.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum Rendezvous {
+    /// Something that could publish this track arrived. The caller repeats the
+    /// lookup rather than assuming the track is now servable.
+    PublisherAppeared,
+    /// No local event, but the re-check interval came round, so the caller looks
+    /// again in case a publisher appeared on another relay.
+    RecheckDue,
+    /// The window closed before routing produced a usable publisher. The caller
+    /// distinguishes a publisher timeout from a routing outage.
+    TimedOut,
+    /// The subscriber withdrew. Nothing to answer.
+    DownstreamLeft,
+}
+
+/// Result of running routing work during a rendezvous hold.
+enum RendezvousWork<T> {
+    Completed(T),
+    TimedOut,
+    DownstreamLeft,
+}
 
 /// Producer of tracks to a remote Subscriber
 #[derive(Clone)]
@@ -27,6 +119,7 @@ pub struct Producer {
     locals: Locals,
     remotes: RemoteManager,
     upstream_namespaces: UpstreamNamespaces,
+    rendezvous_hold_permits: Arc<Semaphore>,
     /// Relay-level context for this MoQT session.
     context: SessionContext,
 }
@@ -34,17 +127,20 @@ pub struct Producer {
 /// Why the wait for upstream readiness ended without the subscription being
 /// established.
 ///
-/// The two cases carry the same [`ServeError`] variants — an upstream rejection
-/// can be `Cancel` or `Done` just as a departing subscriber can — so the
-/// direction has to come from which branch resolved rather than from the error.
-/// Getting it wrong misreports publisher failures as subscriber cancellations in
-/// the subscribe metrics.
+/// An upstream rejection and a departing subscriber can both produce `Cancel`
+/// or `Done`, so the direction has to come from the branch that resolved.
+/// Otherwise publisher failures appear as subscriber cancellations in the
+/// subscribe metrics.
 enum UpstreamWait {
     /// The upstream subscription could not be established.
     UpstreamFailed(ServeError),
 
     /// The downstream subscriber went away before it was established.
     DownstreamLeft(ServeError),
+
+    /// The rendezvous window closed before the upstream subscription was
+    /// established.
+    TimedOut,
 }
 
 impl Producer {
@@ -73,8 +169,21 @@ impl Producer {
             locals,
             remotes,
             upstream_namespaces,
+            rendezvous_hold_permits: Arc::new(Semaphore::new(
+                MAX_CONCURRENT_RENDEZVOUS_HOLDS_PER_SESSION,
+            )),
             context,
         }
+    }
+
+    fn try_acquire_rendezvous_hold(&self) -> Option<(OwnedSemaphorePermit, OwnedSemaphorePermit)> {
+        let session = self
+            .rendezvous_hold_permits
+            .clone()
+            .try_acquire_owned()
+            .ok()?;
+        let relay = self.locals.try_acquire_rendezvous_hold()?;
+        Some((session, relay))
     }
 
     /// Send PUBLISH_NAMESPACE for a set of tracks to the remote peer.
@@ -167,67 +276,182 @@ impl Producer {
         let namespace = subscribed.track_namespace.clone();
         let track_name = subscribed.track_name.clone();
 
-        // Local lookup order inside Locals:
-        // 1. actual FullTrackName -> TrackReader media cache
-        // 2. PUBLISH_NAMESPACE route source, which triggers upstream SUBSCRIBE
-        let mut locals = self.locals.clone();
-        if let Some(local) = locals
-            .get_or_request_track(self.context.scope(), namespace.clone(), &track_name)
-            .await
-        {
-            let ns = namespace.to_utf8_path();
-            tracing::info!(namespace = %ns, track = %track_name, source = "local", "serving subscribe from local: {:?}", local.reader.info);
-            timing_guard.set_label("source", "local");
-            let _track_guard = GaugeGuard::new("moq_relay_active_tracks");
-            // Held until serving finishes. Once the last guard for a cached track
-            // drops, its upstream subscription becomes eligible for release.
-            let _interest_guard = local.interest;
+        let requested_timeout = match subscribed.params.rendezvous_timeout() {
+            Ok(timeout) => timeout,
+            Err(err) => {
+                let serve_err = ServeError::internal_ctx(format!(
+                    "validated rendezvous timeout became invalid: {err}"
+                ));
+                let _ = subscribed.close(serve_err.clone());
+                return Err(serve_err.into());
+            }
+        };
+        let hold = rendezvous_hold(requested_timeout, MAX_RENDEZVOUS_TIMEOUT);
+        // Subscribing before the first lookup closes the race where a publisher
+        // arrives between the lookup missing and the wait starting.
+        let mut rendezvous = hold.map(|hold| {
+            (
+                tokio::time::Instant::now() + hold,
+                self.locals.subscribe_track_changes(),
+                self.locals.subscribe_namespace_changes(),
+            )
+        });
+        let deadline = rendezvous.as_ref().map(|(deadline, _, _)| *deadline);
+        let mut coordinator_lookup_succeeded = false;
+        let mut rendezvous_permit = None;
+        let mut rendezvous_guard = None;
 
-            // Draft-18 §9.4: "The relay MUST have an Established upstream
-            // subscription before sending SUBSCRIBE_OK in response to a
-            // downstream SUBSCRIBE." A pull-through cache entry exists before
-            // its upstream subscription does, so wait for it.
-            if let Some(upstream) = local.upstream {
-                if let Err(outcome) = Self::await_upstream(&subscribed, &upstream).await {
-                    // Which side ended the wait is decided by the branch that
-                    // resolved, not by the error variant: an upstream failure can
-                    // itself be Cancel or Done, so sniffing the variant would
-                    // report a publisher-side failure as a subscriber cancellation
-                    // and skip the upstream-error counter.
-                    let err = match outcome {
-                        UpstreamWait::DownstreamLeft(err) => {
-                            tracing::debug!(namespace = %ns, track = %track_name, error = %err, "downstream subscriber left before the upstream subscription was established");
-                            timing_guard.set_label("source", "downstream_left");
-                            err
-                        }
-                        UpstreamWait::UpstreamFailed(err) => {
-                            tracing::warn!(namespace = %ns, track = %track_name, error = %err, "upstream subscription could not be established");
-                            metrics::counter!("moq_relay_subscribe_upstream_errors_total")
-                                .increment(1);
-                            timing_guard.set_label("source", "upstream_error");
-                            err
-                        }
-                    };
-
-                    // Rejects when the subscription is already closed (the
-                    // downstream-left case), which is fine: the error below is
-                    // still the reason we stopped.
-                    let _ = subscribed.close(err.clone());
-                    return Err(err.into());
+        // Re-entered after a publisher appears. The lookup is repeated rather
+        // than trusting the wake, because `Consumer::serve_track` emits
+        // TrackChange::Added before the coordinator registration behind it has
+        // succeeded, so an event does not guarantee a servable track.
+        loop {
+            // Local lookup order inside Locals:
+            // 1. actual FullTrackName -> TrackReader media cache
+            // 2. PUBLISH_NAMESPACE route source, which triggers upstream SUBSCRIBE
+            let mut locals = self.locals.clone();
+            let local = if let Some(deadline) = deadline {
+                match Self::await_rendezvous_work(
+                    &subscribed,
+                    deadline,
+                    locals.get_or_request_track(
+                        self.context.scope(),
+                        namespace.clone(),
+                        &track_name,
+                    ),
+                )
+                .await
+                {
+                    RendezvousWork::Completed(result) => result,
+                    RendezvousWork::TimedOut => {
+                        return Self::finish_unresolved_rendezvous(
+                            subscribed,
+                            &mut timing_guard,
+                            coordinator_lookup_succeeded,
+                            &namespace,
+                            &track_name,
+                        );
+                    }
+                    RendezvousWork::DownstreamLeft => {
+                        tracing::debug!(
+                            namespace = %namespace.to_utf8_path(),
+                            track = %track_name,
+                            "subscriber left during a rendezvous local lookup"
+                        );
+                        timing_guard.set_label("source", "downstream_left");
+                        return Ok(());
+                    }
                 }
+            } else {
+                locals
+                    .get_or_request_track(self.context.scope(), namespace.clone(), &track_name)
+                    .await
+            };
+
+            if let Some(local) = local {
+                let ns = namespace.to_utf8_path();
+                tracing::info!(namespace = %ns, track = %track_name, source = "local", "serving subscribe from local: {:?}", local.reader.info);
+                timing_guard.set_label("source", "local");
+                let _track_guard = GaugeGuard::new("moq_relay_active_tracks");
+                // Held until serving finishes. Once the last guard for a cached track
+                // drops, its upstream subscription becomes eligible for release.
+                let _interest_guard = local.interest;
+
+                // Draft-18 §9.4: "The relay MUST have an Established upstream
+                // subscription before sending SUBSCRIBE_OK in response to a
+                // downstream SUBSCRIBE." A pull-through cache entry exists before
+                // its upstream subscription does, so wait for it.
+                if let Some(upstream) = local.upstream {
+                    if let Err(outcome) =
+                        Self::await_upstream(&subscribed, &upstream, deadline).await
+                    {
+                        // Which side ended the wait is decided by the branch that
+                        // resolved, not by the error variant: an upstream failure can
+                        // itself be Cancel or Done, so sniffing the variant would
+                        // report a publisher-side failure as a subscriber cancellation
+                        // and skip the upstream-error counter.
+                        let err = match outcome {
+                            UpstreamWait::DownstreamLeft(err) => {
+                                tracing::debug!(namespace = %ns, track = %track_name, error = %err, "downstream subscriber left before the upstream subscription was established");
+                                timing_guard.set_label("source", "downstream_left");
+                                err
+                            }
+                            UpstreamWait::UpstreamFailed(err) => {
+                                tracing::warn!(namespace = %ns, track = %track_name, error = %err, "upstream subscription could not be established");
+                                metrics::counter!("moq_relay_subscribe_upstream_errors_total")
+                                    .increment(1);
+                                timing_guard.set_label("source", "upstream_error");
+                                err
+                            }
+                            UpstreamWait::TimedOut => {
+                                return Self::finish_rendezvous_timeout(
+                                    subscribed,
+                                    &mut timing_guard,
+                                );
+                            }
+                        };
+
+                        // Rejects when the subscription is already closed (the
+                        // downstream-left case), which is fine: the error below is
+                        // still the reason we stopped.
+                        let _ = subscribed.close(err.clone());
+                        return Err(err.into());
+                    }
+                }
+
+                drop(rendezvous_guard.take());
+                drop(rendezvous_permit.take());
+                return Self::serve_resolved_track(
+                    subscribed,
+                    local.reader,
+                    deadline,
+                    &mut timing_guard,
+                )
+                .await;
             }
 
-            return Ok(subscribed.serve(local.reader).await?);
-        }
+            // Check remote tracks after local exact tracks and namespace route sources.
+            let remote = if let Some(deadline) = deadline {
+                match Self::await_rendezvous_work(
+                    &subscribed,
+                    deadline,
+                    self.remotes.subscribe_with_lookup_status(
+                        self.context.scope(),
+                        &namespace,
+                        &track_name,
+                        &mut coordinator_lookup_succeeded,
+                    ),
+                )
+                .await
+                {
+                    RendezvousWork::Completed(result) => result,
+                    RendezvousWork::TimedOut => {
+                        return Self::finish_unresolved_rendezvous(
+                            subscribed,
+                            &mut timing_guard,
+                            coordinator_lookup_succeeded,
+                            &namespace,
+                            &track_name,
+                        );
+                    }
+                    RendezvousWork::DownstreamLeft => {
+                        tracing::debug!(
+                            namespace = %namespace.to_utf8_path(),
+                            track = %track_name,
+                            "subscriber left during a rendezvous route lookup"
+                        );
+                        timing_guard.set_label("source", "downstream_left");
+                        return Ok(());
+                    }
+                }
+            } else {
+                self.remotes
+                    .subscribe(self.context.scope(), &namespace, &track_name)
+                    .await
+            };
 
-        // Check remote tracks after local exact tracks and namespace route sources.
-        match self
-            .remotes
-            .subscribe(self.context.scope(), &namespace, &track_name)
-            .await
-        {
-            Ok(track) => {
-                if let Some((track, interest_guard)) = track {
+            match remote {
+                Ok(Some((track, interest_guard))) => {
                     let ns = namespace.to_utf8_path();
                     tracing::info!(namespace = %ns, track = %track_name, source = "remote", "serving subscribe from remote: {:?}", track.info);
                     // Update label to indicate remote source, timing recorded on drop
@@ -237,55 +461,316 @@ impl Producer {
                     // Held until serving finishes; the cross-relay subscription is
                     // released once the last guard for this track drops.
                     let _interest_guard = interest_guard;
-                    return Ok(subscribed.serve(track).await?);
+                    drop(rendezvous_guard.take());
+                    drop(rendezvous_permit.take());
+                    return Self::serve_resolved_track(
+                        subscribed,
+                        track,
+                        deadline,
+                        &mut timing_guard,
+                    )
+                    .await;
+                }
+                Ok(None) => coordinator_lookup_succeeded = true,
+                Err(e) => {
+                    // Route error = infrastructure failure (couldn't reach coordinator/upstream)
+                    // This is different from "not found" - we don't know if the track exists
+                    let ns = namespace.to_utf8_path();
+                    tracing::error!(namespace = %ns, track = %track_name, error = %e, "failed to route to remote: {}", e);
+                    metrics::counter!("moq_relay_subscribe_route_errors_total").increment(1);
+
+                    // A hold turns this from an answer into a retry. The subscriber
+                    // asked to be kept waiting, a lookup that failed says nothing
+                    // about whether the track exists, and the next re-check may well
+                    // succeed, so failing the subscribe here would make one slow
+                    // coordinator call the end of every rendezvous crossing it.
+                    if deadline.is_none() {
+                        timing_guard.set_label("source", "route_error");
+
+                        // Return an internal error rather than "not found" since we couldn't check
+                        // TODO: Consider returning a more specific error to the subscriber
+                        let err = ServeError::internal_ctx(format!(
+                            "route error for namespace '{}': {}",
+                            namespace, e
+                        ));
+                        subscribed.close(err.clone())?;
+                        return Err(err.into());
+                    }
                 }
             }
-            Err(e) => {
-                // Route error = infrastructure failure (couldn't reach coordinator/upstream)
-                // This is different from "not found" - we don't know if the track exists
-                let ns = namespace.to_utf8_path();
-                tracing::error!(namespace = %ns, track = %track_name, error = %e, "failed to route to remote: {}", e);
-                timing_guard.set_label("source", "route_error");
-                metrics::counter!("moq_relay_subscribe_route_errors_total").increment(1);
 
-                // Return an internal error rather than "not found" since we couldn't check
-                // TODO: Consider returning a more specific error to the subscriber
-                let err = ServeError::internal_ctx(format!(
-                    "route error for namespace '{}': {}",
-                    namespace, e
+            // Nothing is publishing this track. Without a rendezvous window that is
+            // the end of it; with one, hold the subscription open and re-check when
+            // a publisher shows up.
+            let Some((deadline, track_changes, namespace_changes)) = rendezvous.as_mut() else {
+                // timing_guard label already set to "not_found", will record on drop
+                metrics::counter!("moq_relay_subscribe_not_found_total").increment(1);
+
+                let err = ServeError::not_found_ctx(format!(
+                    "track '{}/{}' not found in local or remote tracks",
+                    namespace, track_name
                 ));
                 subscribed.close(err.clone())?;
                 return Err(err.into());
+            };
+
+            // Capacity limits held requests, not ordinary resolution work. An
+            // available publisher must be served even when every hold slot is in
+            // use, so only acquire a slot after the initial lookup misses.
+            if rendezvous_permit.is_none() {
+                let Some(permit) = self.try_acquire_rendezvous_hold() else {
+                    metrics::counter!("moq_relay_rendezvous_rejections_total").increment(1);
+                    timing_guard.set_label("source", "rendezvous_overloaded");
+                    let err = ServeError::Closed(RequestErrorCode::ExcessiveLoad as u64);
+                    let retry_interval = self.locals.rendezvous_overload_retry_interval();
+                    let _ = subscribed.close_with_retry(err.clone(), retry_interval);
+                    return Err(err.into());
+                };
+                rendezvous_permit = Some(permit);
+                rendezvous_guard = Some(GaugeGuard::new("moq_relay_active_rendezvous_holds"));
+            }
+
+            match Self::await_rendezvous(
+                &subscribed,
+                self.context.scope(),
+                &namespace,
+                &track_name,
+                *deadline,
+                track_changes,
+                namespace_changes,
+            )
+            .await
+            {
+                // A publisher may exist now, either because one arrived here or
+                // because enough time passed to be worth asking elsewhere. Either
+                // way the answer comes from repeating the lookup.
+                Rendezvous::PublisherAppeared | Rendezvous::RecheckDue => continue,
+                Rendezvous::TimedOut => {
+                    return Self::finish_unresolved_rendezvous(
+                        subscribed,
+                        &mut timing_guard,
+                        coordinator_lookup_succeeded,
+                        &namespace,
+                        &track_name,
+                    );
+                }
+                Rendezvous::DownstreamLeft => {
+                    timing_guard.set_label("source", "downstream_left");
+                    return Ok(());
+                }
             }
         }
+    }
 
-        // Track not found - we checked all sources and the track doesn't exist
-        // timing_guard label already set to "not_found", will record on drop
-        metrics::counter!("moq_relay_subscribe_not_found_total").increment(1);
+    /// Wait for the upstream subscription behind a cached track to be established.
+    ///
+    /// Also completes when the rendezvous deadline passes or the downstream
+    /// subscriber goes away. Upstream and downstream failures are reported
+    /// separately because the error alone does not identify their direction.
+    async fn await_upstream(
+        subscribed: &Subscribed,
+        upstream: &UpstreamReady,
+        deadline: Option<tokio::time::Instant>,
+    ) -> Result<(), UpstreamWait> {
+        let Some(deadline) = deadline else {
+            return tokio::select! {
+                res = upstream.established() => res.map_err(UpstreamWait::UpstreamFailed),
+                res = subscribed.closed() => Err(UpstreamWait::DownstreamLeft(
+                    res.err().unwrap_or(ServeError::Done),
+                )),
+            };
+        };
 
-        let err = ServeError::not_found_ctx(format!(
-            "track '{}/{}' not found in local or remote tracks",
+        tokio::select! {
+            biased;
+            res = subscribed.closed() => Err(UpstreamWait::DownstreamLeft(
+                res.err().unwrap_or(ServeError::Done),
+            )),
+            () = tokio::time::sleep_until(deadline) => Err(UpstreamWait::TimedOut),
+            res = upstream.established() => {
+                if tokio::time::Instant::now() >= deadline {
+                    Err(UpstreamWait::TimedOut)
+                } else {
+                    res.map_err(UpstreamWait::UpstreamFailed)
+                }
+            },
+        }
+    }
+
+    /// Run routing work under the rendezvous deadline and downstream cancellation
+    /// signal.
+    async fn await_rendezvous_work<T>(
+        subscribed: &Subscribed,
+        deadline: tokio::time::Instant,
+        lookup: impl Future<Output = T>,
+    ) -> RendezvousWork<T> {
+        tokio::select! {
+            biased;
+            _ = subscribed.closed() => RendezvousWork::DownstreamLeft,
+            () = tokio::time::sleep_until(deadline) => RendezvousWork::TimedOut,
+            result = lookup => {
+                if tokio::time::Instant::now() >= deadline {
+                    RendezvousWork::TimedOut
+                } else {
+                    RendezvousWork::Completed(result)
+                }
+            },
+        }
+    }
+
+    fn finish_rendezvous_timeout(
+        subscribed: Subscribed,
+        timing_guard: &mut TimingGuard,
+    ) -> Result<(), anyhow::Error> {
+        Self::record_rendezvous_timeout(timing_guard);
+
+        // TIMEOUT records that the relay completed routing work but no usable
+        // publisher became ready within the requested window.
+        let err = ServeError::Timeout;
+        subscribed.close(err.clone())?;
+        Err(err.into())
+    }
+
+    fn record_rendezvous_timeout(timing_guard: &mut TimingGuard) {
+        metrics::counter!("moq_relay_rendezvous_timeouts_total").increment(1);
+        timing_guard.set_label("source", "rendezvous_timeout");
+    }
+
+    async fn serve_resolved_track(
+        subscribed: Subscribed,
+        track: TrackReader,
+        deadline: Option<tokio::time::Instant>,
+        timing_guard: &mut TimingGuard,
+    ) -> Result<(), anyhow::Error> {
+        let Some(deadline) = deadline else {
+            return Ok(subscribed.serve(track).await?);
+        };
+
+        match subscribed.serve_with_deadline(track, deadline).await {
+            Ok(()) => Ok(()),
+            Err(ServeWithDeadlineError::DeadlineExpired) => {
+                Self::record_rendezvous_timeout(timing_guard);
+                Err(ServeError::Timeout.into())
+            }
+            Err(ServeWithDeadlineError::Session(err)) => Err(err.into()),
+        }
+    }
+
+    fn finish_unresolved_rendezvous(
+        subscribed: Subscribed,
+        timing_guard: &mut TimingGuard,
+        coordinator_lookup_succeeded: bool,
+        namespace: &TrackNamespace,
+        track_name: &TrackName,
+    ) -> Result<(), anyhow::Error> {
+        if coordinator_lookup_succeeded {
+            return Self::finish_rendezvous_timeout(subscribed, timing_guard);
+        }
+
+        // No successful lookup means the relay never established that the track
+        // was absent. A publisher timeout would hide the routing outage.
+        metrics::counter!("moq_relay_subscribe_route_errors_total").increment(1);
+        timing_guard.set_label("source", "route_error");
+        let err = ServeError::internal_ctx(format!(
+            "no coordinator lookup completed during rendezvous hold for '{}/{}'",
             namespace, track_name
         ));
         subscribed.close(err.clone())?;
         Err(err.into())
     }
 
-    /// Wait for the upstream subscription behind a cached track to be established.
+    /// Hold a SUBSCRIBE open until a publisher for the track shows up, the
+    /// deadline passes, or the subscriber gives up (draft-18 §10.2.6).
     ///
-    /// Also completes when the downstream subscriber goes away first, so a
-    /// cancelled SUBSCRIBE is not held here for the full upstream response
-    /// timeout. The two cases are reported separately because they cannot be
-    /// told apart from the error alone — see [`UpstreamWait`].
-    async fn await_upstream(
+    /// Both a new track and a newly announced namespace count as a publisher
+    /// arriving: a track can be served either from an exact PUBLISH or by a
+    /// PUBLISH_NAMESPACE route source that triggers an upstream SUBSCRIBE, and
+    /// the caller re-runs the full lookup either way.
+    ///
+    /// Those events are in-process, so they miss a publisher on another relay
+    /// serving the same scope. The recheck interval covers that by ending the wait
+    /// periodically for the caller to ask the coordinator again.
+    ///
+    /// Waking the subscriber promptly matters beyond tidiness. A held
+    /// subscription keeps its entry in the publisher's per-session name map, and
+    /// a second SUBSCRIBE for the same track on that session is rejected with
+    /// DUPLICATE_SUBSCRIPTION, so a subscriber that gave up and retried would be
+    /// turned away by its own abandoned hold.
+    async fn await_rendezvous(
         subscribed: &Subscribed,
-        upstream: &UpstreamReady,
-    ) -> Result<(), UpstreamWait> {
-        tokio::select! {
-            res = upstream.established() => res.map_err(UpstreamWait::UpstreamFailed),
-            res = subscribed.closed() => Err(UpstreamWait::DownstreamLeft(
-                res.err().unwrap_or(ServeError::Done),
-            )),
+        scope: Option<&str>,
+        namespace: &TrackNamespace,
+        track_name: &TrackName,
+        deadline: tokio::time::Instant,
+        track_changes: &mut broadcast::Receiver<TrackChange>,
+        namespace_changes: &mut broadcast::Receiver<NamespaceChange>,
+    ) -> Rendezvous {
+        let sleep = tokio::time::sleep_until(deadline);
+        tokio::pin!(sleep);
+        let recheck = tokio::time::sleep(RENDEZVOUS_RECHECK_INTERVAL);
+        tokio::pin!(recheck);
+
+        loop {
+            tokio::select! {
+                biased;
+
+                res = subscribed.closed() => {
+                    tracing::debug!(
+                        namespace = %namespace.to_utf8_path(),
+                        track = %track_name,
+                        reason = ?res.err(),
+                        "subscriber left while waiting for a publisher"
+                    );
+                    return Rendezvous::DownstreamLeft;
+                }
+
+                () = &mut sleep => return Rendezvous::TimedOut,
+
+                () = &mut recheck => {
+                    tracing::debug!(
+                        namespace = %namespace.to_utf8_path(),
+                        track = %track_name,
+                        "asking the coordinator again for a publisher during a rendezvous hold"
+                    );
+                    return Rendezvous::RecheckDue;
+                }
+
+                change = track_changes.recv() => {
+                    match change {
+                        Ok(TrackChange::Added { scope: change_scope, track })
+                            if change_scope.as_deref() == scope
+                                && track.info.namespace == *namespace
+                                && track.info.name == *track_name =>
+                        {
+                            return Rendezvous::PublisherAppeared
+                        }
+                        // Some other track, or a removal: keep waiting.
+                        Ok(_) => continue,
+                        // Lagged means events were missed, one of which could have
+                        // been ours, so re-check rather than keep waiting blind.
+                        Err(broadcast::error::RecvError::Lagged(_)) => {
+                            return Rendezvous::PublisherAppeared
+                        }
+                        Err(broadcast::error::RecvError::Closed) => return Rendezvous::TimedOut,
+                    }
+                }
+
+                change = namespace_changes.recv() => {
+                    match change {
+                        Ok(NamespaceChange { scope: change_scope, namespace: ns, added: true })
+                            if change_scope.as_deref() == scope
+                                && namespace_covers(&ns, namespace) =>
+                        {
+                            return Rendezvous::PublisherAppeared
+                        }
+                        Ok(_) => continue,
+                        Err(broadcast::error::RecvError::Lagged(_)) => {
+                            return Rendezvous::PublisherAppeared
+                        }
+                        Err(broadcast::error::RecvError::Closed) => return Rendezvous::TimedOut,
+                    }
+                }
+            }
         }
     }
 
@@ -666,9 +1151,392 @@ fn full_name_for_track(track: &TrackReader) -> FullTrackName {
 
 #[cfg(test)]
 mod tests {
-    use moq_transport::{serve::ServeError, session::SessionError};
+    use std::{
+        sync::{Arc, Mutex},
+        time::Duration,
+    };
 
-    use super::Producer;
+    use async_trait::async_trait;
+    use moq_transport::{
+        coding::{KeyValuePairs, TrackNamespace},
+        message::RequestErrorCode,
+        serve::{ServeError, Track},
+        session::{Session as TransportSession, SessionError, Subscriber, Transport},
+    };
+
+    use super::{
+        namespace_covers, rendezvous_hold, Producer, MAX_CONCURRENT_RENDEZVOUS_HOLDS_PER_SESSION,
+    };
+    use crate::{
+        Coordinator, CoordinatorContext, CoordinatorError, CoordinatorResult, Locals,
+        NamespaceOrigin, NamespaceRegistration, RemoteManager, SessionContext,
+    };
+
+    #[derive(Default)]
+    struct CountingCoordinator {
+        track_lookups: Mutex<Vec<String>>,
+    }
+
+    impl CountingCoordinator {
+        fn looked_up(&self, track: &str) -> bool {
+            self.track_lookups
+                .lock()
+                .expect("track lookup lock poisoned")
+                .iter()
+                .any(|lookup| lookup == track)
+        }
+
+        fn distinct_lookup_count(&self, prefix: &str) -> usize {
+            self.track_lookups
+                .lock()
+                .expect("track lookup lock poisoned")
+                .iter()
+                .filter(|lookup| lookup.starts_with(prefix))
+                .collect::<std::collections::HashSet<_>>()
+                .len()
+        }
+    }
+
+    #[async_trait]
+    impl Coordinator for CountingCoordinator {
+        async fn register_namespace(
+            &self,
+            _scope: Option<&str>,
+            _namespace: &TrackNamespace,
+            _context: &CoordinatorContext,
+        ) -> CoordinatorResult<NamespaceRegistration> {
+            Ok(NamespaceRegistration::new(()))
+        }
+
+        async fn unregister_namespace(
+            &self,
+            _scope: Option<&str>,
+            _namespace: &TrackNamespace,
+        ) -> CoordinatorResult<()> {
+            Ok(())
+        }
+
+        async fn lookup(
+            &self,
+            _scope: Option<&str>,
+            _namespace: &TrackNamespace,
+        ) -> CoordinatorResult<(NamespaceOrigin, Option<moq_native_ietf::quic::Client>)> {
+            Err(CoordinatorError::NamespaceNotFound)
+        }
+
+        async fn lookup_track(
+            &self,
+            _scope: Option<&str>,
+            _namespace: &TrackNamespace,
+            track: &str,
+        ) -> CoordinatorResult<(NamespaceOrigin, Option<moq_native_ietf::quic::Client>)> {
+            self.track_lookups
+                .lock()
+                .map_err(|_| anyhow::anyhow!("track lookup lock poisoned"))?
+                .push(track.to_string());
+            Err(CoordinatorError::NamespaceNotFound)
+        }
+    }
+
+    async fn loopback_webtransport_pair() -> (web_transport::Session, web_transport::Session) {
+        use web_transport::quinn::{ClientBuilder, ServerBuilder};
+
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+        let cert = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])
+            .expect("generate self-signed certificate");
+        let cert_der = cert.cert.der().clone();
+        let key = cert
+            .key_pair
+            .serialize_der()
+            .try_into()
+            .expect("serialize private key");
+        let mut server = ServerBuilder::new()
+            .with_addr("127.0.0.1:0".parse().expect("server addr"))
+            .with_certificate(vec![cert_der], key)
+            .expect("build loopback server");
+        let addr = server.local_addr().expect("server local addr");
+
+        let accepted = tokio::spawn(async move {
+            server
+                .accept()
+                .await
+                .expect("accept loopback request")
+                .ok()
+                .await
+                .expect("accept loopback session")
+        });
+        let client = ClientBuilder::new()
+            .dangerous()
+            .with_no_certificate_verification()
+            .expect("build loopback client");
+        let url = url::Url::parse(&format!("https://127.0.0.1:{}/", addr.port()))
+            .expect("parse loopback URL");
+        let connected = tokio::time::timeout(Duration::from_secs(10), client.connect(url))
+            .await
+            .expect("loopback connect timed out")
+            .expect("connect loopback session");
+
+        (
+            tokio::time::timeout(Duration::from_secs(10), accepted)
+                .await
+                .expect("loopback accept timed out")
+                .expect("join loopback accept")
+                .into(),
+            connected.into(),
+        )
+    }
+
+    async fn spawn_relay_session(
+        locals: Locals,
+        remotes: RemoteManager,
+        coordinator: Arc<dyn Coordinator>,
+    ) -> Subscriber {
+        let (server_transport, client_transport) = loopback_webtransport_pair().await;
+        let (server, client) = tokio::time::timeout(Duration::from_secs(10), async {
+            tokio::join!(
+                TransportSession::accept(server_transport, None, Transport::WebTransport),
+                TransportSession::connect(client_transport, None, Transport::WebTransport),
+            )
+        })
+        .await
+        .expect("MoQT setup timed out");
+        let (server, publisher, _server_subscriber) = server.expect("accept MoQT session");
+        let (client, _client_publisher, subscriber) = client.expect("connect MoQT session");
+        let producer = Producer::new(
+            publisher.expect("server publisher"),
+            locals,
+            remotes,
+            coordinator,
+            SessionContext::public(None),
+        );
+
+        tokio::spawn(async move { server.run().await });
+        tokio::spawn(async move { client.run().await });
+        tokio::spawn(async move { producer.run().await });
+
+        subscriber
+    }
+
+    async fn subscribe_result(
+        subscriber: &mut Subscriber,
+        track_name: &str,
+        rendezvous_timeout: Option<u64>,
+    ) -> Result<moq_transport::session::Subscribe, ServeError> {
+        let namespace = TrackNamespace::from_utf8_path("admission");
+        let (writer, _reader) = Track::new(namespace, track_name).produce();
+        let mut params = KeyValuePairs::default();
+        if let Some(timeout) = rendezvous_timeout {
+            params.set_rendezvous_timeout(timeout);
+        }
+        subscriber.subscribe_open_with_params(writer, params).await
+    }
+
+    async fn rejected_subscribe(
+        subscriber: &mut Subscriber,
+        track_name: &str,
+        rendezvous_timeout: Option<u64>,
+    ) -> ServeError {
+        match subscribe_result(subscriber, track_name, rendezvous_timeout).await {
+            Ok(_) => panic!("expected {track_name} subscription to be rejected"),
+            Err(err) => err,
+        }
+    }
+
+    /// draft-18 §10.2.6: absent and 0 both mean answer immediately, so neither
+    /// produces a hold.
+    #[test]
+    fn no_hold_without_a_rendezvous_request() {
+        let max = Duration::from_secs(30);
+
+        assert_eq!(rendezvous_hold(None, max), None);
+        assert_eq!(rendezvous_hold(Some(0), max), None);
+    }
+
+    #[test]
+    fn a_request_within_the_ceiling_is_honoured() {
+        assert_eq!(
+            rendezvous_hold(Some(5_000), Duration::from_secs(30)),
+            Some(Duration::from_secs(5))
+        );
+    }
+
+    /// The spec lets a relay shorten the window without telling the subscriber,
+    /// which is what stops one client pinning state for as long as it likes.
+    #[test]
+    fn a_request_above_the_ceiling_is_clamped() {
+        assert_eq!(
+            rendezvous_hold(Some(600_000), Duration::from_secs(30)),
+            Some(Duration::from_secs(30))
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn relay_admission_serves_available_tracks_before_rejecting_new_holds() {
+        let locals = Locals::with_rendezvous_capacity(1);
+        let coordinator = Arc::new(CountingCoordinator::default());
+        let remotes = RemoteManager::new(coordinator.clone(), Vec::new());
+        let mut first_subscriber =
+            spawn_relay_session(locals.clone(), remotes.clone(), coordinator.clone()).await;
+        let mut second_subscriber =
+            spawn_relay_session(locals.clone(), remotes, coordinator.clone()).await;
+
+        let first = tokio::spawn(async move {
+            subscribe_result(&mut first_subscriber, "held", Some(10_000)).await
+        });
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while !coordinator.looked_up("held") {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("first request did not enter rendezvous routing");
+
+        let namespace = TrackNamespace::from_utf8_path("admission");
+        let (_available_writer, available_reader) =
+            Track::new(namespace.clone(), "available").produce();
+        let mut registering_locals = locals.clone();
+        let _available_registration = registering_locals
+            .register_track(None, available_reader)
+            .await
+            .expect("register available track");
+        let available = subscribe_result(&mut second_subscriber, "available", Some(10_000))
+            .await
+            .expect("capacity must not reject an available track");
+        drop(available);
+
+        let absent = rejected_subscribe(&mut second_subscriber, "absent", None).await;
+        assert!(matches!(
+            absent,
+            ServeError::NotFound | ServeError::NotFoundWithId(_, _)
+        ));
+        assert!(coordinator.looked_up("absent"));
+
+        let zero = rejected_subscribe(&mut second_subscriber, "zero", Some(0)).await;
+        assert!(matches!(
+            zero,
+            ServeError::NotFound | ServeError::NotFoundWithId(_, _)
+        ));
+        assert!(coordinator.looked_up("zero"));
+
+        let overloaded =
+            rejected_subscribe(&mut second_subscriber, "overloaded", Some(10_000)).await;
+        assert_eq!(
+            overloaded,
+            ServeError::Closed(RequestErrorCode::ExcessiveLoad as u64)
+        );
+        assert!(coordinator.looked_up("overloaded"));
+
+        let (_held_writer, held_reader) = Track::new(namespace.clone(), "held").produce();
+        let _held_registration = registering_locals
+            .register_track(None, held_reader)
+            .await
+            .expect("register held track");
+        let first_subscription = tokio::time::timeout(Duration::from_secs(2), first)
+            .await
+            .expect("held request did not resolve")
+            .expect("join held request")
+            .expect("held request was rejected");
+
+        let (_next_writer, next_reader) = Track::new(namespace, "after-release").produce();
+        let _next_registration = registering_locals
+            .register_track(None, next_reader)
+            .await
+            .expect("register track after capacity release");
+        let accepted = subscribe_result(&mut second_subscriber, "after-release", Some(10_000))
+            .await
+            .expect("resolved hold should be released before the next request");
+        drop(accepted);
+        drop(first_subscription);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn one_session_cannot_monopolize_relay_capacity() {
+        let locals = Locals::new();
+        let coordinator = Arc::new(CountingCoordinator::default());
+        let remotes = RemoteManager::new(coordinator.clone(), Vec::new());
+        let mut saturated_session =
+            spawn_relay_session(locals.clone(), remotes.clone(), coordinator.clone()).await;
+        let mut other_session = spawn_relay_session(locals, remotes, coordinator.clone()).await;
+
+        let mut holds = Vec::new();
+        for index in 0..MAX_CONCURRENT_RENDEZVOUS_HOLDS_PER_SESSION {
+            let mut subscriber = saturated_session.clone();
+            let track = format!("session-hold-{index}");
+            holds.push(tokio::spawn(async move {
+                subscribe_result(&mut subscriber, &track, Some(10_000)).await
+            }));
+        }
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while coordinator.distinct_lookup_count("session-hold-")
+                < MAX_CONCURRENT_RENDEZVOUS_HOLDS_PER_SESSION
+            {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("session did not fill its rendezvous capacity");
+
+        let overloaded = rejected_subscribe(
+            &mut saturated_session,
+            "same-session-overloaded",
+            Some(10_000),
+        )
+        .await;
+        assert_eq!(
+            overloaded,
+            ServeError::Closed(RequestErrorCode::ExcessiveLoad as u64)
+        );
+        assert!(coordinator.looked_up("same-session-overloaded"));
+
+        let other_hold = tokio::spawn(async move {
+            subscribe_result(&mut other_session, "other-session-hold", Some(10_000)).await
+        });
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while !coordinator.looked_up("other-session-hold") {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("saturated session blocked another session");
+
+        other_hold.abort();
+        for hold in holds {
+            hold.abort();
+        }
+    }
+
+    /// Locals routes a track to the longest registered namespace that prefixes
+    /// it, so a shorter announcement still makes the track servable and has to
+    /// wake the waiter.
+    #[test]
+    fn a_prefix_announcement_covers_the_track_namespace() {
+        let target = TrackNamespace::from_utf8_path("meeting/room/42");
+
+        assert!(namespace_covers(
+            &TrackNamespace::from_utf8_path("meeting"),
+            &target
+        ));
+        assert!(namespace_covers(
+            &TrackNamespace::from_utf8_path("meeting/room/42"),
+            &target
+        ));
+    }
+
+    #[test]
+    fn an_unrelated_or_longer_announcement_does_not_cover_it() {
+        let target = TrackNamespace::from_utf8_path("meeting/room/42");
+
+        assert!(!namespace_covers(
+            &TrackNamespace::from_utf8_path("other/room"),
+            &target
+        ));
+        // Longer than the target cannot be a prefix of it.
+        assert!(!namespace_covers(
+            &TrackNamespace::from_utf8_path("meeting/room/42/sub"),
+            &target
+        ));
+    }
 
     #[test]
     fn expected_serve_shutdown_accepts_wrapped_session_errors() {

--- a/moq-relay-ietf/src/remote.rs
+++ b/moq-relay-ietf/src/remote.rs
@@ -29,6 +29,94 @@ type RemoteSlot = Arc<Mutex<Option<Remote>>>;
 type TrackCacheKey = (TrackNamespace, TrackName);
 type TrackSlot = Arc<Mutex<Option<CachedTrack>>>;
 
+struct EmptyRemoteSlotCleanup {
+    remotes: Arc<Mutex<HashMap<RemoteCacheKey, RemoteSlot>>>,
+    key: RemoteCacheKey,
+    slot: RemoteSlot,
+    armed: bool,
+}
+
+impl EmptyRemoteSlotCleanup {
+    fn new(
+        remotes: Arc<Mutex<HashMap<RemoteCacheKey, RemoteSlot>>>,
+        key: RemoteCacheKey,
+        slot: RemoteSlot,
+    ) -> Self {
+        Self {
+            remotes,
+            key,
+            slot,
+            armed: true,
+        }
+    }
+
+    fn disarm(mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for EmptyRemoteSlotCleanup {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+
+        let remotes = self.remotes.clone();
+        let key = self.key.clone();
+        let slot = self.slot.clone();
+        if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+            // The map uses an async mutex, so a cancelled routing future hands
+            // cleanup to a detached task after releasing its slot lock.
+            std::mem::drop(runtime.spawn(async move {
+                remove_empty_remote_slot(&remotes, &key, &slot).await;
+            }));
+        }
+    }
+}
+
+struct EmptyTrackSlotCleanup {
+    tracks: Arc<Mutex<HashMap<TrackCacheKey, TrackSlot>>>,
+    key: TrackCacheKey,
+    slot: TrackSlot,
+    armed: bool,
+}
+
+impl EmptyTrackSlotCleanup {
+    fn new(
+        tracks: Arc<Mutex<HashMap<TrackCacheKey, TrackSlot>>>,
+        key: TrackCacheKey,
+        slot: TrackSlot,
+    ) -> Self {
+        Self {
+            tracks,
+            key,
+            slot,
+            armed: true,
+        }
+    }
+
+    fn disarm(mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for EmptyTrackSlotCleanup {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+
+        let tracks = self.tracks.clone();
+        let key = self.key.clone();
+        let slot = self.slot.clone();
+        if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+            std::mem::drop(runtime.spawn(async move {
+                remove_empty_track_slot(&tracks, &key, &slot).await;
+            }));
+        }
+    }
+}
+
 /// A cached cross-relay track reader plus the downstream interest in it.
 #[derive(Clone)]
 struct CachedTrack {
@@ -90,6 +178,43 @@ mod tests {
         }
     }
 
+    struct FoundCoordinator;
+
+    #[async_trait::async_trait]
+    impl Coordinator for FoundCoordinator {
+        async fn register_namespace(
+            &self,
+            _scope: Option<&str>,
+            _namespace: &TrackNamespace,
+            _context: &crate::CoordinatorContext,
+        ) -> crate::CoordinatorResult<crate::NamespaceRegistration> {
+            Ok(crate::NamespaceRegistration::new(()))
+        }
+
+        async fn unregister_namespace(
+            &self,
+            _scope: Option<&str>,
+            _namespace: &TrackNamespace,
+        ) -> crate::CoordinatorResult<()> {
+            Ok(())
+        }
+
+        async fn lookup(
+            &self,
+            _scope: Option<&str>,
+            namespace: &TrackNamespace,
+        ) -> crate::CoordinatorResult<(crate::NamespaceOrigin, Option<quic::Client>)> {
+            Ok((
+                crate::NamespaceOrigin::new(
+                    namespace.clone(),
+                    Url::parse("https://relay.example.com/live").unwrap(),
+                    None,
+                ),
+                None,
+            ))
+        }
+    }
+
     #[test]
     fn new_uses_default_session_config() {
         let manager = RemoteManager::new(Arc::new(NoopCoordinator), vec![]);
@@ -104,6 +229,43 @@ mod tests {
             RemoteManager::new_with_session_config(Arc::new(NoopCoordinator), vec![], config);
 
         assert_eq!(manager.session_config, config);
+    }
+
+    #[tokio::test]
+    async fn namespace_not_found_counts_as_successful_coordinator_lookup() {
+        let manager = RemoteManager::new(Arc::new(NoopCoordinator), vec![]);
+        let mut lookup_succeeded = false;
+
+        let result = manager
+            .subscribe_with_lookup_status(
+                None,
+                &TrackNamespace::from_utf8_path("example.com"),
+                "video",
+                &mut lookup_succeeded,
+            )
+            .await
+            .unwrap();
+
+        assert!(result.is_none());
+        assert!(lookup_succeeded);
+    }
+
+    #[tokio::test]
+    async fn successful_coordinator_lookup_survives_later_connection_error() {
+        let manager = RemoteManager::new(Arc::new(FoundCoordinator), vec![]);
+        let mut lookup_succeeded = false;
+
+        let result = manager
+            .subscribe_with_lookup_status(
+                None,
+                &TrackNamespace::from_utf8_path("example.com"),
+                "video",
+                &mut lookup_succeeded,
+            )
+            .await;
+
+        assert!(result.is_err());
+        assert!(lookup_succeeded);
     }
 
     #[test]
@@ -162,6 +324,59 @@ mod tests {
             err.to_string().contains("no QUIC clients configured"),
             "unexpected error: {err}"
         );
+    }
+
+    #[tokio::test]
+    async fn cancelled_connection_cleanup_removes_an_empty_slot() {
+        let remotes = Arc::new(Mutex::new(HashMap::new()));
+        let key = (Url::parse("https://relay.example.com/live").unwrap(), None);
+        let slot = Arc::new(Mutex::new(None));
+        remotes.lock().await.insert(key.clone(), slot.clone());
+
+        drop(EmptyRemoteSlotCleanup::new(
+            remotes.clone(),
+            key.clone(),
+            slot,
+        ));
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if !remotes.lock().await.contains_key(&key) {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("cancelled connection cleanup should remove its empty slot");
+    }
+
+    #[tokio::test]
+    async fn cancelled_subscribe_cleanup_removes_an_empty_track_slot() {
+        let tracks = Arc::new(Mutex::new(HashMap::new()));
+        let key = (
+            TrackNamespace::from_utf8_path("example.com"),
+            TrackName::from("video"),
+        );
+        let slot = Arc::new(Mutex::new(None));
+        tracks.lock().await.insert(key.clone(), slot.clone());
+
+        drop(EmptyTrackSlotCleanup::new(
+            tracks.clone(),
+            key.clone(),
+            slot,
+        ));
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if !tracks.lock().await.contains_key(&key) {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("cancelled subscribe cleanup should remove its empty slot");
     }
 
     fn cached_track() -> (TrackSlot, TrackInterest) {
@@ -297,6 +512,23 @@ impl RemoteManager {
         namespace: &TrackNamespace,
         track_name: impl Into<TrackName>,
     ) -> anyhow::Result<Option<(TrackReader, TrackInterestGuard)>> {
+        let mut coordinator_lookup_succeeded = false;
+        self.subscribe_with_lookup_status(
+            scope,
+            namespace,
+            track_name,
+            &mut coordinator_lookup_succeeded,
+        )
+        .await
+    }
+
+    pub(crate) async fn subscribe_with_lookup_status(
+        &self,
+        scope: Option<&str>,
+        namespace: &TrackNamespace,
+        track_name: impl Into<TrackName>,
+        coordinator_lookup_succeeded: &mut bool,
+    ) -> anyhow::Result<Option<(TrackReader, TrackInterestGuard)>> {
         let track_name = track_name.into();
 
         // Coordinator::lookup_track is the ergonomic routing entry point: it
@@ -307,8 +539,14 @@ impl RemoteManager {
             .lookup_track(scope, namespace, &track_name.to_string())
             .await
         {
-            Ok(result) => result,
-            Err(CoordinatorError::NamespaceNotFound) => return Ok(None),
+            Ok(result) => {
+                *coordinator_lookup_succeeded = true;
+                result
+            }
+            Err(CoordinatorError::NamespaceNotFound) => {
+                *coordinator_lookup_succeeded = true;
+                return Ok(None);
+            }
             Err(err) => return Err(err.into()),
         };
 
@@ -425,6 +663,9 @@ impl RemoteManager {
                     .clone()
             };
 
+            let cleanup =
+                EmptyRemoteSlotCleanup::new(self.remotes.clone(), cache_key.clone(), slot.clone());
+
             let mut cached = slot.lock().await;
 
             let is_current_slot = {
@@ -433,12 +674,15 @@ impl RemoteManager {
             };
 
             if !is_current_slot {
+                cleanup.disarm();
                 continue;
             }
 
             if let Some(remote) = cached.as_ref() {
                 if remote.is_connected() {
-                    return Ok(remote.clone());
+                    let remote = remote.clone();
+                    cleanup.disarm();
+                    return Ok(remote);
                 }
 
                 tracing::info!(remote_url = %cache_key.0, "removing dead connection to remote relay");
@@ -467,11 +711,13 @@ impl RemoteManager {
                 Err(err) => {
                     drop(cached);
                     remove_empty_remote_slot(&self.remotes, &cache_key, &slot).await;
+                    cleanup.disarm();
                     return Err(err);
                 }
             };
 
             *cached = Some(remote.clone());
+            cleanup.disarm();
             return Ok(remote);
         }
     }
@@ -786,6 +1032,9 @@ impl Remote {
                     .clone()
             };
 
+            let cleanup =
+                EmptyTrackSlotCleanup::new(self.tracks.clone(), key.clone(), slot.clone());
+
             let mut cached = slot.lock().await;
 
             let is_current_slot = {
@@ -794,6 +1043,7 @@ impl Remote {
             };
 
             if !is_current_slot {
+                cleanup.disarm();
                 continue;
             }
 
@@ -801,7 +1051,9 @@ impl Remote {
                 if !entry.reader.is_closed() {
                     // Register interest while still holding the slot lock, which
                     // is the same lock idle eviction re-checks under.
-                    return Ok(Some((entry.reader.clone(), entry.interest.guard())));
+                    let result = Some((entry.reader.clone(), entry.interest.guard()));
+                    cleanup.disarm();
+                    return Ok(result);
                 }
 
                 tracing::debug!(remote_url = %self.url, namespace = %key.0, track = %key.1, "removing closed remote track from cache");
@@ -820,9 +1072,7 @@ impl Remote {
             let subscribe_result = tokio::select! {
                 result = subscriber.subscribe_open(writer) => result,
                 _ = cancel.cancelled() => {
-                    drop(cached);
-                    remove_empty_track_slot(&self.tracks, &key, &slot).await;
-                    anyhow::bail!("subscribe cancelled, remote connection to {} is closed", self.url);
+                    Err(moq_transport::serve::ServeError::Cancel)
                 }
             };
 
@@ -831,6 +1081,7 @@ impl Remote {
                 Err(err) => {
                     drop(cached);
                     remove_empty_track_slot(&self.tracks, &key, &slot).await;
+                    cleanup.disarm();
                     return Err(err.into());
                 }
             };
@@ -838,6 +1089,7 @@ impl Remote {
             if !self.is_connected() {
                 drop(cached);
                 remove_empty_track_slot(&self.tracks, &key, &slot).await;
+                cleanup.disarm();
                 anyhow::bail!("remote connection to {} is closed", self.url);
             }
 
@@ -851,6 +1103,7 @@ impl Remote {
                 reader: reader.clone(),
                 interest: interest.clone(),
             });
+            cleanup.disarm();
             drop(cached);
 
             let cleanup_key = key.clone();

--- a/moq-transport/src/message/mod.rs
+++ b/moq-transport/src/message/mod.rs
@@ -122,12 +122,20 @@ macro_rules! message_types {
                     return Err(DecodeError::InvalidMessage(t));
                 }
 
+                if !msg.parameter_scopes_valid() {
+                    return Err(DecodeError::InvalidParameter);
+                }
+
                 Ok(msg)
             }
         }
 
         impl Encode for Message {
             fn encode<W: bytes::BufMut>(&self, w: &mut W) -> Result<(), EncodeError> {
+                if !self.parameter_scopes_valid() {
+                    return Err(EncodeError::InvalidValue);
+                }
+
                 match self {
                     $(Self::$name(ref m) => {
                         self.id().encode(w)?;
@@ -158,6 +166,25 @@ macro_rules! message_types {
                 match self {
                     $(Self::$name(_) => stringify!($name),)*
                 }
+            }
+
+            pub(crate) fn parameter_scopes_valid(&self) -> bool {
+                let params = match self {
+                    Self::RequestUpdate(m) => &m.params,
+                    Self::RequestOk(m) => &m.params,
+                    Self::Subscribe(m) => &m.params,
+                    Self::SubscribeOk(m) => &m.params,
+                    Self::PublishNamespace(m) => &m.params,
+                    Self::TrackStatus(m) => &m.params,
+                    Self::Publish(m) => &m.params,
+                    Self::PublishOk(m) => &m.params,
+                    Self::Fetch(m) => &m.params,
+                    Self::FetchOk(m) => &m.params,
+                    Self::SubscribeNamespace(m) => &m.params,
+                    _ => return true,
+                };
+
+                params.parameters_allowed_on(self.id())
             }
 
             /// Return the request ID if this message participates in request ID sequencing.
@@ -405,6 +432,47 @@ mod tests {
 
         let err = Message::decode(&mut buf).unwrap_err();
         assert!(matches!(err, DecodeError::InvalidMessage(0x100)));
+    }
+
+    #[test]
+    fn message_boundary_enforces_parameter_scope() {
+        let mut params = KeyValuePairs::default();
+        params.set_rendezvous_timeout(1_000);
+        let request_ok = RequestOk { id: 1, params };
+
+        let mut encoded = bytes::BytesMut::new();
+        let err = Message::RequestOk(request_ok.clone())
+            .encode(&mut encoded)
+            .unwrap_err();
+        assert!(matches!(err, EncodeError::InvalidValue));
+
+        encoded.clear();
+        let mut payload = bytes::BytesMut::new();
+        request_ok.encode(&mut payload).unwrap();
+        wire_id::RequestOk.encode(&mut encoded).unwrap();
+        (payload.len() as u16).encode(&mut encoded).unwrap();
+        encoded.extend_from_slice(&payload);
+
+        let err = Message::decode(&mut encoded).unwrap_err();
+        assert!(matches!(err, DecodeError::InvalidParameter));
+
+        let mut params = KeyValuePairs::default();
+        params.set_rendezvous_timeout(1_000);
+        params.set_bytesvalue(123, vec![1, 2, 3]);
+        let subscribe = Message::Subscribe(Subscribe {
+            id: 2,
+            track_namespace: namespace(),
+            track_name: "track".into(),
+            params,
+        });
+
+        encoded.clear();
+        subscribe.encode(&mut encoded).unwrap();
+        let Message::Subscribe(decoded) = Message::decode(&mut encoded).unwrap() else {
+            panic!("expected SUBSCRIBE");
+        };
+        assert_eq!(decoded.params.rendezvous_timeout().unwrap(), Some(1_000));
+        assert!(decoded.params.get(123).is_some());
     }
 
     #[test]

--- a/moq-transport/src/message/params.rs
+++ b/moq-transport/src/message/params.rs
@@ -6,12 +6,15 @@ use bytes::Buf as _;
 use crate::coding::{
     Decode, DecodeError, Encode, EncodeError, KeyValuePair, KeyValuePairs, Location, Value,
 };
-use crate::message::{FilterType, GroupOrder};
+use crate::message::{wire_id, FilterType, GroupOrder};
 
 /// Draft-16 message-parameter type IDs.
 pub mod parameter_type {
     pub const DELIVERY_TIMEOUT: u64 = 0x02;
     pub const AUTHORIZATION_TOKEN: u64 = 0x03;
+    /// draft-18 §10.2.6. Milliseconds a subscriber will wait for a publisher to
+    /// appear. Valid on SUBSCRIBE only, unlike the delivery timeouts.
+    pub const RENDEZVOUS_TIMEOUT: u64 = 0x04;
     pub const EXPIRES: u64 = 0x08;
     pub const LARGEST_OBJECT: u64 = 0x09;
     pub const FORWARD: u64 = 0x10;
@@ -37,6 +40,11 @@ pub const U8_VALUE_PARAMETER_TYPES: &[u64] = &[
     parameter_type::SUBSCRIBER_PRIORITY, // 0x20
     parameter_type::GROUP_ORDER,         // 0x22
 ];
+
+/// Message scopes enforced for supported parameters with restricted use.
+/// Unknown parameter types remain available for negotiated extensions.
+const MESSAGE_PARAMETER_SCOPES: &[(u64, &[u64])] =
+    &[(parameter_type::RENDEZVOUS_TIMEOUT, &[wire_id::Subscribe])];
 
 /// Draft-16 extension-header type IDs.
 pub mod extension_type {
@@ -286,6 +294,15 @@ impl KeyValuePairs {
         self.encode_with_u8_types(w, U8_VALUE_PARAMETER_TYPES)
     }
 
+    pub(crate) fn parameters_allowed_on(&self, message_type: u64) -> bool {
+        self.0.iter().all(|parameter| {
+            MESSAGE_PARAMETER_SCOPES
+                .iter()
+                .find(|(parameter_type, _)| *parameter_type == parameter.key)
+                .is_none_or(|(_, message_types)| message_types.contains(&message_type))
+        })
+    }
+
     fn int_parameter(&self, key: u64) -> Result<Option<u64>, DecodeError> {
         get_kvp_int(&self.0, key)
     }
@@ -384,6 +401,17 @@ impl KeyValuePairs {
         self.int_parameter(parameter_type::DELIVERY_TIMEOUT)
     }
 
+    pub fn set_rendezvous_timeout(&mut self, timeout_ms: u64) {
+        self.set_intvalue(parameter_type::RENDEZVOUS_TIMEOUT, timeout_ms);
+    }
+
+    /// Milliseconds the subscriber will wait for a publisher to become available
+    /// (draft-18 §10.2.6). `None` and `Some(0)` are equivalent in effect: the
+    /// spec's default is 0, meaning respond immediately rather than hold.
+    pub fn rendezvous_timeout(&self) -> Result<Option<u64>, DecodeError> {
+        self.int_parameter(parameter_type::RENDEZVOUS_TIMEOUT)
+    }
+
     pub fn set_new_group_request(&mut self, group_id: u64) {
         self.set_intvalue(parameter_type::NEW_GROUP_REQUEST, group_id);
     }
@@ -414,6 +442,7 @@ mod tests {
         params.set_expires(6);
         params.set_delivery_timeout(8);
         params.set_new_group_request(9);
+        params.set_rendezvous_timeout(30_000);
 
         assert_eq!(params.forward().unwrap(), Some(false));
         assert_eq!(params.subscriber_priority().unwrap(), Some(7));
@@ -423,6 +452,23 @@ mod tests {
         assert_eq!(params.expires().unwrap(), Some(6));
         assert_eq!(params.delivery_timeout().unwrap(), Some(8));
         assert_eq!(params.new_group_request().unwrap(), Some(9));
+        assert_eq!(params.rendezvous_timeout().unwrap(), Some(30_000));
+    }
+
+    /// 0x04 is even, so the KVP codec carries it as a varint. A peer sending a
+    /// byte string under that key is malformed rather than something to coerce.
+    #[test]
+    fn rendezvous_timeout_rejects_a_bytes_value() {
+        let mut params = KeyValuePairs::default();
+        params.set_bytesvalue(parameter_type::RENDEZVOUS_TIMEOUT, vec![1, 2, 3]);
+
+        assert!(params.rendezvous_timeout().is_err());
+    }
+
+    /// Absent means the spec default of 0: do not hold, answer immediately.
+    #[test]
+    fn rendezvous_timeout_absent_is_none() {
+        assert_eq!(KeyValuePairs::default().rendezvous_timeout().unwrap(), None);
     }
 
     #[test]

--- a/moq-transport/src/message/subscribe.rs
+++ b/moq-transport/src/message/subscribe.rs
@@ -79,6 +79,28 @@ mod tests {
         assert_eq!(decoded, msg);
     }
 
+    /// The interop guarantee: RENDEZVOUS_TIMEOUT survives the wire unchanged.
+    /// 0x04 is even, so the KVP codec carries it as a varint with no length prefix.
+    #[test]
+    fn rendezvous_timeout_survives_the_wire() {
+        let mut buf = BytesMut::new();
+
+        let mut params = KeyValuePairs::default();
+        params.set_rendezvous_timeout(30_000);
+
+        let msg = Subscribe {
+            id: 7,
+            track_namespace: TrackNamespace::from_utf8_path("meeting/room"),
+            track_name: "camera".into(),
+            params,
+        };
+        msg.encode(&mut buf).unwrap();
+
+        let decoded = Subscribe::decode(&mut buf).unwrap();
+        assert_eq!(decoded, msg);
+        assert_eq!(decoded.params.rendezvous_timeout().unwrap(), Some(30_000));
+    }
+
     #[test]
     fn default_params_roundtrip() {
         // Verify a minimal SUBSCRIBE with no params still round-trips cleanly.

--- a/moq-transport/src/serve/error.rs
+++ b/moq-transport/src/serve/error.rs
@@ -17,6 +17,10 @@ pub enum ServeError {
     #[error("not found")]
     NotFound,
 
+    /// A request ended with draft-18 REQUEST_ERROR TIMEOUT.
+    #[error("request timed out")]
+    Timeout,
+
     #[error("not found: {0} [error:{1}]")]
     NotFoundWithId(String, uuid::Uuid),
 
@@ -72,6 +76,8 @@ impl ServeError {
             Self::Closed(code) => *code,
             // TRACK_DOES_NOT_EXIST (0x4) from SUBSCRIBE_ERROR codes
             Self::NotFound | Self::NotFoundWithId(_, _) => 0x4,
+            // TIMEOUT (0x2) in the REQUEST_ERROR registry
+            Self::Timeout => 0x2,
             // This is more of a session-level error, but keeping a reasonable code
             Self::Duplicate => 0x5,
             // NOT_SUPPORTED (0x3) - appears in multiple error code registries

--- a/moq-transport/src/session/mod.rs
+++ b/moq-transport/src/session/mod.rs
@@ -70,6 +70,13 @@ type BidiReaderFuture = Pin<Box<dyn Future<Output = Result<(), SessionError>> + 
 /// concurrency — no task is spawned, so a reader cannot outlive the session.
 type BidiTaskSender = tokio::sync::mpsc::UnboundedSender<BidiReaderFuture>;
 
+/// Validate and encode a request before allocating its bidirectional stream.
+fn encode_request_frame(msg: &Message) -> Result<bytes::BytesMut, SessionError> {
+    let mut frame = bytes::BytesMut::new();
+    msg.encode(&mut frame)?;
+    Ok(frame)
+}
+
 /// The transport protocol negotiated for this MoQT connection.
 ///
 /// MoQT can run over either WebTransport (HTTP/3 + QUIC) or raw QUIC.
@@ -1211,6 +1218,10 @@ impl Session {
     fn encode_bidi_response_frame(msg: &Message) -> Result<bytes::BytesMut, SessionError> {
         use bytes::BufMut;
 
+        if !msg.parameter_scopes_valid() {
+            return Err(crate::coding::EncodeError::InvalidValue.into());
+        }
+
         // Encode the payload (all fields EXCEPT Request ID, which is
         // implicit from the bidi stream identity in draft-18).
         let mut payload = bytes::BytesMut::new();
@@ -1306,7 +1317,7 @@ impl Session {
 
         use message::wire_id;
 
-        match msg_type {
+        let msg = match msg_type {
             wire_id::RequestError => {
                 let error_code = u64::decode(&mut buf)?;
                 let retry_interval = u64::decode(&mut buf)?;
@@ -1394,7 +1405,13 @@ impl Session {
                     other
                 )))
             }
+        }?;
+
+        if !msg.parameter_scopes_valid() {
+            return Err(DecodeError::InvalidParameter.into());
         }
+
+        Ok(msg)
     }
 
     /// Receives inbound messages from the control stream reader/receiver.
@@ -1701,6 +1718,20 @@ mod tests {
         // type (1 byte) + length 0x0001 (2 bytes) + params_count=0 (1 byte) = 4 bytes
         assert_eq!(bytes[0], wire_id::RequestOk as u8);
         assert_eq!(bytes.len(), 4);
+    }
+
+    #[test]
+    fn encode_bidi_response_rejects_parameter_outside_its_scope() {
+        let mut params = crate::coding::KeyValuePairs::default();
+        params.set_rendezvous_timeout(1_000);
+        let msg = Message::RequestOk(message::RequestOk { id: 1, params });
+
+        assert!(matches!(
+            Session::encode_bidi_response_frame(&msg),
+            Err(SessionError::Encode(
+                crate::coding::EncodeError::InvalidValue
+            ))
+        ));
     }
 
     #[test]

--- a/moq-transport/src/session/publisher.rs
+++ b/moq-transport/src/session/publisher.rs
@@ -174,8 +174,17 @@ impl Publisher {
         };
         // Lock released here.
 
-        // Phase 2: open bidi stream and send (async, no lock held).
-        // If open_bi fails, remove the entry we inserted in Phase 1.
+        // Phase 2: encode before allocating a QUIC stream, then open and send
+        // (async, no lock held). Any failure removes the entry from Phase 1.
+        let frame = match super::encode_request_frame(&wire_msg) {
+            Ok(frame) => frame,
+            Err(e) => {
+                if let Ok(mut ns) = self.publish_namespaces.lock() {
+                    ns.remove(&tracks.namespace);
+                }
+                return Err(e);
+            }
+        };
         let (send_stream, recv_stream) = match self.webtransport.open_bi().await {
             Ok(streams) => streams,
             Err(e) => {
@@ -186,7 +195,7 @@ impl Publisher {
             }
         };
         let mut writer = super::Writer::new(send_stream);
-        if let Err(e) = writer.encode(&wire_msg).await {
+        if let Err(e) = writer.write(&frame).await {
             if let Ok(mut ns) = self.publish_namespaces.lock() {
                 ns.remove(&tracks.namespace);
             }
@@ -389,9 +398,11 @@ impl Publisher {
         request_id: u64,
         msg: message::Publish,
     ) -> Result<super::RequestStreamSink, SessionError> {
+        // Validate local parameters before consuming a peer request-stream slot.
+        let frame = super::encode_request_frame(&Message::Publish(msg))?;
         let (send_stream, recv_stream) = self.webtransport.open_bi().await?;
         let mut writer = super::Writer::new(send_stream);
-        writer.encode(&Message::Publish(msg)).await?;
+        writer.write(&frame).await?;
 
         let (stream_tx, mut stream_rx) = tokio::sync::mpsc::unbounded_channel::<Message>();
         let mut this = self.clone();
@@ -1065,7 +1076,8 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use crate::{
-        coding::{TrackName, TrackNamespace},
+        coding::{KeyValuePairs, TrackName, TrackNamespace},
+        message::{self, Message},
         serve::FullTrackName,
     };
 
@@ -1095,5 +1107,26 @@ mod tests {
         let names = subscribed_names.lock().unwrap();
         assert!(!names.contains_name(&unsubscribed_track));
         assert_eq!(names.get_by_name(&active_track), Some(8));
+    }
+
+    #[test]
+    fn publish_frame_rejects_subscribe_only_params_before_stream_open() {
+        let mut params = KeyValuePairs::default();
+        params.set_rendezvous_timeout(1_000);
+        let msg = Message::Publish(message::Publish {
+            id: 0,
+            track_namespace: TrackNamespace::from_utf8_path("test/ns"),
+            track_name: "video".into(),
+            track_alias: 0,
+            params,
+            track_extensions: Default::default(),
+        });
+
+        assert!(matches!(
+            super::super::encode_request_frame(&msg),
+            Err(crate::session::SessionError::Encode(
+                crate::coding::EncodeError::InvalidValue
+            ))
+        ));
     }
 }

--- a/moq-transport/src/session/subscribe.rs
+++ b/moq-transport/src/session/subscribe.rs
@@ -89,6 +89,7 @@ impl SubscribeInfo {
             .unwrap_or(FilterType::AbsoluteStart);
         let start_location = filter.as_ref().and_then(|filter| filter.start_location);
         let end_group_id = filter.as_ref().and_then(|filter| filter.end_group_id);
+        msg.params.rendezvous_timeout()?;
 
         Ok(Self {
             id: msg.id,
@@ -175,31 +176,19 @@ pub struct Subscribe {
 }
 
 impl Subscribe {
-    fn build_info(request_id: u64, track: &TrackWriter) -> (message::Subscribe, SubscribeInfo) {
+    fn build_info(
+        request_id: u64,
+        track: &TrackWriter,
+        params: KeyValuePairs,
+    ) -> Result<(message::Subscribe, SubscribeInfo), SessionError> {
         let subscribe_message = message::Subscribe {
             id: request_id,
             track_namespace: track.namespace.clone(),
             track_name: track.name.clone(),
-            params: KeyValuePairs::default(),
+            params,
         };
-        let info = SubscribeInfo::new_from_subscribe(&subscribe_message).unwrap_or_else(|err| {
-            tracing::warn!(error = %err, "failed to decode outbound subscribe parameters");
-            SubscribeInfo {
-                id: request_id,
-                track_namespace: track.namespace.clone(),
-                track_name: track.name.clone(),
-                subscriber_priority: 128,
-                group_order: GroupOrder::Publisher,
-                forward: true,
-                filter_type: FilterType::AbsoluteStart,
-                start_location: None,
-                end_group_id: None,
-                filter: None,
-                params: Default::default(),
-                track_status: false,
-            }
-        });
-        (subscribe_message, info)
+        let info = SubscribeInfo::new_from_subscribe(&subscribe_message)?;
+        Ok((subscribe_message, info))
     }
 
     /// Create a Subscribe without sending on the control stream, returning the
@@ -210,10 +199,11 @@ impl Subscribe {
         subscriber: Subscriber,
         request_id: u64,
         track: TrackWriter,
-    ) -> (Subscribe, SubscribeRecv, message::Subscribe) {
-        let (msg, info) = Self::build_info(request_id, &track);
+        params: KeyValuePairs,
+    ) -> Result<(Subscribe, SubscribeRecv, message::Subscribe), SessionError> {
+        let (msg, info) = Self::build_info(request_id, &track, params)?;
         let (send, recv) = Self::from_parts(subscriber, info, track);
-        (send, recv, msg)
+        Ok((send, recv, msg))
     }
 
     fn from_parts(
@@ -516,7 +506,8 @@ mod tests {
         );
         let (writer, _reader) =
             crate::serve::Track::new(TrackNamespace::from_utf8_path("test"), "track").produce();
-        let (send, recv, _msg) = Subscribe::new(subscriber, 0, writer);
+        let (send, recv, _msg) =
+            Subscribe::new(subscriber, 0, writer, KeyValuePairs::default()).unwrap();
         (send, recv)
     }
 
@@ -567,6 +558,60 @@ mod tests {
 
         assert!(recv.drain_timeout());
         assert_eq!(send.closed().await, Err(ServeError::Closed(0x6)));
+    }
+
+    #[test]
+    fn rendezvous_timeout_is_parsed_from_params() {
+        let mut params = KeyValuePairs::default();
+        params.set_rendezvous_timeout(30_000);
+
+        assert_eq!(
+            subscribe_info_with(params)
+                .params
+                .rendezvous_timeout()
+                .unwrap(),
+            Some(30_000)
+        );
+    }
+
+    #[test]
+    fn invalid_outbound_params_are_rejected() {
+        let (writer, _reader) =
+            crate::serve::Track::new(TrackNamespace::from_utf8_path("test"), "track").produce();
+        let mut params = KeyValuePairs::default();
+        params.set_bytesvalue(message::parameter_type::RENDEZVOUS_TIMEOUT, vec![1]);
+
+        assert!(Subscribe::build_info(0, &writer, params).is_err());
+    }
+
+    /// Absent carries draft-18's default of 0, so a relay must not hold the
+    /// subscription. Kept as None rather than defaulted to 0 so a relay can tell
+    /// "not requested" from "explicitly zero" if it ever wants to.
+    #[test]
+    fn omitted_rendezvous_timeout_is_none() {
+        assert_eq!(
+            subscribe_info_with(KeyValuePairs::default())
+                .params
+                .rendezvous_timeout()
+                .unwrap(),
+            None
+        );
+    }
+
+    /// Zero is meaningful and distinct from absent on the wire, even though both
+    /// mean "answer immediately".
+    #[test]
+    fn explicit_zero_rendezvous_timeout_is_preserved() {
+        let mut params = KeyValuePairs::default();
+        params.set_rendezvous_timeout(0);
+
+        assert_eq!(
+            subscribe_info_with(params)
+                .params
+                .rendezvous_timeout()
+                .unwrap(),
+            Some(0)
+        );
     }
 
     #[test]

--- a/moq-transport/src/session/subscribed.rs
+++ b/moq-transport/src/session/subscribed.rs
@@ -23,6 +23,7 @@ use super::{DeliveryFilter, Publisher, SessionError, SubscribeInfo, Writer};
 struct ObjectForwarderState {
     largest_location: Option<Location>,
     stream_count: u64,
+    retry_interval: u64,
     /// Set to true when UNSUBSCRIBE is received.  When true, Drop skips sending
     /// PUBLISH_DONE or REQUEST_ERROR because the subscriber already terminated.
     unsubscribed: bool,
@@ -51,6 +52,7 @@ impl Default for ObjectForwarderState {
         Self {
             largest_location: None,
             stream_count: 0,
+            retry_interval: 0,
             unsubscribed: false,
             closed: Ok(()),
         }
@@ -67,6 +69,18 @@ pub struct Subscribed {
     /// Tracks if SubscribeOk has been sent yet or not. Used to send
     /// PUBLISH_DONE vs REQUEST_ERROR on drop.
     ok: bool,
+}
+
+/// Failure while serving a track under a pre-acceptance deadline.
+#[derive(Debug, thiserror::Error)]
+pub enum ServeWithDeadlineError {
+    /// The deadline passed before SUBSCRIBE_OK was committed.
+    #[error("subscribe deadline expired before acceptance")]
+    DeadlineExpired,
+
+    /// Serving failed before or after acceptance for another reason.
+    #[error(transparent)]
+    Session(#[from] SessionError),
 }
 
 /// Serves a track's Objects on a session, keyed by Track Alias.
@@ -116,6 +130,24 @@ impl ObjectForwarder {
         Ok(())
     }
 
+    /// Commit the decision to accept a SUBSCRIBE while holding the same state
+    /// lock used by withdrawal.
+    fn prepare_subscribe_ok(
+        &self,
+        largest_location: Option<Location>,
+        deadline: Option<tokio::time::Instant>,
+    ) -> Result<(), ServeError> {
+        let state = self.state.lock();
+        state.closed.clone()?;
+
+        if deadline.is_some_and(|deadline| tokio::time::Instant::now() >= deadline) {
+            return Err(ServeError::Timeout);
+        }
+
+        state.into_mut().ok_or(ServeError::Cancel)?.largest_location = largest_location;
+        Ok(())
+    }
+
     /// Subgroup streams opened so far. The PUBLISH path needs this separately
     /// from [`Self::terminal_state`], because there the terminal message is sent
     /// by `Published::drop` after the forwarder is gone.
@@ -125,7 +157,7 @@ impl ObjectForwarder {
 
     /// Snapshot the fields a terminal message needs, without holding the lock
     /// across the send that follows.
-    fn terminal_state(&self) -> (ServeError, u64, bool) {
+    fn terminal_state(&self) -> (ServeError, u64, u64, bool) {
         let state = self.state.lock();
         let err = state
             .closed
@@ -133,15 +165,21 @@ impl ObjectForwarder {
             .err()
             .cloned()
             .unwrap_or(ServeError::Done);
-        (err, state.stream_count, state.unsubscribed)
+        (
+            err,
+            state.stream_count,
+            state.retry_interval,
+            state.unsubscribed,
+        )
     }
 
-    fn close(&self, err: ServeError) -> Result<(), ServeError> {
+    fn close(&self, err: ServeError, retry_interval: u64) -> Result<(), ServeError> {
         let state = self.state.lock();
         state.closed.clone()?;
 
         let mut state = state.into_mut().ok_or(ServeError::Done)?;
         state.closed = Err(err);
+        state.retry_interval = retry_interval;
 
         Ok(())
     }
@@ -198,8 +236,41 @@ impl Subscribed {
         Ok((send, recv))
     }
 
-    pub async fn serve(mut self, track: serve::TrackReader) -> Result<(), SessionError> {
-        let res = self.serve_inner(track).await;
+    pub async fn serve(self, track: serve::TrackReader) -> Result<(), SessionError> {
+        self.serve_before(track, None).await
+    }
+
+    /// Serve a track only if acceptance is committed before `deadline`.
+    pub async fn serve_with_deadline(
+        mut self,
+        track: serve::TrackReader,
+        deadline: tokio::time::Instant,
+    ) -> Result<(), ServeWithDeadlineError> {
+        let result = self.serve_inner(track, Some(deadline)).await;
+        let deadline_expired =
+            !self.ok && matches!(result, Err(SessionError::Serve(ServeError::Timeout)));
+
+        let Err(err) = result else {
+            return Ok(());
+        };
+
+        if deadline_expired {
+            // A simultaneous UNSUBSCRIBE may have closed the shared state first,
+            // but the relay still needs the deadline result for its response and metric.
+            let _ = self.close(err.clone().into());
+            return Err(ServeWithDeadlineError::DeadlineExpired);
+        }
+
+        self.close(err.clone().into()).map_err(SessionError::from)?;
+        Err(err.into())
+    }
+
+    async fn serve_before(
+        mut self,
+        track: serve::TrackReader,
+        deadline: Option<tokio::time::Instant>,
+    ) -> Result<(), SessionError> {
+        let res = self.serve_inner(track, deadline).await;
         if let Err(err) = &res {
             self.close(err.clone().into())?;
         }
@@ -207,10 +278,15 @@ impl Subscribed {
         res
     }
 
-    async fn serve_inner(&mut self, track: serve::TrackReader) -> Result<(), SessionError> {
+    async fn serve_inner(
+        &mut self,
+        track: serve::TrackReader,
+        deadline: Option<tokio::time::Instant>,
+    ) -> Result<(), SessionError> {
         // Update largest location before sending SubscribeOk
         let largest_location = track.largest_location();
-        self.forwarder.set_largest_location(largest_location)?;
+        self.forwarder
+            .prepare_subscribe_ok(largest_location, deadline)?;
 
         // Send SubscribeOk using send_message_and_wait to ensure it is sent at least to the QUIC stack before
         // we start serving the track.  If a subscriber gets the stream before SubscribeOk
@@ -240,7 +316,15 @@ impl Subscribed {
     }
 
     pub fn close(self, err: ServeError) -> Result<(), ServeError> {
-        self.forwarder.close(err)
+        self.close_with_retry(err, 0)
+    }
+
+    /// Reject a pending subscription and tell the subscriber when it may retry.
+    ///
+    /// `retry_interval` uses the REQUEST_ERROR wire encoding: minimum delay in
+    /// milliseconds plus one, or zero when the request should not be retried.
+    pub fn close_with_retry(self, err: ServeError, retry_interval: u64) -> Result<(), ServeError> {
+        self.forwarder.close(err, retry_interval)
     }
 
     pub async fn closed(&self) -> Result<(), ServeError> {
@@ -258,7 +342,7 @@ impl ops::Deref for Subscribed {
 
 impl Drop for Subscribed {
     fn drop(&mut self) {
-        let (err, stream_count, unsubscribed) = self.forwarder.terminal_state();
+        let (err, stream_count, retry_interval, unsubscribed) = self.forwarder.terminal_state();
 
         // Subscriber already sent UNSUBSCRIBE — no terminal message needed.
         if unsubscribed {
@@ -280,7 +364,7 @@ impl Drop for Subscribed {
                 message::RequestError {
                     id: self.info.id,
                     error_code: Self::request_error_code(&err),
-                    retry_interval: 0,
+                    retry_interval,
                     reason: ReasonPhrase(err.to_string()),
                 },
             );
@@ -304,6 +388,10 @@ impl Subscribed {
             ServeError::NotFound | ServeError::NotFoundWithId(_, _) => {
                 RequestErrorCode::DoesNotExist as u64
             }
+            // draft-18 §10.2.6 distinguishes the two: DOES_NOT_EXIST when the relay
+            // did not wait, TIMEOUT when it held the subscription and no publisher
+            // arrived before the subscriber's RENDEZVOUS_TIMEOUT elapsed.
+            ServeError::Timeout => RequestErrorCode::Timeout as u64,
             ServeError::Duplicate => RequestErrorCode::DuplicateSubscription as u64,
             ServeError::Cancel | ServeError::Done => RequestErrorCode::Uninterested as u64,
             ServeError::Mode
@@ -679,6 +767,127 @@ impl ObjectForwarderRecv {
 mod tests {
     use super::*;
 
+    async fn test_subscribed() -> (
+        Subscribed,
+        ObjectForwarderRecv,
+        crate::watch::Queue<message::Message>,
+    ) {
+        let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (outgoing, outgoing_recv) = crate::watch::Queue::default().split();
+        let publisher = Publisher::new(
+            outgoing,
+            crate::session::test_support::loopback_session().await,
+            None,
+            crate::session::RequestId::new(0, 1),
+            bidi_task_tx,
+        );
+        let (subscribed, recv) = Subscribed::new(
+            publisher,
+            message::Subscribe {
+                id: 0,
+                track_namespace: crate::coding::TrackNamespace::from_utf8_path("test"),
+                track_name: "track".into(),
+                params: KeyValuePairs::default(),
+            },
+            None,
+        )
+        .unwrap();
+        (subscribed, recv, outgoing_recv)
+    }
+
+    #[tokio::test]
+    async fn deadline_prevents_subscribe_ok() {
+        let (subscribed, _recv, _outgoing) = test_subscribed().await;
+        let (_writer, reader) = serve::Track::new(
+            crate::coding::TrackNamespace::from_utf8_path("test"),
+            "track",
+        )
+        .produce();
+
+        let error = subscribed
+            .serve_with_deadline(reader, tokio::time::Instant::now())
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, ServeWithDeadlineError::DeadlineExpired));
+    }
+
+    #[tokio::test]
+    async fn withdrawal_prevents_subscribe_ok() {
+        let (subscribed, mut recv, _outgoing) = test_subscribed().await;
+        recv.recv_unsubscribe().unwrap();
+        let (_writer, reader) = serve::Track::new(
+            crate::coding::TrackNamespace::from_utf8_path("test"),
+            "track",
+        )
+        .produce();
+
+        let error = subscribed
+            .serve_with_deadline(
+                reader,
+                tokio::time::Instant::now() + std::time::Duration::from_secs(1),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ServeWithDeadlineError::Session(SessionError::Serve(ServeError::Cancel))
+        ));
+    }
+
+    /// A publisher-side timeout after SUBSCRIBE_OK is a track failure, not an
+    /// expired rendezvous window.
+    #[tokio::test]
+    async fn accepted_track_timeout_is_not_a_deadline_expiration() {
+        let (subscribed, _recv, mut outgoing) = test_subscribed().await;
+        let (writer, reader) = serve::Track::new(
+            crate::coding::TrackNamespace::from_utf8_path("test"),
+            "track",
+        )
+        .produce();
+
+        let serve = subscribed.serve_with_deadline(
+            reader,
+            tokio::time::Instant::now() + std::time::Duration::from_secs(1),
+        );
+        let close_after_accept = async move {
+            assert!(matches!(
+                outgoing.pop().await,
+                Some(message::Message::SubscribeOk(_))
+            ));
+            writer.close(ServeError::Timeout).unwrap();
+        };
+
+        let (result, ()) = tokio::join!(serve, close_after_accept);
+        assert!(matches!(
+            result.unwrap_err(),
+            ServeWithDeadlineError::Session(SessionError::Serve(ServeError::Timeout))
+        ));
+    }
+
+    #[tokio::test]
+    async fn rejection_preserves_retry_interval() {
+        let (subscribed, _recv, mut outgoing) = test_subscribed().await;
+        // The session retains a Publisher while individual requests come and go.
+        let _publisher = subscribed.forwarder.publisher.clone();
+        let retry_interval = 1_500;
+
+        subscribed
+            .close_with_retry(
+                ServeError::Closed(RequestErrorCode::ExcessiveLoad as u64),
+                retry_interval,
+            )
+            .unwrap();
+
+        let outgoing = outgoing.pop().await;
+        let Some(message::Message::RequestError(rejection)) = outgoing else {
+            panic!("expected REQUEST_ERROR, got {outgoing:?}");
+        };
+        assert_eq!(rejection.error_code, RequestErrorCode::ExcessiveLoad as u64);
+        assert_eq!(rejection.retry_interval, retry_interval);
+    }
+
     #[test]
     fn subscribed_state_counts_opened_streams() {
         let mut state = ObjectForwarderState::default();
@@ -739,6 +948,11 @@ mod tests {
         assert_eq!(
             Subscribed::request_error_code(&ServeError::Duplicate),
             RequestErrorCode::DuplicateSubscription as u64
+        );
+        // A rendezvous hold that expired is TIMEOUT, not DOES_NOT_EXIST.
+        assert_eq!(
+            Subscribed::request_error_code(&ServeError::Timeout),
+            RequestErrorCode::Timeout as u64
         );
         assert_eq!(
             Subscribed::request_error_code(&ServeError::NotImplemented("fetch".to_string())),

--- a/moq-transport/src/session/subscriber.rs
+++ b/moq-transport/src/session/subscriber.rs
@@ -300,9 +300,13 @@ impl Subscriber {
         &self,
         msg: &message::Message,
     ) -> Result<(Writer, Reader), SessionError> {
+        // Validate and encode before allocating a QUIC stream, so malformed
+        // local parameters cannot consume a request-stream slot.
+        let frame = super::encode_request_frame(msg)?;
+
         let (send_stream, recv_stream) = self.webtransport.open_bi().await?;
         let mut writer = Writer::new(send_stream);
-        writer.encode(msg).await?;
+        writer.write(&frame).await?;
         Ok((writer, Reader::new(recv_stream)))
     }
 
@@ -346,6 +350,23 @@ impl Subscriber {
         &mut self,
         track: serve::TrackWriter,
     ) -> Result<Subscribe, ServeError> {
+        self.subscribe_open_with_params(track, KeyValuePairs::default())
+            .await
+    }
+
+    /// Like [`Self::subscribe_open`], but with SUBSCRIBE parameters.
+    ///
+    /// Draft-18 moved subscriber priority, group order, forward and the
+    /// subscription filter out of fixed fields and into parameters, and added
+    /// RENDEZVOUS_TIMEOUT (§10.2.6) for holding a subscription open until a
+    /// publisher appears. None of that is reachable without a way to attach
+    /// parameters, so this is the API that makes those features usable; the
+    /// no-parameter form above delegates here.
+    pub async fn subscribe_open_with_params(
+        &mut self,
+        track: serve::TrackWriter,
+        params: KeyValuePairs,
+    ) -> Result<Subscribe, ServeError> {
         let request_id = self
             .get_next_request_id()
             .map_err(|e| ServeError::internal_ctx(format!("request ID limit: {}", e)))?;
@@ -369,7 +390,18 @@ impl Subscriber {
             names.insert(full_name, request_id);
         }
 
-        let (send, recv, subscribe) = Subscribe::new(self.clone(), request_id, track);
+        let (send, recv, subscribe) = match Subscribe::new(self.clone(), request_id, track, params)
+        {
+            Ok(subscribe) => subscribe,
+            Err(err) => {
+                if let Ok(mut names) = self.subscriber_names.lock() {
+                    names.remove_by_request_id(request_id);
+                }
+                return Err(ServeError::internal_ctx(format!(
+                    "invalid subscribe parameters: {err}"
+                )));
+            }
+        };
 
         // Open a bidi stream and send the SUBSCRIBE message BEFORE
         // registering in the subscribes map — avoids a leaked entry if
@@ -1282,6 +1314,8 @@ impl Subscriber {
             c if c == RequestErrorCode::InternalError as u64 => {
                 ServeError::internal_ctx(msg.reason.0.clone())
             }
+            // Preserve TIMEOUT as a semantic variant rather than an opaque code.
+            c if c == RequestErrorCode::Timeout as u64 => ServeError::Timeout,
             c if c == RequestErrorCode::DuplicateSubscription as u64 => ServeError::Duplicate,
             c if c == RequestErrorCode::NotSupported as u64 => {
                 ServeError::NotImplemented(msg.reason.0.clone())
@@ -1902,6 +1936,25 @@ mod tests {
         writer
     }
 
+    #[test]
+    fn request_frame_rejects_invalid_params_before_stream_open() {
+        let mut params = KeyValuePairs::default();
+        params.set_bytesvalue(0x100, vec![1]);
+        let msg = Message::Subscribe(message::Subscribe {
+            id: 0,
+            track_namespace: TrackNamespace::from_utf8_path("test/ns"),
+            track_name: "video".into(),
+            params,
+        });
+
+        assert!(matches!(
+            super::super::encode_request_frame(&msg),
+            Err(SessionError::Encode(
+                crate::coding::EncodeError::InvalidValue
+            ))
+        ));
+    }
+
     /// `Subscribe::drop` must remove the request's entry from the subscribes map
     /// (the real Drop impl calls `Subscriber::remove_subscribe`).
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1909,8 +1962,13 @@ mod tests {
         let subscriber = test_subscriber(loopback_session().await);
         let request_id = 4;
 
-        let (subscribe, recv, _msg) =
-            Subscribe::new(subscriber.clone(), request_id, test_track("video"));
+        let (subscribe, recv, _msg) = Subscribe::new(
+            subscriber.clone(),
+            request_id,
+            test_track("video"),
+            Default::default(),
+        )
+        .unwrap();
         // Mimic subscribe_open: register the recv state under the request id.
         subscriber
             .subscribes
@@ -1945,8 +2003,13 @@ mod tests {
         let request_id = 6;
         let track_alias = 42;
 
-        let (subscribe, mut recv, _msg) =
-            Subscribe::new(subscriber.clone(), request_id, test_track("audio"));
+        let (subscribe, mut recv, _msg) = Subscribe::new(
+            subscriber.clone(),
+            request_id,
+            test_track("audio"),
+            Default::default(),
+        )
+        .unwrap();
         // Record the track alias while the Subscribe (the state's send half) is
         // still alive, so the recv state accepts the mutation. Then drop the
         // handle — its Drop runs against the still-empty map (a no-op) — and


### PR DESCRIPTION
feat(moq-transport): support rendezvous timeout subscriptions

Subscribers can attach draft-18 SUBSCRIBE parameters, including RENDEZVOUS_TIMEOUT. Sessions preserve TIMEOUT responses, reject supported parameters outside their permitted message scope, and can enforce a deadline before accepting a subscription without changing the existing no-parameter API.

feat(moq-relay-ietf): wait for rendezvous publishers

A relay can hold a SUBSCRIBE when no publisher exists and resolve it from a publisher that appears locally or through the coordinator. The requested wait is capped at 30 seconds, with capacity limited to 128 holds per relay and 64 per session. Requests above either limit receive EXCESSIVE_LOAD with a spread retry interval.