### PR TITLE
fix(moq-transport): support draft-18 subgroup modifiers

### DIFF
--- a/moq-transport/src/data/header.rs
+++ b/moq-transport/src/data/header.rs
@@ -6,72 +6,203 @@ use crate::coding::{Decode, DecodeError, Encode, EncodeError};
 use crate::data::{FetchHeader, SubgroupHeader};
 use std::fmt;
 
-/// Stream Header Types
-#[repr(u64)]
+/// Priority inherited when DEFAULT_PRIORITY is set and the Track Property is absent (§12.4).
+pub const DEFAULT_PUBLISHER_PRIORITY: u8 = 128;
+
+/// Encoding of the Subgroup ID in a draft-18 SUBGROUP_HEADER (§11.4.2).
 #[derive(Copy, Debug, Clone, Eq, PartialEq)]
-pub enum StreamHeaderType {
-    SubgroupZeroId = 0x10,
-    SubgroupZeroIdExt = 0x11,
-    SubgroupFirstObjectId = 0x12,
-    SubgroupFirstObjectIdExt = 0x13,
-    SubgroupId = 0x14,
-    SubgroupIdExt = 0x15,
-    SubgroupZeroIdEndOfGroup = 0x18,
-    SubgroupZeroIdExtEndOfGroup = 0x19,
-    SubgroupFirstObjectIdEndOfGroup = 0x1a,
-    SubgroupFirstObjectIdExtEndOfGroup = 0x1b,
-    SubgroupIdEndOfGroup = 0x1c,
-    SubgroupIdExtEndOfGroup = 0x1d,
-    Fetch = 0x5,
+pub enum SubgroupIdMode {
+    /// The Subgroup ID field is absent and the value is zero.
+    Zero,
+    /// The field is absent and the first transmitted Object ID supplies the value.
+    FirstObject,
+    /// The Subgroup ID is carried explicitly in the header.
+    Explicit,
+}
+
+macro_rules! stream_header_types {
+    (
+        Fetch = $fetch_value:literal;
+        $(
+            $name:ident = $value:literal =>
+                ($mode:ident, $properties:literal, $end_of_group:literal,
+                 $default_priority:literal, $first_object:literal)
+        ),+ $(,)?
+    ) => {
+        /// A validated draft-18 stream header type.
+        #[repr(u64)]
+        #[derive(Copy, Debug, Clone, Eq, PartialEq)]
+        pub enum StreamHeaderType {
+            Fetch = $fetch_value,
+            $($name = $value),+
+        }
+
+        impl StreamHeaderType {
+            fn from_value(value: u64) -> Option<Self> {
+                match value {
+                    $fetch_value => Some(Self::Fetch),
+                    $($value => Some(Self::$name),)+
+                    _ => None,
+                }
+            }
+
+            /// Construct a valid draft-18 SUBGROUP_HEADER type from its semantic fields (§11.4.2).
+            pub const fn subgroup(
+                subgroup_id_mode: SubgroupIdMode,
+                has_properties: bool,
+                end_of_group: bool,
+                default_priority: bool,
+                first_object: bool,
+            ) -> Self {
+                match (
+                    subgroup_id_mode,
+                    has_properties,
+                    end_of_group,
+                    default_priority,
+                    first_object,
+                ) {
+                    $(
+                        (
+                            SubgroupIdMode::$mode,
+                            $properties,
+                            $end_of_group,
+                            $default_priority,
+                            $first_object,
+                        ) => Self::$name,
+                    )+
+                }
+            }
+        }
+    };
+}
+
+stream_header_types! {
+    Fetch = 0x05;
+    SubgroupZeroId = 0x10 => (Zero, false, false, false, false),
+    SubgroupZeroIdExt = 0x11 => (Zero, true, false, false, false),
+    SubgroupFirstObjectId = 0x12 => (FirstObject, false, false, false, false),
+    SubgroupFirstObjectIdExt = 0x13 => (FirstObject, true, false, false, false),
+    SubgroupId = 0x14 => (Explicit, false, false, false, false),
+    SubgroupIdExt = 0x15 => (Explicit, true, false, false, false),
+    SubgroupZeroIdEndOfGroup = 0x18 => (Zero, false, true, false, false),
+    SubgroupZeroIdExtEndOfGroup = 0x19 => (Zero, true, true, false, false),
+    SubgroupFirstObjectIdEndOfGroup = 0x1a => (FirstObject, false, true, false, false),
+    SubgroupFirstObjectIdExtEndOfGroup = 0x1b => (FirstObject, true, true, false, false),
+    SubgroupIdEndOfGroup = 0x1c => (Explicit, false, true, false, false),
+    SubgroupIdExtEndOfGroup = 0x1d => (Explicit, true, true, false, false),
+    SubgroupZeroIdDefaultPriority = 0x30 => (Zero, false, false, true, false),
+    SubgroupZeroIdExtDefaultPriority = 0x31 => (Zero, true, false, true, false),
+    SubgroupFirstObjectIdDefaultPriority = 0x32 => (FirstObject, false, false, true, false),
+    SubgroupFirstObjectIdExtDefaultPriority = 0x33 => (FirstObject, true, false, true, false),
+    SubgroupIdDefaultPriority = 0x34 => (Explicit, false, false, true, false),
+    SubgroupIdExtDefaultPriority = 0x35 => (Explicit, true, false, true, false),
+    SubgroupZeroIdEndOfGroupDefaultPriority = 0x38 => (Zero, false, true, true, false),
+    SubgroupZeroIdExtEndOfGroupDefaultPriority = 0x39 => (Zero, true, true, true, false),
+    SubgroupFirstObjectIdEndOfGroupDefaultPriority = 0x3a => (FirstObject, false, true, true, false),
+    SubgroupFirstObjectIdExtEndOfGroupDefaultPriority = 0x3b => (FirstObject, true, true, true, false),
+    SubgroupIdEndOfGroupDefaultPriority = 0x3c => (Explicit, false, true, true, false),
+    SubgroupIdExtEndOfGroupDefaultPriority = 0x3d => (Explicit, true, true, true, false),
+    SubgroupZeroIdFirstObject = 0x50 => (Zero, false, false, false, true),
+    SubgroupZeroIdExtFirstObject = 0x51 => (Zero, true, false, false, true),
+    SubgroupFirstObjectIdFirstObject = 0x52 => (FirstObject, false, false, false, true),
+    SubgroupFirstObjectIdExtFirstObject = 0x53 => (FirstObject, true, false, false, true),
+    SubgroupIdFirstObject = 0x54 => (Explicit, false, false, false, true),
+    SubgroupIdExtFirstObject = 0x55 => (Explicit, true, false, false, true),
+    SubgroupZeroIdEndOfGroupFirstObject = 0x58 => (Zero, false, true, false, true),
+    SubgroupZeroIdExtEndOfGroupFirstObject = 0x59 => (Zero, true, true, false, true),
+    SubgroupFirstObjectIdEndOfGroupFirstObject = 0x5a => (FirstObject, false, true, false, true),
+    SubgroupFirstObjectIdExtEndOfGroupFirstObject = 0x5b => (FirstObject, true, true, false, true),
+    SubgroupIdEndOfGroupFirstObject = 0x5c => (Explicit, false, true, false, true),
+    SubgroupIdExtEndOfGroupFirstObject = 0x5d => (Explicit, true, true, false, true),
+    SubgroupZeroIdDefaultPriorityFirstObject = 0x70 => (Zero, false, false, true, true),
+    SubgroupZeroIdExtDefaultPriorityFirstObject = 0x71 => (Zero, true, false, true, true),
+    SubgroupFirstObjectIdDefaultPriorityFirstObject = 0x72 => (FirstObject, false, false, true, true),
+    SubgroupFirstObjectIdExtDefaultPriorityFirstObject = 0x73 => (FirstObject, true, false, true, true),
+    SubgroupIdDefaultPriorityFirstObject = 0x74 => (Explicit, false, false, true, true),
+    SubgroupIdExtDefaultPriorityFirstObject = 0x75 => (Explicit, true, false, true, true),
+    SubgroupZeroIdEndOfGroupDefaultPriorityFirstObject = 0x78 => (Zero, false, true, true, true),
+    SubgroupZeroIdExtEndOfGroupDefaultPriorityFirstObject = 0x79 => (Zero, true, true, true, true),
+    SubgroupFirstObjectIdEndOfGroupDefaultPriorityFirstObject = 0x7a => (FirstObject, false, true, true, true),
+    SubgroupFirstObjectIdExtEndOfGroupDefaultPriorityFirstObject = 0x7b => (FirstObject, true, true, true, true),
+    SubgroupIdEndOfGroupDefaultPriorityFirstObject = 0x7c => (Explicit, false, true, true, true),
+    SubgroupIdExtEndOfGroupDefaultPriorityFirstObject = 0x7d => (Explicit, true, true, true, true),
 }
 
 impl StreamHeaderType {
+    const PROPERTIES: u64 = 0x01;
+    const SUBGROUP_ID_MODE: u64 = 0x06;
+    const END_OF_GROUP: u64 = 0x08;
+    const DEFAULT_PRIORITY: u64 = 0x20;
+    const FIRST_OBJECT: u64 = 0x40;
+
+    /// Return the stream header's wire value.
+    pub const fn value(self) -> u64 {
+        self as u64
+    }
+
+    /// Returns whether this is a SUBGROUP_HEADER type.
     pub fn is_subgroup(&self) -> bool {
-        let header_type = *self as u64;
-        (0x10..=0x1d).contains(&header_type)
+        *self != Self::Fetch
     }
 
+    /// Returns whether this is a FETCH_HEADER type.
     pub fn is_fetch(&self) -> bool {
-        *self == StreamHeaderType::Fetch
+        *self == Self::Fetch
     }
 
+    /// Returns whether every Object on the stream carries a Properties field.
+    pub fn has_properties(&self) -> bool {
+        self.is_subgroup() && self.value() & Self::PROPERTIES != 0
+    }
+
+    /// Compatibility alias for the properties-bearing Object grammar.
     pub fn has_extension_headers(&self) -> bool {
-        matches!(
-            *self,
-            StreamHeaderType::SubgroupZeroIdExt
-                | StreamHeaderType::SubgroupFirstObjectIdExt
-                | StreamHeaderType::SubgroupIdExt
-                | StreamHeaderType::SubgroupZeroIdExtEndOfGroup
-                | StreamHeaderType::SubgroupFirstObjectIdExtEndOfGroup
-                | StreamHeaderType::SubgroupIdExtEndOfGroup
-                | StreamHeaderType::Fetch
-        )
+        self.is_fetch() || self.has_properties()
     }
 
+    /// Returns the encoded Subgroup ID mode, or `None` for a FETCH header.
+    pub fn subgroup_id_mode(&self) -> Option<SubgroupIdMode> {
+        if !self.is_subgroup() {
+            return None;
+        }
+
+        match self.value() & Self::SUBGROUP_ID_MODE {
+            0x00 => Some(SubgroupIdMode::Zero),
+            0x02 => Some(SubgroupIdMode::FirstObject),
+            0x04 => Some(SubgroupIdMode::Explicit),
+            _ => None,
+        }
+    }
+
+    /// Returns whether the header carries an explicit Subgroup ID field.
     pub fn has_subgroup_id(&self) -> bool {
-        matches!(
-            *self,
-            StreamHeaderType::SubgroupId
-                | StreamHeaderType::SubgroupIdExt
-                | StreamHeaderType::SubgroupIdEndOfGroup
-                | StreamHeaderType::SubgroupIdExtEndOfGroup
-        )
+        self.subgroup_id_mode() == Some(SubgroupIdMode::Explicit)
     }
 
+    /// Returns whether the first transmitted Object ID supplies the Subgroup ID.
     pub fn uses_first_object_id_as_subgroup_id(&self) -> bool {
-        matches!(
-            *self,
-            StreamHeaderType::SubgroupFirstObjectId
-                | StreamHeaderType::SubgroupFirstObjectIdExt
-                | StreamHeaderType::SubgroupFirstObjectIdEndOfGroup
-                | StreamHeaderType::SubgroupFirstObjectIdExtEndOfGroup
-        )
+        self.subgroup_id_mode() == Some(SubgroupIdMode::FirstObject)
+    }
+
+    /// Returns whether FIN identifies the stream's last Object as the Group's largest.
+    pub fn end_of_group(&self) -> bool {
+        self.is_subgroup() && self.value() & Self::END_OF_GROUP != 0
+    }
+
+    /// Returns whether the Publisher Priority field is omitted and inherited.
+    pub fn uses_default_priority(&self) -> bool {
+        self.is_subgroup() && self.value() & Self::DEFAULT_PRIORITY != 0
+    }
+
+    /// Returns whether the stream begins with the first Object published in the Subgroup.
+    pub fn begins_with_first_object(&self) -> bool {
+        self.is_subgroup() && self.value() & Self::FIRST_OBJECT != 0
     }
 }
 
 impl Encode for StreamHeaderType {
     fn encode<W: bytes::BufMut>(&self, w: &mut W) -> Result<(), EncodeError> {
-        let val = *self as u64;
+        let val = self.value();
         tracing::trace!(
             "[ENCODE] StreamHeaderType: encoding {:?} as {:#x}",
             self,
@@ -96,27 +227,14 @@ impl Decode for StreamHeaderType {
             type_value
         );
 
-        let header_type = match type_value {
-            0x10_u64 => Ok(Self::SubgroupZeroId),
-            0x11_u64 => Ok(Self::SubgroupZeroIdExt),
-            0x12_u64 => Ok(Self::SubgroupFirstObjectId),
-            0x13_u64 => Ok(Self::SubgroupFirstObjectIdExt),
-            0x14_u64 => Ok(Self::SubgroupId),
-            0x15_u64 => Ok(Self::SubgroupIdExt),
-            0x18_u64 => Ok(Self::SubgroupZeroIdEndOfGroup),
-            0x19_u64 => Ok(Self::SubgroupZeroIdExtEndOfGroup),
-            0x1a_u64 => Ok(Self::SubgroupFirstObjectIdEndOfGroup),
-            0x1b_u64 => Ok(Self::SubgroupFirstObjectIdExtEndOfGroup),
-            0x1c_u64 => Ok(Self::SubgroupIdEndOfGroup),
-            0x1d_u64 => Ok(Self::SubgroupIdExtEndOfGroup),
-            0x05_u64 => Ok(Self::Fetch),
-            _ => {
-                tracing::error!(
-                    "[DECODE] StreamHeaderType: INVALID type value={:#x}",
-                    type_value
-                );
-                Err(DecodeError::InvalidHeaderType)
-            }
+        let header_type = if let Some(header_type) = Self::from_value(type_value) {
+            Ok(header_type)
+        } else {
+            tracing::error!(
+                "[DECODE] StreamHeaderType: INVALID type value={:#x}",
+                type_value
+            );
+            Err(DecodeError::InvalidHeaderType)
         };
 
         if let Ok(header_type_inner) = &header_type {
@@ -134,7 +252,7 @@ impl Decode for StreamHeaderType {
 
 impl fmt::Display for StreamHeaderType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?} ({:#x})", self, *self as u64)
+        write!(f, "{:?} ({:#x})", self, self.value())
     }
 }
 
@@ -282,6 +400,65 @@ mod tests {
         let mut buf: Bytes = data.into();
         let result = StreamHeaderType::decode(&mut buf);
         assert!(matches!(result, Err(DecodeError::InvalidHeaderType)));
+    }
+
+    #[test]
+    fn decodes_every_valid_draft_18_subgroup_header_type() {
+        for first_object in [false, true] {
+            for default_priority in [false, true] {
+                for end_of_group in [false, true] {
+                    for has_properties in [false, true] {
+                        for subgroup_id_mode in [
+                            SubgroupIdMode::Zero,
+                            SubgroupIdMode::FirstObject,
+                            SubgroupIdMode::Explicit,
+                        ] {
+                            let expected = StreamHeaderType::subgroup(
+                                subgroup_id_mode,
+                                has_properties,
+                                end_of_group,
+                                default_priority,
+                                first_object,
+                            );
+                            let mut buf = BytesMut::new();
+                            expected.encode(&mut buf).unwrap();
+                            let actual = StreamHeaderType::decode(&mut buf).unwrap();
+
+                            assert_eq!(actual, expected);
+                            assert_eq!(actual.subgroup_id_mode(), Some(subgroup_id_mode));
+                            assert_eq!(actual.has_properties(), has_properties);
+                            assert_eq!(actual.end_of_group(), end_of_group);
+                            assert_eq!(actual.uses_default_priority(), default_priority);
+                            assert_eq!(actual.begins_with_first_object(), first_object);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn rejects_reserved_and_out_of_form_subgroup_header_types() {
+        for value in 0_u64..=0x7f {
+            let mut buf = BytesMut::new();
+            value.encode(&mut buf).unwrap();
+            let valid = value == StreamHeaderType::Fetch.value()
+                || value & 0x10 != 0 && value & 0x06 != 0x06;
+            assert_eq!(
+                StreamHeaderType::decode(&mut buf).is_ok(),
+                valid,
+                "{value:#x}"
+            );
+        }
+
+        for value in [0x80_u64, 0x90, u64::MAX] {
+            let mut buf = BytesMut::new();
+            value.encode(&mut buf).unwrap();
+            assert!(matches!(
+                StreamHeaderType::decode(&mut buf),
+                Err(DecodeError::InvalidHeaderType)
+            ));
+        }
     }
 
     #[test]

--- a/moq-transport/src/data/subgroup.rs
+++ b/moq-transport/src/data/subgroup.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::coding::{Decode, DecodeError, Encode, EncodeError};
-use crate::data::{ExtensionHeaders, ObjectStatus, StreamHeaderType};
+use crate::data::{ExtensionHeaders, ObjectStatus, StreamHeaderType, DEFAULT_PUBLISHER_PRIORITY};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, thiserror::Error)]
 pub(crate) enum ObjectIdDeltaError {
@@ -96,7 +96,11 @@ impl SubgroupHeader {
             }
         };
 
-        let publisher_priority = u8::decode(r)?;
+        let publisher_priority = if header_type.uses_default_priority() {
+            DEFAULT_PUBLISHER_PRIORITY
+        } else {
+            u8::decode(r)?
+        };
         tracing::trace!(
             "[DECODE] SubgroupHeader: publisher_priority={}, buffer_remaining={} bytes",
             publisher_priority,
@@ -169,11 +173,13 @@ impl Encode for SubgroupHeader {
             tracing::trace!("[ENCODE] SubgroupHeader: subgroup_id not encoded (not required for this header type)");
         }
 
-        self.publisher_priority.encode(w)?;
-        tracing::trace!(
-            "[ENCODE] SubgroupHeader: encoded publisher_priority={}",
-            self.publisher_priority
-        );
+        if !self.header_type.uses_default_priority() {
+            self.publisher_priority.encode(w)?;
+            tracing::trace!(
+                "[ENCODE] SubgroupHeader: encoded publisher_priority={}",
+                self.publisher_priority
+            );
+        }
 
         let bytes_written = start_pos - w.remaining_mut();
         tracing::trace!(
@@ -408,6 +414,7 @@ impl Encode for SubgroupObjectExt {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::data::{StreamHeader, SubgroupIdMode};
     use bytes::Bytes;
     use bytes::BytesMut;
 
@@ -423,6 +430,64 @@ mod tests {
             let decoded =
                 deltas.map(|delta| decode_object_id_delta(&mut decode_previous, delta).unwrap());
             assert_eq!(decoded, object_ids);
+        }
+    }
+
+    #[test]
+    fn type_78_omits_priority_without_consuming_the_first_object() {
+        let header = SubgroupHeader {
+            header_type: StreamHeaderType::subgroup(SubgroupIdMode::Zero, false, true, true, true),
+            track_alias: 0,
+            group_id: 0,
+            subgroup_id: None,
+            publisher_priority: 200,
+        };
+        let mut encoded = BytesMut::new();
+        header.encode(&mut encoded).unwrap();
+        assert_eq!(encoded.as_ref(), &[0x78, 0x00, 0x00]);
+        encoded.extend_from_slice(&[0x00, 0x01, b'x']);
+
+        let mut encoded = encoded.freeze();
+        let decoded = StreamHeader::decode(&mut encoded)
+            .unwrap()
+            .subgroup_header
+            .unwrap();
+        assert_eq!(decoded.header_type.value(), 0x78);
+        assert_eq!(decoded.publisher_priority, 128);
+        assert_eq!(encoded.as_ref(), &[0x00, 0x01, b'x']);
+
+        let object = SubgroupObject::decode(&mut encoded).unwrap();
+        assert_eq!(object.object_id_delta, 0);
+        assert_eq!(object.payload_length, 1);
+        assert_eq!(encoded.as_ref(), b"x");
+    }
+
+    #[test]
+    fn subgroup_id_modes_consume_only_their_declared_fields() {
+        for (mode, subgroup_id, expected_id) in [
+            (SubgroupIdMode::Zero, None, None),
+            (SubgroupIdMode::FirstObject, None, None),
+            (SubgroupIdMode::Explicit, Some(9), Some(9)),
+        ] {
+            let header = SubgroupHeader {
+                header_type: StreamHeaderType::subgroup(mode, false, false, true, false),
+                track_alias: 7,
+                group_id: 8,
+                subgroup_id,
+                publisher_priority: 200,
+            };
+            let mut encoded = BytesMut::new();
+            header.encode(&mut encoded).unwrap();
+            encoded.extend_from_slice(&[0x0b, 0x01, b'x']);
+
+            let mut encoded = encoded.freeze();
+            let decoded = StreamHeader::decode(&mut encoded)
+                .unwrap()
+                .subgroup_header
+                .unwrap();
+            assert_eq!(decoded.subgroup_id, expected_id);
+            assert_eq!(decoded.publisher_priority, 128);
+            assert_eq!(encoded.as_ref(), &[0x0b, 0x01, b'x']);
         }
     }
 

--- a/moq-transport/src/message/params.rs
+++ b/moq-transport/src/message/params.rs
@@ -94,6 +94,12 @@ impl TrackExtensions {
         self.0.is_empty()
     }
 
+    pub(crate) fn contains_only(&self, supported_types: &[u64]) -> bool {
+        self.0
+            .iter()
+            .all(|extension| supported_types.contains(&extension.key))
+    }
+
     pub fn delivery_timeout(&self) -> Result<Option<u64>, DecodeError> {
         get_kvp_int(&self.0, extension_type::DELIVERY_TIMEOUT)
     }
@@ -501,5 +507,17 @@ mod tests {
             extensions.set_default_publisher_group_order(GroupOrder::Publisher),
             Err(EncodeError::InvalidValue)
         ));
+    }
+
+    #[test]
+    fn track_extensions_contains_only_supported_types() {
+        let mut extensions = TrackExtensions::default();
+        let supported = [extension_type::DEFAULT_PUBLISHER_PRIORITY];
+
+        assert!(extensions.contains_only(&supported));
+        extensions.set_default_publisher_priority(30);
+        assert!(extensions.contains_only(&supported));
+        extensions.set_delivery_timeout(10);
+        assert!(!extensions.contains_only(&supported));
     }
 }

--- a/moq-transport/src/mlog/events.rs
+++ b/moq-transport/src/mlog/events.rs
@@ -549,9 +549,14 @@ pub fn go_away_created(time: f64, stream_id: u64, msg: &message::GoAway) -> Even
 fn subgroup_header_to_json(header: &data::SubgroupHeader) -> JsonValue {
     let mut json = json!({
         "header_type": format!("{:?}", header.header_type),
+        "header_type_value": header.header_type.value(),
         "track_alias": header.track_alias,
         "group_id": header.group_id,
         "publisher_priority": header.publisher_priority,
+        "has_properties": header.header_type.has_properties(),
+        "end_of_group": header.header_type.end_of_group(),
+        "default_priority": header.header_type.uses_default_priority(),
+        "first_object": header.header_type.begins_with_first_object(),
     });
 
     if let Some(subgroup_id) = header.subgroup_id {
@@ -806,7 +811,10 @@ pub fn loglevel_event(time: f64, level: LogLevel, message: String) -> Event {
 mod tests {
     use super::*;
     use crate::coding::{KeyValuePairs, TrackNamespacePrefix};
-    use crate::message::{SubscribeNamespace, SubscribeOptions};
+    use crate::{
+        data::{StreamHeaderType, SubgroupHeader, SubgroupIdMode},
+        message::{SubscribeNamespace, SubscribeOptions},
+    };
 
     #[test]
     fn subscribe_namespace_event_includes_prefix_and_options() {
@@ -830,5 +838,34 @@ mod tests {
             "/example.com/meeting"
         );
         assert_eq!(data.message["subscribe_options"], "Both");
+    }
+
+    #[test]
+    fn subgroup_header_event_preserves_legacy_name_and_exposes_modifiers() {
+        let legacy = subgroup_header_to_json(&SubgroupHeader {
+            header_type: StreamHeaderType::SubgroupIdExt,
+            track_alias: 1,
+            group_id: 2,
+            subgroup_id: Some(3),
+            publisher_priority: 4,
+        });
+        assert_eq!(legacy["header_type"], "SubgroupIdExt");
+        assert_eq!(legacy["header_type_value"], 0x15);
+
+        let modified = subgroup_header_to_json(&SubgroupHeader {
+            header_type: StreamHeaderType::subgroup(SubgroupIdMode::Zero, false, true, true, true),
+            track_alias: 1,
+            group_id: 2,
+            subgroup_id: None,
+            publisher_priority: 200,
+        });
+        assert_eq!(
+            modified["header_type"],
+            "SubgroupZeroIdEndOfGroupDefaultPriorityFirstObject"
+        );
+        assert_eq!(modified["header_type_value"], 0x78);
+        assert_eq!(modified["end_of_group"], true);
+        assert_eq!(modified["default_priority"], true);
+        assert_eq!(modified["first_object"], true);
     }
 }

--- a/moq-transport/src/serve/subgroup.rs
+++ b/moq-transport/src/serve/subgroup.rs
@@ -103,13 +103,21 @@ impl SubgroupsWriter {
 
     /// Create a new subgroup with the given parameters, inserting it into the track.
     pub fn create(&mut self, subgroup: Subgroup) -> Result<SubgroupWriter, ServeError> {
+        self.create_with_metadata(subgroup, SubgroupStreamMetadata::default())
+    }
+
+    pub(crate) fn create_with_metadata(
+        &mut self,
+        subgroup: Subgroup,
+        metadata: SubgroupStreamMetadata,
+    ) -> Result<SubgroupWriter, ServeError> {
         let subgroup = SubgroupInfo {
             track: self.info.clone(),
             group_id: subgroup.group_id,
             subgroup_id: subgroup.subgroup_id,
             priority: subgroup.priority,
         };
-        let (writer, reader) = subgroup.produce();
+        let (writer, reader) = subgroup.produce_with_metadata(metadata);
 
         let mut state = self.state.lock_mut().ok_or(ServeError::Cancel)?;
 
@@ -252,7 +260,14 @@ pub struct SubgroupInfo {
 
 impl SubgroupInfo {
     pub fn produce(self) -> (SubgroupWriter, SubgroupReader) {
-        let (writer, reader) = State::default().split();
+        self.produce_with_metadata(SubgroupStreamMetadata::default())
+    }
+
+    pub(crate) fn produce_with_metadata(
+        self,
+        metadata: SubgroupStreamMetadata,
+    ) -> (SubgroupWriter, SubgroupReader) {
+        let (writer, reader) = State::new(SubgroupState::new(metadata)).split();
         let info = Arc::new(self);
 
         let writer = SubgroupWriter::new(writer, info.clone());
@@ -270,18 +285,42 @@ impl Deref for SubgroupInfo {
     }
 }
 
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(crate) struct SubgroupStreamMetadata {
+    pub has_properties: bool,
+    pub end_of_group: bool,
+    pub first_object: bool,
+}
+
+impl Default for SubgroupStreamMetadata {
+    fn default() -> Self {
+        Self {
+            // Existing application-created subgroups have always used the
+            // properties-capable wire grammar.
+            has_properties: true,
+            end_of_group: false,
+            // A locally created stream begins with the first Object published
+            // in its subgroup. Relay receive paths supply explicit metadata.
+            first_object: true,
+        }
+    }
+}
+
 struct SubgroupState {
     // The data that has been received thus far.
     objects: Vec<SubgroupObjectReader>,
+
+    metadata: SubgroupStreamMetadata,
 
     // Set when the writer or all readers are dropped.
     closed: Result<(), ServeError>,
 }
 
-impl Default for SubgroupState {
-    fn default() -> Self {
+impl SubgroupState {
+    fn new(metadata: SubgroupStreamMetadata) -> Self {
         Self {
             objects: Vec::new(),
+            metadata,
             closed: Ok(()),
         }
     }
@@ -408,6 +447,10 @@ impl SubgroupReader {
     pub fn latest(&self) -> Option<u64> {
         let state = self.state.lock();
         state.objects.last().map(|o| o.object_id)
+    }
+
+    pub(crate) fn metadata(&self) -> SubgroupStreamMetadata {
+        self.state.lock().metadata
     }
 
     pub async fn read_next(&mut self) -> Result<Option<Bytes>, ServeError> {
@@ -661,6 +704,12 @@ mod tests {
             priority: 128,
         }
         .produce()
+    }
+
+    #[test]
+    fn locally_created_subgroup_begins_with_first_object() {
+        let (_writer, reader) = subgroup();
+        assert!(reader.metadata().first_object);
     }
 
     #[tokio::test]

--- a/moq-transport/src/session/mod.rs
+++ b/moq-transport/src/session/mod.rs
@@ -495,6 +495,7 @@ impl Session {
         let subscriber = Some(Subscriber::new(
             outgoing.0,
             webtransport.clone(),
+            transport,
             mlog_shared.clone(),
             request_id.clone(),
             bidi_task_tx,
@@ -726,6 +727,7 @@ impl Session {
     /// inbound control messages, receiving and processing new inbound uni-directional QUIC streams,
     /// and receiving and processing QUIC datagrams received
     pub async fn run(self) -> Result<(), SessionError> {
+        let close_session = self.webtransport.clone();
         let mut bidi_task_rx = self.bidi_task_rx;
         let mut reader_tasks: FuturesUnordered<BidiReaderFuture> = FuturesUnordered::new();
 
@@ -768,6 +770,15 @@ impl Session {
         // in-flight reader future, cancelling them — no task abort needed since
         // nothing was ever spawned onto the runtime.
         drop(reader_tasks);
+
+        if let Err(err) = &result {
+            if err.is_session_fatal() {
+                close_session.close(
+                    u32::try_from(err.code()).unwrap_or(0x1),
+                    "session protocol error",
+                );
+            }
+        }
 
         result
     }
@@ -1609,6 +1620,80 @@ pub(crate) mod test_support {
         (client, server)
     }
 
+    pub(crate) async fn loopback_raw_session_pair(
+    ) -> (web_transport::Session, web_transport::Session) {
+        use std::sync::Arc;
+        use web_transport::quinn::quinn;
+
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+        let cert = rcgen::generate_simple_self_signed(vec!["localhost".to_string()])
+            .expect("generate self-signed certificate");
+        let cert_der = cert.cert.der().clone();
+        let key = cert
+            .key_pair
+            .serialize_der()
+            .try_into()
+            .expect("serialize private key");
+
+        let mut server_crypto = rustls::ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(vec![cert_der.clone()], key)
+            .expect("configure raw QUIC server certificate");
+        server_crypto.alpn_protocols = vec![b"moqt-18".to_vec()];
+        let server_crypto = quinn::crypto::rustls::QuicServerConfig::try_from(server_crypto)
+            .expect("configure raw QUIC server crypto");
+        let server = quinn::Endpoint::server(
+            quinn::ServerConfig::with_crypto(Arc::new(server_crypto)),
+            "127.0.0.1:0".parse().expect("server addr"),
+        )
+        .expect("build raw QUIC server");
+        let addr = server.local_addr().expect("raw QUIC server addr");
+
+        let mut roots = rustls::RootCertStore::empty();
+        roots.add(cert_der).expect("trust raw QUIC server cert");
+        let mut client_crypto = rustls::ClientConfig::builder()
+            .with_root_certificates(roots)
+            .with_no_client_auth();
+        client_crypto.alpn_protocols = vec![b"moqt-18".to_vec()];
+        let client_crypto = quinn::crypto::rustls::QuicClientConfig::try_from(client_crypto)
+            .expect("configure raw QUIC client crypto");
+        let mut client =
+            quinn::Endpoint::client("127.0.0.1:0".parse().expect("raw QUIC client addr"))
+                .expect("build raw QUIC client");
+        client.set_default_client_config(quinn::ClientConfig::new(Arc::new(client_crypto)));
+
+        let accept = tokio::spawn(async move {
+            server
+                .accept()
+                .await
+                .expect("accept raw QUIC connection")
+                .await
+                .expect("establish raw QUIC server connection")
+        });
+        let client = client
+            .connect(addr, "localhost")
+            .expect("start raw QUIC connection")
+            .await
+            .expect("establish raw QUIC client connection");
+        let server = accept.await.expect("join raw QUIC accept task");
+        let url = url::Url::parse(&format!("moqt://localhost:{}/", addr.port()))
+            .expect("parse raw QUIC URL");
+
+        let client = web_transport::quinn::Session::raw(
+            client,
+            url.clone(),
+            web_transport::quinn::proto::ConnectResponse::default(),
+        )
+        .into();
+        let server = web_transport::quinn::Session::raw(
+            server,
+            url,
+            web_transport::quinn::proto::ConnectResponse::default(),
+        )
+        .into();
+        (client, server)
+    }
+
     /// Establish a real `web_transport::Session` over an in-process QUIC
     /// loopback so tests can construct a `Publisher`/`Subscriber` and exercise
     /// the real cleanup paths.
@@ -1862,5 +1947,74 @@ mod tests {
             !bytes.contains(&88),
             "Request ID must not appear in bidi encoding"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn malformed_uni_header_closes_session_with_protocol_violation() {
+        let (client_transport, server_transport) = test_support::loopback_session_pair().await;
+        let client_peer = client_transport.clone();
+        let client_close = client_transport.clone();
+        let (client, server) = tokio::join!(
+            Session::connect(client_transport, None, Transport::WebTransport),
+            Session::accept(server_transport, None, Transport::WebTransport),
+        );
+        let (client_session, _client_publisher, _client_subscriber) = client.unwrap();
+        let (server_session, _server_publisher, _server_subscriber) = server.unwrap();
+
+        let send_invalid = async move {
+            let mut stream = client_peer.open_uni().await.unwrap();
+            stream.write(&[0x16]).await.unwrap();
+            client_close.closed().await
+        };
+        let (run_result, close_error) = tokio::join!(server_session.run(), send_invalid);
+
+        assert!(matches!(
+            run_result,
+            Err(SessionError::Decode(
+                crate::coding::DecodeError::InvalidHeaderType
+            ))
+        ));
+        assert!(matches!(
+            close_error,
+            web_transport::Error::Session(web_transport::quinn::SessionError::WebTransportError(
+                web_transport::quinn::WebTransportError::Closed(0x3, _)
+            ))
+        ));
+        drop(client_session);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn malformed_raw_quic_uni_header_closes_with_protocol_violation() {
+        let (client_transport, server_transport) = test_support::loopback_raw_session_pair().await;
+        let client_peer = client_transport.clone();
+        let client_close = client_transport.clone();
+        let (client, server) = tokio::join!(
+            Session::connect(client_transport, None, Transport::RawQuic),
+            Session::accept(server_transport, None, Transport::RawQuic),
+        );
+        let (client_session, _client_publisher, _client_subscriber) = client.unwrap();
+        let (server_session, _server_publisher, _server_subscriber) = server.unwrap();
+
+        let send_invalid = async move {
+            let mut stream = client_peer.open_uni().await.unwrap();
+            stream.write(&[0x16]).await.unwrap();
+            client_close.closed().await
+        };
+        let (run_result, close_error) = tokio::join!(server_session.run(), send_invalid);
+
+        assert!(matches!(
+            run_result,
+            Err(SessionError::Decode(
+                crate::coding::DecodeError::InvalidHeaderType
+            ))
+        ));
+        let web_transport::Error::Session(web_transport::quinn::SessionError::ConnectionError(
+            web_transport::quinn::quinn::ConnectionError::ApplicationClosed(close),
+        )) = close_error
+        else {
+            panic!("expected raw QUIC application close, got {close_error:?}");
+        };
+        assert_eq!(close.error_code.into_inner(), 0x3);
+        drop(client_session);
     }
 }

--- a/moq-transport/src/session/publish_received.rs
+++ b/moq-transport/src/session/publish_received.rs
@@ -256,6 +256,8 @@ pub(crate) struct PublishReceivedRecv {
     /// Objects without going through the application.
     writer: Option<TrackWriterMode>,
 
+    pub(super) default_publisher_priority: u8,
+
     /// PUBLISH_DONE Stream Count accounting (§10.11).
     drain: StreamDrain<u64>,
 }
@@ -272,6 +274,7 @@ impl PublishReceivedRecv {
         name: TrackName,
         initial_forward: bool,
         largest_location: Option<Location>,
+        default_publisher_priority: u8,
         writer: serve::TrackWriter,
         reader: TrackReader,
     ) -> (PublishReceived, PublishReceivedRecv) {
@@ -291,6 +294,7 @@ impl PublishReceivedRecv {
         let recv = Self {
             state: transport_state,
             writer: Some(writer.into()),
+            default_publisher_priority,
             drain: StreamDrain::default(),
         };
 
@@ -319,11 +323,23 @@ impl PublishReceivedRecv {
             }
         };
 
-        let subgroup_writer = match subgroups.create(serve::Subgroup {
-            group_id: header.group_id,
-            subgroup_id: header.subgroup_id.unwrap_or(0),
-            priority: header.publisher_priority,
-        }) {
+        let priority = if header.header_type.uses_default_priority() {
+            self.default_publisher_priority
+        } else {
+            header.publisher_priority
+        };
+        let subgroup_writer = match subgroups.create_with_metadata(
+            serve::Subgroup {
+                group_id: header.group_id,
+                subgroup_id: header.subgroup_id.unwrap_or(0),
+                priority,
+            },
+            serve::SubgroupStreamMetadata {
+                has_properties: header.header_type.has_properties(),
+                end_of_group: header.header_type.end_of_group(),
+                first_object: header.header_type.begins_with_first_object(),
+            },
+        ) {
             Ok(writer) => writer,
             Err(err) => {
                 // Put the writer back: one rejected subgroup must not strand
@@ -522,6 +538,7 @@ mod tests {
         let subscriber = crate::session::Subscriber::new(
             outgoing.clone(),
             loopback_session().await,
+            crate::session::Transport::WebTransport,
             None,
             RequestId::new(0, 1),
             bidi_task_tx,
@@ -536,6 +553,7 @@ mod tests {
             "0.mp4".into(),
             true,
             None,
+            128,
             writer,
             reader,
         );

--- a/moq-transport/src/session/subscribe.rs
+++ b/moq-transport/src/session/subscribe.rs
@@ -222,6 +222,7 @@ impl Subscribe {
         let recv = SubscribeRecv {
             state: recv,
             writer: Some(track.into()),
+            default_publisher_priority: data::DEFAULT_PUBLISHER_PRIORITY,
             drain: StreamDrain::default(),
         };
 
@@ -282,12 +283,13 @@ impl ops::Deref for Subscribe {
 pub(super) struct SubscribeRecv {
     state: State<SubscribeState>,
     writer: Option<TrackWriterMode>,
+    pub(super) default_publisher_priority: u8,
     /// PUBLISH_DONE Stream Count accounting (draft-18 §10.11).
     drain: StreamDrain<ServeError>,
 }
 
 impl SubscribeRecv {
-    pub fn ok(&mut self, alias: u64) -> Result<(), ServeError> {
+    pub fn ok(&mut self, alias: u64, default_publisher_priority: u8) -> Result<(), ServeError> {
         let state = self.state.lock();
         if state.ok {
             return Err(ServeError::Duplicate);
@@ -297,6 +299,7 @@ impl SubscribeRecv {
             state.ok = true;
             state.track_alias = Some(alias);
         }
+        self.default_publisher_priority = default_publisher_priority;
 
         Ok(())
     }
@@ -426,12 +429,24 @@ impl SubscribeRecv {
             }
         };
 
-        let writer = match subgroups.create(serve::Subgroup {
-            group_id: header.group_id,
-            // When subgroup_id is not present in the header type, it implicitly means subgroup 0
-            subgroup_id: header.subgroup_id.unwrap_or(0),
-            priority: header.publisher_priority,
-        }) {
+        let priority = if header.header_type.uses_default_priority() {
+            self.default_publisher_priority
+        } else {
+            header.publisher_priority
+        };
+        let writer = match subgroups.create_with_metadata(
+            serve::Subgroup {
+                group_id: header.group_id,
+                // When subgroup_id is not present in the header type, it implicitly means subgroup 0
+                subgroup_id: header.subgroup_id.unwrap_or(0),
+                priority,
+            },
+            serve::SubgroupStreamMetadata {
+                has_properties: header.header_type.has_properties(),
+                end_of_group: header.header_type.end_of_group(),
+                first_object: header.header_type.begins_with_first_object(),
+            },
+        ) {
             Ok(writer) => writer,
             Err(err) => {
                 self.writer = Some(subgroups.into());
@@ -500,6 +515,7 @@ mod tests {
         let subscriber = crate::session::Subscriber::new(
             crate::watch::Queue::default(),
             crate::session::test_support::loopback_session().await,
+            crate::session::Transport::WebTransport,
             None,
             crate::session::RequestId::new(0, 1),
             bidi_task_tx,

--- a/moq-transport/src/session/subscribe_namespace.rs
+++ b/moq-transport/src/session/subscribe_namespace.rs
@@ -439,6 +439,7 @@ mod tests {
         Subscriber::new(
             Queue::default(),
             loopback_session().await,
+            crate::session::Transport::WebTransport,
             None,
             RequestId::new(0, 1),
             bidi_task_tx,

--- a/moq-transport/src/session/subscribed.rs
+++ b/moq-transport/src/session/subscribed.rs
@@ -102,6 +102,52 @@ pub(super) struct ObjectForwarder {
     mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
 }
 
+struct ResetOnDropWriter {
+    writer: Writer,
+    closed: bool,
+}
+
+impl ResetOnDropWriter {
+    fn new(writer: Writer) -> Self {
+        Self {
+            writer,
+            closed: false,
+        }
+    }
+
+    fn finish(&mut self) -> Result<(), SessionError> {
+        self.closed = true;
+        self.writer.finish()
+    }
+
+    fn reset(&mut self, code: u32) {
+        self.writer.reset(code);
+        self.closed = true;
+    }
+}
+
+impl std::ops::Deref for ResetOnDropWriter {
+    type Target = Writer;
+
+    fn deref(&self) -> &Self::Target {
+        &self.writer
+    }
+}
+
+impl std::ops::DerefMut for ResetOnDropWriter {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.writer
+    }
+}
+
+impl Drop for ResetOnDropWriter {
+    fn drop(&mut self) {
+        if !self.closed {
+            self.writer.reset(0);
+        }
+    }
+}
+
 impl ObjectForwarder {
     pub(super) fn new(
         publisher: Publisher,
@@ -443,21 +489,14 @@ impl ObjectForwarder {
             tokio::select! {
                 res = subgroups.next(), if done.is_none() => match res {
                     Ok(Some(subgroup)) => {
-                        let header = data::SubgroupHeader {
-                            header_type: data::StreamHeaderType::SubgroupIdExt,  // SubGroupId = Yes, Extensions = Yes, ContainsEndOfGroup = No
-                            track_alias: self.track_alias,
-                            group_id: subgroup.group_id,
-                            subgroup_id: Some(subgroup.subgroup_id),
-                            publisher_priority: subgroup.priority,
-                        };
-
                         let publisher = self.publisher.clone();
                         let state = self.state.clone();
                         let info = subgroup.info.clone();
                         let mlog = self.mlog.clone();
+                        let track_alias = self.track_alias;
 
                         tasks.push(async move {
-                            let res = Self::serve_subgroup(header, subgroup, publisher, state, mlog, delivery_filter).await;
+                            let res = Self::serve_subgroup(track_alias, subgroup, publisher, state, mlog, delivery_filter).await;
                             if let Err(err) = &res {
                                 if Subscribed::is_expected_serve_shutdown(err) {
                                     tracing::debug!(subgroup_info = ?info, error = %err, "stopped serving subgroup");
@@ -471,7 +510,7 @@ impl ObjectForwarder {
                     Ok(None) => done = Some(Ok(())),
                     Err(err) => done = Some(Err(err)),
                 },
-                res = self.closed(), if done.is_none() => done = Some(res),
+                res = self.closed(), if done.is_none() || !tasks.is_empty() => return res.map_err(Into::into),
                 res = tasks.next(), if !tasks.is_empty() => {
                     // Remaining subgroups still get their chance to send; the
                     // first local failure is reported once they settle.
@@ -499,7 +538,7 @@ impl ObjectForwarder {
     }
 
     async fn serve_subgroup(
-        header: data::SubgroupHeader,
+        track_alias: u64,
         mut subgroup_reader: serve::SubgroupReader,
         mut publisher: Publisher,
         state: State<ObjectForwarderState>,
@@ -513,32 +552,62 @@ impl ObjectForwarder {
             subgroup_reader.priority
         );
 
-        let mut writer: Option<Writer> = None;
+        let mut writer: Option<ResetOnDropWriter> = None;
         let mut object_count = 0;
         let mut previous_object_id = None;
-        while let Some(mut subgroup_object_reader) = subgroup_reader.next().await? {
+        let mut filtered_prefix = false;
+        let metadata = subgroup_reader.metadata();
+        loop {
+            let mut subgroup_object_reader = match subgroup_reader.next().await {
+                Ok(Some(object)) => object,
+                Ok(None) => break,
+                Err(err) => {
+                    if let Some(writer) = writer.as_mut() {
+                        writer.reset(0);
+                    }
+                    return Err(err.into());
+                }
+            };
             if !delivery_filter.allows(subgroup_reader.group_id, subgroup_object_reader.object_id) {
                 tracing::trace!(
                     "[PUBLISHER] serve_subgroup: filtered object group_id={}, object_id={}",
                     subgroup_reader.group_id,
                     subgroup_object_reader.object_id
                 );
+                filtered_prefix = true;
                 continue;
             }
 
             if writer.is_none() {
+                let header = data::SubgroupHeader {
+                    header_type: data::StreamHeaderType::subgroup(
+                        data::SubgroupIdMode::Explicit,
+                        metadata.has_properties,
+                        metadata.end_of_group,
+                        false,
+                        metadata.first_object && !filtered_prefix,
+                    ),
+                    track_alias,
+                    group_id: subgroup_reader.group_id,
+                    subgroup_id: Some(subgroup_reader.subgroup_id),
+                    publisher_priority: subgroup_reader.priority,
+                };
                 let mut send_stream = publisher.open_uni().await?;
                 tracing::trace!("[PUBLISHER] serve_subgroup: opened unidirectional stream");
 
-                state
-                    .lock_mut()
-                    .ok_or(ServeError::Done)?
-                    .record_stream_opened();
-
                 // TODO figure out u32 vs u64 priority
                 send_stream.set_priority(subgroup_reader.priority as i32);
+                let mut new_writer = ResetOnDropWriter::new(Writer::new(send_stream));
 
-                let mut new_writer = Writer::new(send_stream);
+                {
+                    let locked = state.lock();
+                    let closed = locked.closed.clone();
+                    locked
+                        .into_mut()
+                        .ok_or(ServeError::Done)?
+                        .record_stream_opened();
+                    closed?;
+                }
 
                 tracing::trace!(
                     "[PUBLISHER] serve_subgroup: sending header - track_alias={}, group_id={}, subgroup_id={:?}, priority={}, header_type={:?}",
@@ -570,44 +639,75 @@ impl ObjectForwarder {
                 subgroup_object_reader.object_id,
             )
             .map_err(|err| SessionError::Serve(ServeError::internal_ctx(err.to_string())))?;
-            let subgroup_object = data::SubgroupObjectExt {
-                object_id_delta,
-                extension_headers: subgroup_object_reader.extension_headers.clone(), // Pass through extension headers
-                payload_length: subgroup_object_reader.size,
-                status: if subgroup_object_reader.size == 0 {
-                    // Only set status if payload length is zero
-                    Some(subgroup_object_reader.status)
-                } else {
-                    None
-                },
+            let status = if subgroup_object_reader.size == 0 {
+                Some(subgroup_object_reader.status)
+            } else {
+                None
             };
 
             tracing::trace!(
                 "[PUBLISHER] serve_subgroup: sending object #{} - object_id={}, object_id_delta={}, payload_length={}, status={:?}, extension_headers={:?}",
                 object_count + 1,
                 subgroup_object_reader.object_id,
-                subgroup_object.object_id_delta,
-                subgroup_object.payload_length,
-                subgroup_object.status,
-                subgroup_object.extension_headers
+                object_id_delta,
+                subgroup_object_reader.size,
+                status,
+                subgroup_object_reader.extension_headers
             );
 
-            writer.encode(&subgroup_object).await?;
+            if metadata.has_properties {
+                let subgroup_object = data::SubgroupObjectExt {
+                    object_id_delta,
+                    extension_headers: subgroup_object_reader.extension_headers.clone(),
+                    payload_length: subgroup_object_reader.size,
+                    status,
+                };
+                writer.encode(&subgroup_object).await?;
 
-            // Log subgroup object created/sent
-            if let Some(ref mlog) = mlog {
-                if let Ok(mut mlog_guard) = mlog.lock() {
-                    let time = mlog_guard.elapsed_ms();
-                    let stream_id = 0; // TODO: Placeholder, need actual QUIC stream ID
-                    let event = mlog::subgroup_object_ext_created(
-                        time,
-                        stream_id,
-                        subgroup_reader.group_id,
-                        subgroup_reader.subgroup_id,
-                        subgroup_object_reader.object_id,
-                        &subgroup_object,
-                    );
-                    let _ = mlog_guard.add_event(event);
+                if let Some(ref mlog) = mlog {
+                    if let Ok(mut mlog_guard) = mlog.lock() {
+                        let time = mlog_guard.elapsed_ms();
+                        let stream_id = 0; // TODO: Placeholder, need actual QUIC stream ID
+                        let event = mlog::subgroup_object_ext_created(
+                            time,
+                            stream_id,
+                            subgroup_reader.group_id,
+                            subgroup_reader.subgroup_id,
+                            subgroup_object_reader.object_id,
+                            &subgroup_object,
+                        );
+                        let _ = mlog_guard.add_event(event);
+                    }
+                }
+            } else {
+                if !subgroup_object_reader.extension_headers.is_empty() {
+                    writer.reset(0);
+                    return Err(ServeError::internal_ctx(
+                        "subgroup Object has properties without the PROPERTIES header bit",
+                    )
+                    .into());
+                }
+                let subgroup_object = data::SubgroupObject {
+                    object_id_delta,
+                    payload_length: subgroup_object_reader.size,
+                    status,
+                };
+                writer.encode(&subgroup_object).await?;
+
+                if let Some(ref mlog) = mlog {
+                    if let Ok(mut mlog_guard) = mlog.lock() {
+                        let time = mlog_guard.elapsed_ms();
+                        let stream_id = 0; // TODO: Placeholder, need actual QUIC stream ID
+                        let event = mlog::subgroup_object_created(
+                            time,
+                            stream_id,
+                            subgroup_reader.group_id,
+                            subgroup_reader.subgroup_id,
+                            subgroup_object_reader.object_id,
+                            &subgroup_object,
+                        );
+                        let _ = mlog_guard.add_event(event);
+                    }
                 }
             }
 
@@ -621,7 +721,15 @@ impl ObjectForwarder {
 
             let mut chunks_sent = 0;
             let mut bytes_sent = 0;
-            while let Some(chunk) = subgroup_object_reader.read().await? {
+            loop {
+                let chunk = match subgroup_object_reader.read().await {
+                    Ok(Some(chunk)) => chunk,
+                    Ok(None) => break,
+                    Err(err) => {
+                        writer.reset(0);
+                        return Err(err.into());
+                    }
+                };
                 tracing::trace!(
                     "[PUBLISHER] serve_subgroup: sending payload chunk #{} for object #{} ({} bytes)",
                     chunks_sent + 1,
@@ -648,6 +756,10 @@ impl ObjectForwarder {
             subgroup_reader.subgroup_id,
             object_count
         );
+
+        if let Some(writer) = writer.as_mut() {
+            writer.finish()?;
+        }
 
         Ok(())
     }
@@ -827,18 +939,20 @@ mod tests {
         }
         .produce();
         for object_id in [0, 1, 5, 6, 9] {
-            let mut object = source.create_with_id(object_id, 1, None).unwrap();
+            let extension_headers = if object_id == 5 {
+                let mut headers = data::ExtensionHeaders::new();
+                headers.set_intvalue(2, 9);
+                Some(headers)
+            } else {
+                None
+            };
+            let mut object = source
+                .create_with_id(object_id, 1, extension_headers)
+                .unwrap();
             object.write(Bytes::from(vec![object_id as u8])).unwrap();
         }
         drop(source);
 
-        let header = data::SubgroupHeader {
-            header_type: data::StreamHeaderType::SubgroupIdExt,
-            track_alias: 42,
-            group_id: 0,
-            subgroup_id: Some(0),
-            publisher_priority: 128,
-        };
         let filter = DeliveryFilter {
             forward: true,
             start_location: Some(Location::new(0, 5)),
@@ -849,11 +963,16 @@ mod tests {
             let stream = peer_session.accept_uni().await.unwrap();
             let mut reader = Reader::new(stream);
             let stream_header: data::StreamHeader = reader.decode().await.unwrap();
-            assert_eq!(stream_header.subgroup_header.unwrap().track_alias, 42);
+            let header = stream_header.subgroup_header.unwrap();
+            assert_eq!(header.track_alias, 42);
+            assert!(header.header_type.has_properties());
 
             let mut received = Vec::new();
             for expected_payload in [5, 6, 9] {
                 let object: data::SubgroupObjectExt = reader.decode().await.unwrap();
+                if expected_payload == 5 {
+                    assert!(object.extension_headers.has(2));
+                }
                 let payload = reader
                     .read_chunk(object.payload_length)
                     .await
@@ -865,7 +984,7 @@ mod tests {
             received
         };
         let send = ObjectForwarder::serve_subgroup(
-            header,
+            42,
             source_reader,
             forwarder.publisher.clone(),
             forwarder.state.clone(),
@@ -876,6 +995,429 @@ mod tests {
         let (send_result, received_deltas) = tokio::join!(send, receive);
         send_result.unwrap();
         assert_eq!(received_deltas, [5, 0, 2]);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn forwards_subgroup_semantics_and_clears_first_object_after_filtering() {
+        for (start_location, expected_first_object) in
+            [(None, true), (Some(Location::new(0, 5)), false)]
+        {
+            let (publisher_session, peer_session) = loopback_session_pair().await;
+            let (outgoing, _outgoing_recv) = crate::watch::Queue::default().split();
+            let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+            let publisher = Publisher::new(
+                outgoing,
+                publisher_session,
+                None,
+                crate::session::RequestId::new(0, 1),
+                bidi_task_tx,
+            );
+            let (forwarder, _recv) = ObjectForwarder::new(publisher, 42, None);
+
+            let track = Arc::new(serve::Track::new(
+                crate::coding::TrackNamespace::from_utf8_path("test"),
+                "track",
+            ));
+            let (mut source, source_reader) = serve::SubgroupInfo {
+                track,
+                group_id: 0,
+                subgroup_id: 0,
+                priority: 200,
+            }
+            .produce_with_metadata(serve::SubgroupStreamMetadata {
+                has_properties: false,
+                end_of_group: true,
+                first_object: true,
+            });
+            for object_id in [0, 5] {
+                let mut object = source.create_with_id(object_id, 1, None).unwrap();
+                object.write(Bytes::from(vec![object_id as u8])).unwrap();
+            }
+            drop(source);
+
+            let filter = DeliveryFilter {
+                forward: true,
+                start_location,
+                end_group_id: None,
+            };
+            let receive = async move {
+                let stream = peer_session.accept_uni().await.unwrap();
+                let mut reader = Reader::new(stream);
+                let stream_header: data::StreamHeader = reader.decode().await.unwrap();
+                let header = stream_header.subgroup_header.unwrap();
+                assert_eq!(
+                    header.header_type.subgroup_id_mode(),
+                    Some(data::SubgroupIdMode::Explicit)
+                );
+                assert!(!header.header_type.has_properties());
+                assert!(header.header_type.end_of_group());
+                assert_eq!(
+                    header.header_type.begins_with_first_object(),
+                    expected_first_object
+                );
+                assert!(!header.header_type.uses_default_priority());
+                assert_eq!(header.publisher_priority, 200);
+
+                let expected_ids: &[u64] = if expected_first_object { &[0, 5] } else { &[5] };
+                let mut previous = None;
+                for expected_id in expected_ids {
+                    let object: data::SubgroupObject = reader.decode().await.unwrap();
+                    let actual_id =
+                        data::decode_object_id_delta(&mut previous, object.object_id_delta)
+                            .unwrap();
+                    assert_eq!(actual_id, *expected_id);
+                    assert_eq!(
+                        reader
+                            .read_chunk(object.payload_length)
+                            .await
+                            .unwrap()
+                            .unwrap()
+                            .as_ref(),
+                        &[*expected_id as u8]
+                    );
+                }
+                assert!(reader.done().await.unwrap());
+            };
+            let send = ObjectForwarder::serve_subgroup(
+                42,
+                source_reader,
+                forwarder.publisher.clone(),
+                forwarder.state.clone(),
+                None,
+                filter,
+            );
+
+            let (send_result, ()) = tokio::join!(send, receive);
+            send_result.unwrap();
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn eog_subgroup_source_error_resets_downstream_instead_of_finishing() {
+        let (publisher_session, peer_session) = loopback_session_pair().await;
+        let (outgoing, _outgoing_recv) = crate::watch::Queue::default().split();
+        let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+        let publisher = Publisher::new(
+            outgoing,
+            publisher_session,
+            None,
+            crate::session::RequestId::new(0, 1),
+            bidi_task_tx,
+        );
+        let (forwarder, _recv) = ObjectForwarder::new(publisher, 42, None);
+        let track = Arc::new(serve::Track::new(
+            crate::coding::TrackNamespace::from_utf8_path("test"),
+            "track",
+        ));
+        let (mut source, source_reader) = serve::SubgroupInfo {
+            track,
+            group_id: 0,
+            subgroup_id: 0,
+            priority: 200,
+        }
+        .produce_with_metadata(serve::SubgroupStreamMetadata {
+            has_properties: false,
+            end_of_group: true,
+            first_object: true,
+        });
+        let mut object = source.create_with_id(0, 1, None).unwrap();
+        object.write(Bytes::from_static(b"x")).unwrap();
+        drop(object);
+        let (object_received, wait_for_object) = tokio::sync::oneshot::channel();
+
+        let receive = tokio::time::timeout(std::time::Duration::from_secs(5), async move {
+            let stream = peer_session.accept_uni().await.unwrap();
+            let mut reader = Reader::new(stream);
+            let header: data::StreamHeader = reader.decode().await.unwrap();
+            assert!(header.header_type.end_of_group());
+            let object: data::SubgroupObject = reader.decode().await.unwrap();
+            assert_eq!(
+                reader
+                    .read_chunk(object.payload_length)
+                    .await
+                    .unwrap()
+                    .unwrap(),
+                b"x"[..]
+            );
+            object_received.send(()).unwrap();
+            assert!(matches!(
+                reader.done().await,
+                Err(SessionError::WebTransport(web_transport::Error::Read(
+                    web_transport::quinn::ReadError::Reset(0)
+                )))
+            ));
+        });
+        let close_source = async move {
+            wait_for_object.await.unwrap();
+            source.close(ServeError::internal_ctx("upstream reset"))
+        };
+        let send = ObjectForwarder::serve_subgroup(
+            42,
+            source_reader,
+            forwarder.publisher.clone(),
+            forwarder.state.clone(),
+            None,
+            DeliveryFilter {
+                forward: true,
+                start_location: None,
+                end_group_id: None,
+            },
+        );
+
+        let (send_result, receive_result, close_result) = tokio::join!(send, receive, close_source);
+        close_result.unwrap();
+        assert!(
+            receive_result.is_ok(),
+            "receive failed: {receive_result:?}; send result: {send_result:?}"
+        );
+        assert!(send_result.is_err());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn unsubscribe_cancels_active_subgroup_and_resets_downstream() {
+        let (publisher_session, peer_session) = loopback_session_pair().await;
+        let (outgoing, _outgoing_recv) = crate::watch::Queue::default().split();
+        let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+        let publisher = Publisher::new(
+            outgoing,
+            publisher_session,
+            None,
+            crate::session::RequestId::new(0, 1),
+            bidi_task_tx,
+        );
+        let (mut forwarder, mut forwarder_recv) = ObjectForwarder::new(publisher, 42, None);
+
+        let (track_writer, track_reader) = serve::Track::new(
+            crate::coding::TrackNamespace::from_utf8_path("test"),
+            "track",
+        )
+        .produce();
+        let mut subgroups_writer = track_writer.subgroups().unwrap();
+        let mut subgroup_writer = subgroups_writer
+            .create(serve::Subgroup {
+                group_id: 0,
+                subgroup_id: 0,
+                priority: 128,
+            })
+            .unwrap();
+        let mut object = subgroup_writer.create_with_id(0, 1, None).unwrap();
+        object.write(Bytes::from_static(b"x")).unwrap();
+        drop(object);
+        let serve::TrackReaderMode::Subgroups(subgroups_reader) =
+            track_reader.mode().await.unwrap()
+        else {
+            panic!("expected subgroup delivery");
+        };
+        let (object_received, cancel_after_object) = tokio::sync::oneshot::channel();
+
+        let serve = forwarder.serve_subgroups(
+            subgroups_reader,
+            DeliveryFilter {
+                forward: true,
+                start_location: None,
+                end_group_id: None,
+            },
+        );
+        let receive = async move {
+            let stream = peer_session.accept_uni().await.unwrap();
+            let mut reader = Reader::new(stream);
+            let header: data::StreamHeader = reader.decode().await.unwrap();
+            assert!(header.header_type.begins_with_first_object());
+            let object: data::SubgroupObjectExt = reader.decode().await.unwrap();
+            assert_eq!(
+                reader
+                    .read_chunk(object.payload_length)
+                    .await
+                    .unwrap()
+                    .unwrap(),
+                b"x"[..]
+            );
+            object_received.send(()).unwrap();
+            assert!(matches!(
+                reader.done().await,
+                Err(SessionError::WebTransport(web_transport::Error::Read(
+                    web_transport::quinn::ReadError::Reset(0)
+                )))
+            ));
+        };
+        let cancel = async move {
+            cancel_after_object.await.unwrap();
+            forwarder_recv.recv_unsubscribe()
+        };
+
+        let (serve_result, (), cancel_result) =
+            tokio::time::timeout(std::time::Duration::from_secs(5), async {
+                tokio::join!(serve, receive, cancel)
+            })
+            .await
+            .unwrap();
+        cancel_result.unwrap();
+        assert!(matches!(
+            serve_result,
+            Err(SessionError::Serve(ServeError::Cancel))
+        ));
+        drop(subgroup_writer);
+        drop(subgroups_writer);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn source_track_error_drains_active_subgroup_before_returning() {
+        let (publisher_session, peer_session) = loopback_session_pair().await;
+        let (outgoing, _outgoing_recv) = crate::watch::Queue::default().split();
+        let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+        let publisher = Publisher::new(
+            outgoing,
+            publisher_session,
+            None,
+            crate::session::RequestId::new(0, 1),
+            bidi_task_tx,
+        );
+        let (mut forwarder, _forwarder_recv) = ObjectForwarder::new(publisher, 42, None);
+
+        let (track_writer, track_reader) = serve::Track::new(
+            crate::coding::TrackNamespace::from_utf8_path("test"),
+            "track",
+        )
+        .produce();
+        let mut subgroups_writer = track_writer.subgroups().unwrap();
+        let mut subgroup_writer = subgroups_writer
+            .create(serve::Subgroup {
+                group_id: 0,
+                subgroup_id: 0,
+                priority: 128,
+            })
+            .unwrap();
+        let mut object = subgroup_writer.create_with_id(0, 1, None).unwrap();
+        object.write(Bytes::from_static(b"x")).unwrap();
+        drop(object);
+        let serve::TrackReaderMode::Subgroups(subgroups_reader) =
+            track_reader.mode().await.unwrap()
+        else {
+            panic!("expected subgroup delivery");
+        };
+        let (object_received, close_after_object) = tokio::sync::oneshot::channel();
+
+        let serve = forwarder.serve_subgroups(
+            subgroups_reader,
+            DeliveryFilter {
+                forward: true,
+                start_location: None,
+                end_group_id: None,
+            },
+        );
+        let receive = async move {
+            let stream = peer_session.accept_uni().await.unwrap();
+            let mut reader = Reader::new(stream);
+            let _: data::StreamHeader = reader.decode().await.unwrap();
+            let object: data::SubgroupObjectExt = reader.decode().await.unwrap();
+            assert_eq!(
+                reader
+                    .read_chunk(object.payload_length)
+                    .await
+                    .unwrap()
+                    .unwrap(),
+                b"x"[..]
+            );
+            object_received.send(()).unwrap();
+            assert!(reader.done().await.unwrap());
+        };
+        let close_source = async move {
+            close_after_object.await.unwrap();
+            subgroups_writer.close(ServeError::Closed(0x42)).unwrap();
+            drop(subgroup_writer);
+        };
+
+        let (serve_result, (), ()) =
+            tokio::time::timeout(std::time::Duration::from_secs(5), async {
+                tokio::join!(serve, receive, close_source)
+            })
+            .await
+            .unwrap();
+        assert!(matches!(
+            serve_result,
+            Err(SessionError::Serve(ServeError::Closed(0x42)))
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn dropped_request_owner_overrides_source_drain_and_resets_subgroup() {
+        let (publisher_session, peer_session) = loopback_session_pair().await;
+        let (outgoing, _outgoing_recv) = crate::watch::Queue::default().split();
+        let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+        let publisher = Publisher::new(
+            outgoing,
+            publisher_session,
+            None,
+            crate::session::RequestId::new(0, 1),
+            bidi_task_tx,
+        );
+        let (mut forwarder, forwarder_recv) = ObjectForwarder::new(publisher, 42, None);
+        let (track_writer, track_reader) = serve::Track::new(
+            crate::coding::TrackNamespace::from_utf8_path("test"),
+            "track",
+        )
+        .produce();
+        let mut subgroups_writer = track_writer.subgroups().unwrap();
+        let mut subgroup_writer = subgroups_writer
+            .create(serve::Subgroup {
+                group_id: 0,
+                subgroup_id: 0,
+                priority: 128,
+            })
+            .unwrap();
+        let mut object = subgroup_writer.create_with_id(0, 1, None).unwrap();
+        object.write(Bytes::from_static(b"x")).unwrap();
+        drop(object);
+        let serve::TrackReaderMode::Subgroups(subgroups_reader) =
+            track_reader.mode().await.unwrap()
+        else {
+            panic!("expected subgroup delivery");
+        };
+        let (object_received, cancel_after_object) = tokio::sync::oneshot::channel();
+
+        let serve = forwarder.serve_subgroups(
+            subgroups_reader,
+            DeliveryFilter {
+                forward: true,
+                start_location: None,
+                end_group_id: None,
+            },
+        );
+        let receive = async move {
+            let stream = peer_session.accept_uni().await.unwrap();
+            let mut reader = Reader::new(stream);
+            let _: data::StreamHeader = reader.decode().await.unwrap();
+            let object: data::SubgroupObjectExt = reader.decode().await.unwrap();
+            assert_eq!(
+                reader
+                    .read_chunk(object.payload_length)
+                    .await
+                    .unwrap()
+                    .unwrap(),
+                b"x"[..]
+            );
+            object_received.send(()).unwrap();
+            assert!(matches!(
+                reader.done().await,
+                Err(SessionError::WebTransport(web_transport::Error::Read(
+                    web_transport::quinn::ReadError::Reset(0)
+                )))
+            ));
+        };
+        let cancel = async move {
+            cancel_after_object.await.unwrap();
+            subgroups_writer.close(ServeError::Closed(0x42)).unwrap();
+            drop(forwarder_recv);
+        };
+
+        let (serve_result, (), ()) =
+            tokio::time::timeout(std::time::Duration::from_secs(5), async {
+                tokio::join!(serve, receive, cancel)
+            })
+            .await
+            .unwrap();
+        serve_result.unwrap();
+        drop(subgroup_writer);
     }
 
     #[tokio::test]

--- a/moq-transport/src/session/subscriber.rs
+++ b/moq-transport/src/session/subscriber.rs
@@ -185,6 +185,8 @@ pub struct Subscriber {
     /// WebTransport session, used to open bidi streams for requests (draft-18).
     webtransport: web_transport::Session,
 
+    transport: super::Transport,
+
     /// Shared with Publisher so all requests within a session use unique IDs.
     /// When we need a new Request Id for sending a request, we can get it from here.
     /// The manager is shared with the Publisher, so the session uses unique request ids
@@ -201,10 +203,45 @@ pub struct Subscriber {
     bidi_task_tx: super::BidiTaskSender,
 }
 
+#[derive(Default)]
+struct ReceivedSubgroup {
+    writer: Option<serve::SubgroupWriter>,
+    complete: bool,
+}
+
+impl ReceivedSubgroup {
+    fn is_none(&self) -> bool {
+        self.writer.is_none()
+    }
+
+    fn set(&mut self, writer: serve::SubgroupWriter) {
+        self.writer = Some(writer);
+    }
+
+    fn as_mut(&mut self) -> Option<&mut serve::SubgroupWriter> {
+        self.writer.as_mut()
+    }
+
+    fn finish(&mut self) {
+        self.complete = true;
+    }
+}
+
+impl Drop for ReceivedSubgroup {
+    fn drop(&mut self) {
+        if !self.complete {
+            if let Some(writer) = self.writer.take() {
+                let _ = writer.close(ServeError::internal_ctx("subgroup receive failed"));
+            }
+        }
+    }
+}
+
 impl Subscriber {
     pub(super) fn new(
         outgoing: Queue<Message>,
         webtransport: web_transport::Session,
+        transport: super::Transport,
         mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
         request_id: RequestId,
         bidi_task_tx: super::BidiTaskSender,
@@ -216,6 +253,7 @@ impl Subscriber {
             subscribe_namespaces: Default::default(),
             outgoing,
             webtransport,
+            transport,
             request_id,
             mlog,
             track_alias_map: Default::default(),
@@ -651,6 +689,12 @@ impl Subscriber {
             .map_err(|_| SessionError::Internal)?
             .get_mut(&msg.id)
         {
+            let default_publisher_priority = msg
+                .track_extensions
+                .default_publisher_priority()
+                .map_err(SessionError::Decode)?
+                .unwrap_or(data::DEFAULT_PUBLISHER_PRIORITY);
+
             // Track Aliases are session-scoped (§10.1), so the alias in
             // SUBSCRIBE_OK must not already be bound by another SUBSCRIBE or an
             // inbound PUBLISH.
@@ -669,7 +713,7 @@ impl Subscriber {
             self.track_alias_notify.notify_waiters();
 
             // Notify the subscribe of the successful subscription
-            subscribe.ok(msg.track_alias)?;
+            subscribe.ok(msg.track_alias, default_publisher_priority)?;
         }
 
         Ok(())
@@ -1090,10 +1134,17 @@ impl Subscriber {
     /// This establishes a publisher-initiated subscription: the peer offers a
     /// track and this endpoint becomes its subscriber.
     fn recv_publish(&mut self, msg: &message::Publish) -> Result<(), SessionError> {
-        // First-cut policy: reject non-empty TrackExtensions. They are not
-        // carried through TrackReader/TrackWriter yet, so accepting them would
-        // silently drop relay-visible metadata (§8.6).
-        if !msg.track_extensions.is_empty() {
+        let default_publisher_priority = msg
+            .track_extensions
+            .default_publisher_priority()
+            .map_err(SessionError::Decode)?
+            .unwrap_or(data::DEFAULT_PUBLISHER_PRIORITY);
+        // DEFAULT_PUBLISHER_PRIORITY is consumed by subgroup decoding. Keep
+        // rejecting properties the serve model cannot preserve yet.
+        if !msg
+            .track_extensions
+            .contains_only(&[message::extension_type::DEFAULT_PUBLISHER_PRIORITY])
+        {
             self.send_request_error(
                 "publish",
                 message::RequestError {
@@ -1181,6 +1232,7 @@ impl Subscriber {
             msg.track_name.clone(),
             initial_forward,
             largest_location,
+            default_publisher_priority,
             writer,
             reader,
         );
@@ -1436,8 +1488,26 @@ impl Subscriber {
         tracing::trace!("[SUBSCRIBER] recv_stream: new stream received, decoding header");
         let mut reader = Reader::new(stream);
 
-        // Decode the stream header
-        let stream_header: data::StreamHeader = reader.decode().await?;
+        // A complete malformed stream header is a session error. Stop this
+        // stream explicitly before closing the session so dropping the receive
+        // handle cannot emit an unrelated code 0.
+        let stream_header: data::StreamHeader = match reader.decode().await {
+            Ok(header) => header,
+            Err(err) => {
+                if err.is_session_fatal() {
+                    let code = u32::try_from(err.code()).unwrap_or(0x1);
+                    if self.transport == super::Transport::WebTransport {
+                        reader.stop(code);
+                    } else {
+                        // The transport dependency maps stream codes through
+                        // HTTP/3 even for raw sessions. Close raw QUIC directly
+                        // before dropping the receive stream instead.
+                        self.webtransport.close(code, "session protocol error");
+                    }
+                }
+                return Err(err);
+            }
+        };
         tracing::trace!(
             "[SUBSCRIBER] recv_stream: decoded stream header type={:?}",
             stream_header.header_type
@@ -1590,7 +1660,7 @@ impl Subscriber {
 
         let mut object_count = 0;
         let mut previous_object_id: Option<u64> = None;
-        let mut subgroup_writer: Option<serve::SubgroupWriter> = None;
+        let mut subgroup = ReceivedSubgroup::default();
         while !reader.done().await? {
             tracing::trace!(
                 "[SUBSCRIBER] recv_subgroup: reading object #{} (has_ext_headers={})",
@@ -1689,12 +1759,12 @@ impl Subscriber {
                 ));
             }
 
-            if subgroup_writer.is_none() {
+            if subgroup.is_none() {
                 if stream_header_type.uses_first_object_id_as_subgroup_id() {
                     subgroup_header.subgroup_id = Some(current_object_id);
                 }
 
-                subgroup_writer = Some(self.open_subgroup_writer(origin, &subgroup_header)?);
+                subgroup.set(self.open_subgroup_writer(origin, &subgroup_header)?);
             }
 
             // Log subgroup object parsed/received
@@ -1734,7 +1804,7 @@ impl Subscriber {
             // Pass the absolute Object ID and extension headers through to the serve layer.
             // TODO SLG - object status is still being ignored.
 
-            let subgroup_writer = subgroup_writer.as_mut().ok_or(SessionError::Internal)?;
+            let subgroup_writer = subgroup.as_mut().ok_or(SessionError::Internal)?;
             let mut object_writer = subgroup_writer.create_with_id(
                 current_object_id,
                 remaining_bytes,
@@ -1778,6 +1848,7 @@ impl Subscriber {
             );
             object_count += 1;
         }
+        subgroup.finish();
 
         tracing::trace!(
             "[SUBSCRIBER] recv_subgroup: completed subgroup (group_id={}, subgroup_id={}, {} objects received)",
@@ -1907,7 +1978,14 @@ mod tests {
     fn test_subscriber(session: web_transport::Session) -> Subscriber {
         let outgoing = Queue::default().split().0;
         let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
-        Subscriber::new(outgoing, session, None, RequestId::new(0, 1), bidi_task_tx)
+        Subscriber::new(
+            outgoing,
+            session,
+            super::super::Transport::WebTransport,
+            None,
+            RequestId::new(0, 1),
+            bidi_task_tx,
+        )
     }
 
     /// Like `test_subscriber`, but keeps the background-task receiver alive.
@@ -1923,7 +2001,14 @@ mod tests {
         let outgoing = Queue::default().split().0;
         let (bidi_task_tx, bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
         (
-            Subscriber::new(outgoing, session, None, RequestId::new(0, 1), bidi_task_tx),
+            Subscriber::new(
+                outgoing,
+                session,
+                super::super::Transport::WebTransport,
+                None,
+                RequestId::new(0, 1),
+                bidi_task_tx,
+            ),
             bidi_task_rx,
         )
     }
@@ -1940,6 +2025,16 @@ mod tests {
         request_id: u64,
         track_alias: u64,
     ) -> Subscribe {
+        register_test_subscribe_with_priority(subscriber, track, request_id, track_alias, 128)
+    }
+
+    fn register_test_subscribe_with_priority(
+        subscriber: &Subscriber,
+        track: serve::TrackWriter,
+        request_id: u64,
+        track_alias: u64,
+        default_publisher_priority: u8,
+    ) -> Subscribe {
         let (subscribe, mut recv, _message) = Subscribe::new(
             subscriber.clone(),
             request_id,
@@ -1947,7 +2042,7 @@ mod tests {
             KeyValuePairs::default(),
         )
         .unwrap();
-        recv.ok(track_alias).unwrap();
+        recv.ok(track_alias, default_publisher_priority).unwrap();
         subscriber
             .subscribes
             .lock()
@@ -2020,6 +2115,184 @@ mod tests {
             assert_eq!(object.object_id, expected_object_id);
             assert_eq!(object.read_all().await.unwrap().as_ref(), &[0]);
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn relays_moxygen_type_78_without_misreading_the_first_object() {
+        let (receiver_session, peer_session) = loopback_session_pair().await;
+        let subscriber = test_subscriber(receiver_session.clone());
+        let (track_writer, track_reader) =
+            serve::Track::new(TrackNamespace::from_utf8_path("test/ns"), "type-78").produce();
+        let subscribe =
+            register_test_subscribe_with_priority(&subscriber, track_writer, 0, 42, 200);
+
+        let send = async {
+            let stream = peer_session.open_uni().await.unwrap();
+            let mut writer = Writer::new(stream);
+            // Literal moxygen test-1 wire image: type 0x78, alias 42, group 0,
+            // then Object 0 with a one-byte payload. Subgroup ID and priority
+            // are both omitted by the header type.
+            writer
+                .write(&[0x78, 0x2a, 0x00, 0x00, 0x01, b'x'])
+                .await
+                .unwrap();
+            writer.finish().unwrap();
+        };
+        let receive = async {
+            let stream = receiver_session.accept_uni().await.unwrap();
+            Subscriber::recv_stream(subscriber, stream).await.unwrap();
+        };
+        tokio::join!(send, receive);
+        drop(subscribe);
+
+        let (publisher_session, downstream_session) = loopback_session_pair().await;
+        let outgoing = Queue::default().split().0;
+        let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+        let publisher = super::super::Publisher::new(
+            outgoing,
+            publisher_session,
+            None,
+            RequestId::new(0, 1),
+            bidi_task_tx,
+        );
+        let (mut forwarder, _recv) = super::super::ObjectForwarder::new(publisher, 84, None);
+        let forward = forwarder.serve(
+            track_reader,
+            super::super::DeliveryFilter {
+                forward: true,
+                start_location: None,
+                end_group_id: None,
+            },
+        );
+        let verify = async move {
+            let stream = downstream_session.accept_uni().await.unwrap();
+            let mut reader = Reader::new(stream);
+            let stream_header: data::StreamHeader = reader.decode().await.unwrap();
+            let header = stream_header.subgroup_header.unwrap();
+            assert_eq!(header.track_alias, 84);
+            assert_eq!(header.subgroup_id, Some(0));
+            assert_eq!(header.publisher_priority, 200);
+            assert!(header.header_type.end_of_group());
+            assert!(header.header_type.begins_with_first_object());
+            assert!(!header.header_type.has_properties());
+
+            let object: data::SubgroupObject = reader.decode().await.unwrap();
+            assert_eq!(object.object_id_delta, 0);
+            assert_eq!(
+                reader
+                    .read_chunk(object.payload_length)
+                    .await
+                    .unwrap()
+                    .unwrap(),
+                b"x"[..]
+            );
+            assert!(reader.done().await.unwrap());
+        };
+        let (forward_result, ()) = tokio::join!(forward, verify);
+        forward_result.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn receives_first_object_subgroup_id_mode_with_properties() {
+        let (receiver_session, peer_session) = loopback_session_pair().await;
+        let subscriber = test_subscriber(receiver_session.clone());
+        let (track_writer, track_reader) =
+            serve::Track::new(TrackNamespace::from_utf8_path("test/ns"), "type-53").produce();
+        let subscribe = register_test_subscribe(&subscriber, track_writer, 0, 42);
+
+        let send = async {
+            let stream = peer_session.open_uni().await.unwrap();
+            let mut writer = Writer::new(stream);
+            // Type 0x53: PROPERTIES + subgroup ID from first Object +
+            // FIRST_OBJECT, with explicit priority 200. Object 7 carries
+            // integer property 2=9 and a one-byte payload.
+            writer
+                .write(&[0x53, 0x2a, 0x00, 200, 0x07, 0x02, 0x02, 0x09, 0x01, b'x'])
+                .await
+                .unwrap();
+            writer.finish().unwrap();
+        };
+        let receive = async {
+            let stream = receiver_session.accept_uni().await.unwrap();
+            Subscriber::recv_stream(subscriber, stream).await.unwrap();
+        };
+        tokio::join!(send, receive);
+        drop(subscribe);
+
+        let serve::TrackReaderMode::Subgroups(mut subgroups) = track_reader.mode().await.unwrap()
+        else {
+            panic!("expected subgroup delivery");
+        };
+        let mut subgroup = subgroups.next().await.unwrap().unwrap();
+        assert_eq!(subgroup.subgroup_id, 7);
+        assert_eq!(subgroup.priority, 200);
+        assert!(subgroup.metadata().has_properties);
+        assert!(subgroup.metadata().first_object);
+        let mut object = subgroup.next().await.unwrap().unwrap();
+        assert_eq!(object.object_id, 7);
+        assert!(object.extension_headers.has(2));
+        assert_eq!(object.read_all().await.unwrap().as_ref(), b"x");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn subscribe_ok_records_default_publisher_priority() {
+        let mut subscriber = test_subscriber(loopback_session().await);
+        let (subscribe, recv, _message) = Subscribe::new(
+            subscriber.clone(),
+            0,
+            test_track("priority"),
+            KeyValuePairs::default(),
+        )
+        .unwrap();
+        subscriber.subscribes.lock().unwrap().insert(0, recv);
+        let mut track_extensions = message::TrackExtensions::default();
+        track_extensions.set_default_publisher_priority(200);
+
+        subscriber
+            .recv_subscribe_ok(&message::SubscribeOk {
+                id: 0,
+                track_alias: 42,
+                params: KeyValuePairs::default(),
+                track_extensions,
+            })
+            .unwrap();
+
+        assert_eq!(
+            subscriber
+                .subscribes
+                .lock()
+                .unwrap()
+                .get(&0)
+                .unwrap()
+                .default_publisher_priority,
+            200
+        );
+        drop(subscribe);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn malformed_subgroup_type_stops_stream_with_protocol_violation() {
+        let (receiver_session, peer_session) = loopback_session_pair().await;
+        let subscriber = test_subscriber(receiver_session.clone());
+
+        let send = async {
+            let mut stream = peer_session.open_uni().await.unwrap();
+            stream.write(&[0x16]).await.unwrap();
+            stream.closed().await.unwrap()
+        };
+        let receive = async {
+            let stream = receiver_session.accept_uni().await.unwrap();
+            Subscriber::recv_stream(subscriber, stream)
+                .await
+                .unwrap_err()
+        };
+        let (stop_code, err) = tokio::join!(send, receive);
+
+        assert_eq!(stop_code, Some(0x3));
+        assert!(matches!(
+            err,
+            SessionError::Decode(crate::coding::DecodeError::InvalidHeaderType)
+        ));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -2115,7 +2388,7 @@ mod tests {
         // still alive, so the recv state accepts the mutation. Then drop the
         // handle — its Drop runs against the still-empty map (a no-op) — and
         // drive remove_subscribe directly via the registered recv state.
-        recv.ok(track_alias).unwrap();
+        recv.ok(track_alias, 128).unwrap();
         drop(subscribe);
         subscriber
             .subscribes
@@ -2179,6 +2452,59 @@ mod tests {
         let publish = subscriber.publish_received().await.expect("queued PUBLISH");
         assert_eq!(publish.track_alias(), 7);
         assert_eq!(publish.name(), &TrackName::from("video"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn recv_publish_accepts_default_publisher_priority() {
+        let mut subscriber = test_subscriber(loopback_session().await);
+        let mut track_extensions = message::TrackExtensions::default();
+        track_extensions.set_default_publisher_priority(200);
+
+        subscriber
+            .recv_publish(&message::Publish {
+                id: 1,
+                track_namespace: TrackNamespace::from_utf8_path("test/ns"),
+                track_name: "video".into(),
+                track_alias: 7,
+                params: Default::default(),
+                track_extensions,
+            })
+            .unwrap();
+
+        assert_eq!(
+            subscriber
+                .publishes_received
+                .lock()
+                .unwrap()
+                .get(&1)
+                .unwrap()
+                .default_publisher_priority,
+            200
+        );
+
+        let mut publish = subscriber.publish_received().await.unwrap();
+        let track_reader = publish.take_reader().unwrap();
+        let subgroup_writer = subscriber
+            .publishes_received
+            .lock()
+            .unwrap()
+            .get_mut(&1)
+            .unwrap()
+            .subgroup(data::SubgroupHeader {
+                header_type: data::StreamHeaderType::SubgroupIdDefaultPriorityFirstObject,
+                track_alias: 7,
+                group_id: 0,
+                subgroup_id: Some(0),
+                publisher_priority: 128,
+            })
+            .unwrap();
+        drop(subgroup_writer);
+
+        let serve::TrackReaderMode::Subgroups(mut subgroups) = track_reader.mode().await.unwrap()
+        else {
+            panic!("expected subgroup delivery");
+        };
+        assert_eq!(subgroups.next().await.unwrap().unwrap().priority, 200);
     }
 
     /// A second PUBLISH for a track we already subscribe to is rejected as a


### PR DESCRIPTION
- support all valid draft-18 `SUBGROUP_HEADER` modifier combinations
- preserve properties, end-of-group, first-object, subgroup identity, and effective publisher priority across relay forwarding
- resolve default publisher priority at ingress and emit explicit downstream priorities
- reset incomplete subgroup streams and explicitly close malformed sessions with the appropriate protocol error