### PR TITLE
fix(moq-transport): preserve subgroup object IDs

### DIFF
--- a/moq-transport/CHANGELOG.md
+++ b/moq-transport/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- *(moq-transport)* preserve subgroup Object IDs across relay forwarding
+
 ## [0.16.0](https://github.com/cloudflare/moq-rs/compare/moq-transport-v0.15.1...moq-transport-v0.16.0) - 2026-07-19
 
 ### Added

--- a/moq-transport/src/data/subgroup.rs
+++ b/moq-transport/src/data/subgroup.rs
@@ -4,6 +4,47 @@
 use crate::coding::{Decode, DecodeError, Encode, EncodeError};
 use crate::data::{ExtensionHeaders, ObjectStatus, StreamHeaderType};
 
+#[derive(Debug, Clone, Copy, Eq, PartialEq, thiserror::Error)]
+pub(crate) enum ObjectIdDeltaError {
+    #[error("object ID delta overflow")]
+    Overflow,
+
+    #[error("object IDs must increase within a subgroup stream")]
+    NonMonotonic,
+}
+
+/// Decode an Object ID Delta and advance the stream's Object ID state.
+pub(crate) fn decode_object_id_delta(
+    previous_object_id: &mut Option<u64>,
+    object_id_delta: u64,
+) -> Result<u64, ObjectIdDeltaError> {
+    let object_id = match *previous_object_id {
+        Some(previous) => previous
+            .checked_add(object_id_delta)
+            .and_then(|value| value.checked_add(1))
+            .ok_or(ObjectIdDeltaError::Overflow)?,
+        None => object_id_delta,
+    };
+    *previous_object_id = Some(object_id);
+    Ok(object_id)
+}
+
+/// Encode an absolute Object ID and advance the stream's Object ID state.
+pub(crate) fn encode_object_id_delta(
+    previous_object_id: &mut Option<u64>,
+    object_id: u64,
+) -> Result<u64, ObjectIdDeltaError> {
+    let object_id_delta = match *previous_object_id {
+        Some(previous) => object_id
+            .checked_sub(previous)
+            .and_then(|difference| difference.checked_sub(1))
+            .ok_or(ObjectIdDeltaError::NonMonotonic)?,
+        None => object_id,
+    };
+    *previous_object_id = Some(object_id);
+    Ok(object_id_delta)
+}
+
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct SubgroupHeader {
     /// Subgroup Header Type
@@ -369,6 +410,52 @@ mod tests {
     use super::*;
     use bytes::Bytes;
     use bytes::BytesMut;
+
+    #[test]
+    fn object_id_delta_round_trips_absolute_first_and_relative_followups() {
+        for (object_ids, expected_deltas) in [([0, 1, 2], [0, 0, 0]), ([7, 9, 12], [7, 1, 2])] {
+            let mut encode_previous = None;
+            let deltas = object_ids
+                .map(|object_id| encode_object_id_delta(&mut encode_previous, object_id).unwrap());
+            assert_eq!(deltas, expected_deltas);
+
+            let mut decode_previous = None;
+            let decoded =
+                deltas.map(|delta| decode_object_id_delta(&mut decode_previous, delta).unwrap());
+            assert_eq!(decoded, object_ids);
+        }
+    }
+
+    #[test]
+    fn object_id_delta_rejects_overflow_and_non_monotonic_ids() {
+        let mut previous = Some(u64::MAX);
+        assert_eq!(
+            decode_object_id_delta(&mut previous, 0),
+            Err(ObjectIdDeltaError::Overflow)
+        );
+        assert_eq!(previous, Some(u64::MAX));
+
+        for object_id in [9, 8] {
+            let mut previous = Some(9);
+            assert_eq!(
+                encode_object_id_delta(&mut previous, object_id),
+                Err(ObjectIdDeltaError::NonMonotonic)
+            );
+            assert_eq!(previous, Some(9));
+        }
+    }
+
+    #[test]
+    fn filtered_object_ids_use_the_previous_transmitted_object() {
+        let mut previous = None;
+        let deltas = [0, 1, 5, 6, 9]
+            .into_iter()
+            .filter(|object_id| *object_id > 4)
+            .map(|object_id| encode_object_id_delta(&mut previous, object_id).unwrap())
+            .collect::<Vec<_>>();
+
+        assert_eq!(deltas, [5, 0, 2]);
+    }
 
     #[test]
     fn encode_decode_object() {

--- a/moq-transport/src/serve/subgroup.rs
+++ b/moq-transport/src/serve/subgroup.rs
@@ -296,7 +296,7 @@ pub struct SubgroupWriter {
     pub info: Arc<SubgroupInfo>,
 
     // The next object sequence number to use.
-    next_object_id: u64,
+    next_object_id: Option<u64>,
 }
 
 impl SubgroupWriter {
@@ -304,7 +304,7 @@ impl SubgroupWriter {
         Self {
             state,
             info: group,
-            next_object_id: 0,
+            next_object_id: Some(0),
         }
     }
 
@@ -323,19 +323,34 @@ impl SubgroupWriter {
         size: usize,
         extension_headers: Option<crate::data::ExtensionHeaders>,
     ) -> Result<SubgroupObjectWriter, ServeError> {
+        let object_id = self.next_object_id.ok_or(ServeError::Duplicate)?;
+        self.create_with_id(object_id, size, extension_headers)
+    }
+
+    /// Write an object with an explicit absolute Object ID.
+    pub fn create_with_id(
+        &mut self,
+        object_id: u64,
+        size: usize,
+        extension_headers: Option<crate::data::ExtensionHeaders>,
+    ) -> Result<SubgroupObjectWriter, ServeError> {
+        let next_object_id = self.next_object_id.ok_or(ServeError::Duplicate)?;
+        if object_id < next_object_id {
+            return Err(ServeError::Duplicate);
+        }
+
         let (writer, reader) = SubgroupObject {
             group: self.info.clone(),
-            object_id: self.next_object_id,
+            object_id,
             status: ObjectStatus::NormalObject,
             size,
             extension_headers: extension_headers.unwrap_or_default(),
         }
         .produce();
 
-        self.next_object_id += 1;
-
         let mut state = self.state.lock_mut().ok_or(ServeError::Cancel)?;
         state.objects.push(reader);
+        self.next_object_id = object_id.checked_add(1);
 
         Ok(writer)
     }
@@ -630,5 +645,63 @@ impl Deref for SubgroupObjectReader {
 
     fn deref(&self) -> &Self::Target {
         &self.info
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::coding::TrackNamespace;
+
+    fn subgroup() -> (SubgroupWriter, SubgroupReader) {
+        SubgroupInfo {
+            track: Arc::new(Track::new(TrackNamespace::from_utf8_path("test"), "track")),
+            group_id: 0,
+            subgroup_id: 0,
+            priority: 128,
+        }
+        .produce()
+    }
+
+    #[tokio::test]
+    async fn create_with_id_preserves_nonzero_and_gapped_object_ids() {
+        let (mut writer, mut reader) = subgroup();
+
+        for object_id in [7, 9] {
+            let mut object = writer.create_with_id(object_id, 1, None).unwrap();
+            object.write(Bytes::from_static(b"x")).unwrap();
+        }
+
+        for expected in [7, 9] {
+            let object = reader.next().await.unwrap().unwrap();
+            assert_eq!(object.object_id, expected);
+        }
+    }
+
+    #[tokio::test]
+    async fn create_with_id_accepts_u64_max_as_the_final_object() {
+        let (mut writer, mut reader) = subgroup();
+
+        drop(writer.create_with_id(u64::MAX, 0, None).unwrap());
+
+        assert_eq!(reader.next().await.unwrap().unwrap().object_id, u64::MAX);
+        assert!(writer.create(0, None).is_err());
+        assert!(writer.create_with_id(u64::MAX, 0, None).is_err());
+    }
+
+    #[test]
+    fn create_with_id_rejects_duplicate_and_decreasing_ids() {
+        let (mut writer, _reader) = subgroup();
+
+        drop(writer.create_with_id(7, 0, None).unwrap());
+
+        assert!(matches!(
+            writer.create_with_id(7, 0, None),
+            Err(ServeError::Duplicate)
+        ));
+        assert!(matches!(
+            writer.create_with_id(6, 0, None),
+            Err(ServeError::Duplicate)
+        ));
     }
 }

--- a/moq-transport/src/session/mod.rs
+++ b/moq-transport/src/session/mod.rs
@@ -1534,13 +1534,16 @@ impl Session {
                     let stream = res?;
                     let subscriber = subscriber.clone().ok_or(SessionError::RoleViolation)?;
 
-                    tasks.push(async move {
-                        if let Err(err) = Subscriber::recv_stream(subscriber, stream).await {
-                            tracing::warn!("failed to serve stream: {}", err);
-                        };
-                    });
+                    tasks.push(Subscriber::recv_stream(subscriber, stream));
                 },
-                _ = tasks.next(), if !tasks.is_empty() => {},
+                result = tasks.next(), if !tasks.is_empty() => {
+                    if let Some(Err(err)) = result {
+                        if err.is_session_fatal() {
+                            return Err(err);
+                        }
+                        tracing::warn!("failed to serve stream: {}", err);
+                    }
+                },
             };
         }
     }
@@ -1564,21 +1567,10 @@ impl Session {
 /// Shared helpers for session-layer unit tests.
 #[cfg(test)]
 pub(crate) mod test_support {
-    /// Establish a real `web_transport::Session` over an in-process QUIC
-    /// loopback so tests can construct a `Publisher`/`Subscriber` and exercise
-    /// the real cleanup paths.
-    ///
-    /// Most tests never send anything over it — they only touch in-memory maps
-    /// and queues — but `Publisher` and `Subscriber` hold a concrete
-    /// `web_transport::Session`, so a live connection is the only honest way to
-    /// build one. The accepted server side is parked for the lifetime of the test
-    /// to keep the client session established.
-    pub(crate) async fn loopback_session() -> web_transport::Session {
+    pub(crate) async fn loopback_session_pair() -> (web_transport::Session, web_transport::Session)
+    {
         use web_transport::quinn::{ClientBuilder, ServerBuilder};
 
-        // Under `cargo test --workspace`, feature unification links both the
-        // `ring` and `aws-lc-rs` rustls providers, leaving no unambiguous
-        // process default. Install one explicitly (idempotent across tests).
         let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
         let cert = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])
@@ -1596,15 +1588,9 @@ pub(crate) mod test_support {
             .expect("build loopback server");
         let addr = server.local_addr().expect("server local addr");
 
-        tokio::spawn(async move {
-            if let Some(request) = server.accept().await {
-                // Hold the accepted server session open for the lifetime of the
-                // test so the client side stays established; the spawned task is
-                // cancelled at runtime shutdown when the test returns.
-                if let Ok(_session) = request.ok().await {
-                    std::future::pending::<()>().await;
-                }
-            }
+        let accept = tokio::spawn(async move {
+            let request = server.accept().await.expect("accept loopback request");
+            request.ok().await.expect("accept loopback session").into()
         });
 
         let client = ClientBuilder::new()
@@ -1613,13 +1599,32 @@ pub(crate) mod test_support {
             .expect("build loopback client");
         let url = url::Url::parse(&format!("https://127.0.0.1:{}/", addr.port()))
             .expect("parse loopback url");
-
-        // Fail fast rather than hang CI if the loopback handshake ever stalls.
-        tokio::time::timeout(std::time::Duration::from_secs(10), client.connect(url))
+        let client = tokio::time::timeout(std::time::Duration::from_secs(10), client.connect(url))
             .await
             .expect("loopback connect timed out")
             .expect("connect loopback session")
-            .into()
+            .into();
+        let server = accept.await.expect("join loopback accept task");
+
+        (client, server)
+    }
+
+    /// Establish a real `web_transport::Session` over an in-process QUIC
+    /// loopback so tests can construct a `Publisher`/`Subscriber` and exercise
+    /// the real cleanup paths.
+    ///
+    /// Most tests never send anything over it — they only touch in-memory maps
+    /// and queues — but `Publisher` and `Subscriber` hold a concrete
+    /// `web_transport::Session`, so a live connection is the only honest way to
+    /// build one. The accepted server side is parked for the lifetime of the test
+    /// to keep the client session established.
+    pub(crate) async fn loopback_session() -> web_transport::Session {
+        let (client, server) = loopback_session_pair().await;
+        tokio::spawn(async move {
+            let _server = server;
+            std::future::pending::<()>().await;
+        });
+        client
     }
 }
 

--- a/moq-transport/src/session/subscribed.rs
+++ b/moq-transport/src/session/subscribed.rs
@@ -515,6 +515,7 @@ impl ObjectForwarder {
 
         let mut writer: Option<Writer> = None;
         let mut object_count = 0;
+        let mut previous_object_id = None;
         while let Some(mut subgroup_object_reader) = subgroup_reader.next().await? {
             if !delivery_filter.allows(subgroup_reader.group_id, subgroup_object_reader.object_id) {
                 tracing::trace!(
@@ -564,11 +565,13 @@ impl ObjectForwarder {
             }
 
             let writer = writer.as_mut().ok_or(SessionError::Internal)?;
+            let object_id_delta = data::encode_object_id_delta(
+                &mut previous_object_id,
+                subgroup_object_reader.object_id,
+            )
+            .map_err(|err| SessionError::Serve(ServeError::internal_ctx(err.to_string())))?;
             let subgroup_object = data::SubgroupObjectExt {
-                // TODO(itzmanish): compute real delta when the receive side uses object IDs
-                // for ordering. Both sender and receiver must agree on the same prev tracking
-                // semantics before this is meaningful.
-                object_id_delta: 0,
+                object_id_delta,
                 extension_headers: subgroup_object_reader.extension_headers.clone(), // Pass through extension headers
                 payload_length: subgroup_object_reader.size,
                 status: if subgroup_object_reader.size == 0 {
@@ -766,6 +769,9 @@ impl ObjectForwarderRecv {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::session::test_support::loopback_session_pair;
+    use crate::session::Reader;
+    use bytes::Bytes;
 
     async fn test_subscribed() -> (
         Subscribed,
@@ -793,6 +799,83 @@ mod tests {
         )
         .unwrap();
         (subscribed, recv, outgoing_recv)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn filtered_subgroup_deltas_follow_transmitted_object_ids() {
+        let (publisher_session, peer_session) = loopback_session_pair().await;
+        let (outgoing, _outgoing_recv) = crate::watch::Queue::default().split();
+        let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+        let publisher = Publisher::new(
+            outgoing,
+            publisher_session,
+            None,
+            crate::session::RequestId::new(0, 1),
+            bidi_task_tx,
+        );
+        let (forwarder, _recv) = ObjectForwarder::new(publisher, 42, None);
+
+        let track = Arc::new(serve::Track::new(
+            crate::coding::TrackNamespace::from_utf8_path("test"),
+            "track",
+        ));
+        let (mut source, source_reader) = serve::SubgroupInfo {
+            track,
+            group_id: 0,
+            subgroup_id: 0,
+            priority: 128,
+        }
+        .produce();
+        for object_id in [0, 1, 5, 6, 9] {
+            let mut object = source.create_with_id(object_id, 1, None).unwrap();
+            object.write(Bytes::from(vec![object_id as u8])).unwrap();
+        }
+        drop(source);
+
+        let header = data::SubgroupHeader {
+            header_type: data::StreamHeaderType::SubgroupIdExt,
+            track_alias: 42,
+            group_id: 0,
+            subgroup_id: Some(0),
+            publisher_priority: 128,
+        };
+        let filter = DeliveryFilter {
+            forward: true,
+            start_location: Some(Location::new(0, 5)),
+            end_group_id: None,
+        };
+
+        let receive = async move {
+            let stream = peer_session.accept_uni().await.unwrap();
+            let mut reader = Reader::new(stream);
+            let stream_header: data::StreamHeader = reader.decode().await.unwrap();
+            assert_eq!(stream_header.subgroup_header.unwrap().track_alias, 42);
+
+            let mut received = Vec::new();
+            for expected_payload in [5, 6, 9] {
+                let object: data::SubgroupObjectExt = reader.decode().await.unwrap();
+                let payload = reader
+                    .read_chunk(object.payload_length)
+                    .await
+                    .unwrap()
+                    .unwrap();
+                assert_eq!(payload.as_ref(), &[expected_payload]);
+                received.push(object.object_id_delta);
+            }
+            received
+        };
+        let send = ObjectForwarder::serve_subgroup(
+            header,
+            source_reader,
+            forwarder.publisher.clone(),
+            forwarder.state.clone(),
+            None,
+            filter,
+        );
+
+        let (send_result, received_deltas) = tokio::join!(send, receive);
+        send_result.unwrap();
+        assert_eq!(received_deltas, [5, 0, 2]);
     }
 
     #[tokio::test]

--- a/moq-transport/src/session/subscriber.rs
+++ b/moq-transport/src/session/subscriber.rs
@@ -1963,7 +1963,7 @@ mod tests {
     }
 
     async fn send_test_subgroup(
-        session: web_transport::Session,
+        session: &web_transport::Session,
         track_alias: u64,
         object_id_deltas: &[u64],
     ) {
@@ -2003,7 +2003,7 @@ mod tests {
             serve::Track::new(TrackNamespace::from_utf8_path("test/ns"), "video").produce();
         let _subscribe = register_test_subscribe(&subscriber, track_writer, 0, 42);
 
-        let send = send_test_subgroup(peer_session, 42, &[7, 1, 2]);
+        let send = send_test_subgroup(&peer_session, 42, &[7, 1, 2]);
         let receive = async {
             let stream = receiver_session.accept_uni().await.unwrap();
             Subscriber::recv_stream(subscriber, stream).await.unwrap();
@@ -2030,7 +2030,7 @@ mod tests {
             serve::Track::new(TrackNamespace::from_utf8_path("test/ns"), "overflow").produce();
         let _subscribe = register_test_subscribe(&subscriber, track_writer, 0, 42);
 
-        let send = send_test_subgroup(peer_session, 42, &[u64::MAX, 0]);
+        let send = send_test_subgroup(&peer_session, 42, &[u64::MAX, 0]);
         let run = Session::run_streams(receiver_session, Some(subscriber));
         let ((), result) = tokio::join!(send, run);
 

--- a/moq-transport/src/session/subscriber.rs
+++ b/moq-transport/src/session/subscriber.rs
@@ -1669,16 +1669,10 @@ impl Subscriber {
                     }
                 };
 
-            let current_object_id = match previous_object_id {
-                Some(previous) => previous
-                    .checked_add(object_id_delta)
-                    .and_then(|value| value.checked_add(1))
-                    .ok_or_else(|| {
-                        SessionError::ProtocolViolation("subgroup object id overflow".to_string())
-                    })?,
-                None => object_id_delta,
-            };
-            previous_object_id = Some(current_object_id);
+            let current_object_id =
+                data::decode_object_id_delta(&mut previous_object_id, object_id_delta).map_err(
+                    |_| SessionError::ProtocolViolation("subgroup object id overflow".to_string()),
+                )?;
 
             // Extract extension headers if present
             let extension_headers = decoded_object
@@ -1737,11 +1731,15 @@ impl Subscriber {
                 }
             }
 
-            // Pass extension headers through to the serve layer
-            // TODO SLG - object_id_delta and object status are still being ignored
+            // Pass the absolute Object ID and extension headers through to the serve layer.
+            // TODO SLG - object status is still being ignored.
 
             let subgroup_writer = subgroup_writer.as_mut().ok_or(SessionError::Internal)?;
-            let mut object_writer = subgroup_writer.create(remaining_bytes, extension_headers)?;
+            let mut object_writer = subgroup_writer.create_with_id(
+                current_object_id,
+                remaining_bytes,
+                extension_headers,
+            )?;
             tracing::trace!(
                 "[SUBSCRIBER] recv_subgroup: reading payload for object #{} ({} bytes)",
                 object_count + 1,
@@ -1904,7 +1902,7 @@ impl Subscriber {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::session::test_support::loopback_session;
+    use crate::session::test_support::{loopback_session, loopback_session_pair};
 
     fn test_subscriber(session: web_transport::Session) -> Subscriber {
         let outgoing = Queue::default().split().0;
@@ -1934,6 +1932,109 @@ mod tests {
         let (writer, _reader) =
             serve::Track::new(TrackNamespace::from_utf8_path("test/ns"), name).produce();
         writer
+    }
+
+    fn register_test_subscribe(
+        subscriber: &Subscriber,
+        track: serve::TrackWriter,
+        request_id: u64,
+        track_alias: u64,
+    ) -> Subscribe {
+        let (subscribe, mut recv, _message) = Subscribe::new(
+            subscriber.clone(),
+            request_id,
+            track,
+            KeyValuePairs::default(),
+        )
+        .unwrap();
+        recv.ok(track_alias).unwrap();
+        subscriber
+            .subscribes
+            .lock()
+            .unwrap()
+            .insert(request_id, recv);
+        subscriber
+            .track_alias_map
+            .lock()
+            .unwrap()
+            .insert(track_alias, TrackOrigin::Subscribe(request_id))
+            .unwrap();
+        subscribe
+    }
+
+    async fn send_test_subgroup(
+        session: web_transport::Session,
+        track_alias: u64,
+        object_id_deltas: &[u64],
+    ) {
+        let stream = session.open_uni().await.unwrap();
+        let mut writer = Writer::new(stream);
+        writer
+            .encode(&data::SubgroupHeader {
+                header_type: data::StreamHeaderType::SubgroupIdExt,
+                track_alias,
+                group_id: 0,
+                subgroup_id: Some(0),
+                publisher_priority: 128,
+            })
+            .await
+            .unwrap();
+
+        for delta in object_id_deltas {
+            writer
+                .encode(&data::SubgroupObjectExt {
+                    object_id_delta: *delta,
+                    extension_headers: Default::default(),
+                    payload_length: 1,
+                    status: None,
+                })
+                .await
+                .unwrap();
+            writer.write(&[0]).await.unwrap();
+        }
+        writer.finish().unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn decoded_subgroup_object_ids_are_preserved() {
+        let (receiver_session, peer_session) = loopback_session_pair().await;
+        let subscriber = test_subscriber(receiver_session.clone());
+        let (track_writer, track_reader) =
+            serve::Track::new(TrackNamespace::from_utf8_path("test/ns"), "video").produce();
+        let _subscribe = register_test_subscribe(&subscriber, track_writer, 0, 42);
+
+        let send = send_test_subgroup(peer_session, 42, &[7, 1, 2]);
+        let receive = async {
+            let stream = receiver_session.accept_uni().await.unwrap();
+            Subscriber::recv_stream(subscriber, stream).await.unwrap();
+        };
+        tokio::join!(send, receive);
+
+        let serve::TrackReaderMode::Subgroups(mut subgroups) = track_reader.mode().await.unwrap()
+        else {
+            panic!("expected subgroup delivery");
+        };
+        let mut subgroup = subgroups.next().await.unwrap().unwrap();
+        for expected_object_id in [7, 9, 12] {
+            let mut object = subgroup.next().await.unwrap().unwrap();
+            assert_eq!(object.object_id, expected_object_id);
+            assert_eq!(object.read_all().await.unwrap().as_ref(), &[0]);
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn run_streams_propagates_subgroup_object_id_overflow() {
+        let (receiver_session, peer_session) = loopback_session_pair().await;
+        let subscriber = test_subscriber(receiver_session.clone());
+        let (track_writer, _track_reader) =
+            serve::Track::new(TrackNamespace::from_utf8_path("test/ns"), "overflow").produce();
+        let _subscribe = register_test_subscribe(&subscriber, track_writer, 0, 42);
+
+        let send = send_test_subgroup(peer_session, 42, &[u64::MAX, 0]);
+        let run = Session::run_streams(receiver_session, Some(subscriber));
+        let ((), result) = tokio::join!(send, run);
+
+        assert!(matches!(result, Err(SessionError::ProtocolViolation(_))));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- preserve decoded non-zero and sparse subgroup Object IDs in the serve model
- encode checked Object ID deltas relative to the previous transmitted Object after filtering
- propagate fatal subgroup Object ID overflow and cover ingress plus filtered retransmission over in-process transport sessions

## Validation
- `cargo fmt --all --check`
- focused contiguous, sparse, filtered, non-monotonic, and overflow vectors
- `cargo test -p moq-transport`
- `cargo test --workspace`
- workspace Clippy with the four pre-existing baseline lints explicitly allowed

## Scope
This intentionally does not change subgroup header modifiers, FIRST_OBJECT, priority, properties, completion semantics, datagrams, mixed delivery, FETCH, logging, or moq-test-client behavior.

Base: `cloudflare/moq-rs@9ed84735722adf0aa756c5781eaf31c8e12a00f4`