### PR TITLE
fix(moq-transport): preserve draft-18 datagram semantics

### DIFF
--- a/moq-clock-ietf/src/clock.rs
+++ b/moq-clock-ietf/src/clock.rs
@@ -67,6 +67,8 @@ impl Publisher {
                         group_id: next_group_id as u64,
                         object_id: 0,
                         priority: 127,
+                        status: moq_transport::data::ObjectStatus::NormalObject,
+                        end_of_group: false,
                         payload: time_str.clone().into_bytes().into(),
                         extension_headers: Default::default(),
                     })

--- a/moq-relay-ietf/src/local.rs
+++ b/moq-relay-ietf/src/local.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, RwLock, Weak};
 use std::time::Duration;
 
 use moq_transport::{
-    coding::{TrackNamespace, TrackNamespacePrefix},
+    coding::{Location, TrackNamespace, TrackNamespacePrefix},
     serve::{FullTrackName, ServeError, Track, TrackReader, TrackWriter},
 };
 use tokio::sync::{broadcast, mpsc, watch, OwnedSemaphorePermit, Semaphore};
@@ -249,6 +249,9 @@ struct TrackEntry {
 pub struct LocalTrack {
     /// The media reader to serve downstream.
     pub reader: TrackReader,
+
+    /// Greatest Object present when this lookup resolved.
+    pub largest_location: Option<Location>,
 
     /// Held for as long as the caller serves [`Self::reader`]. Dropping it is what
     /// eventually lets an idle upstream subscription be released.
@@ -824,6 +827,7 @@ impl Locals {
             if let Some(entry) = bucket.get(&full_name) {
                 if !entry.reader.is_closed() {
                     return Some(LocalTrack {
+                        largest_location: entry.reader.largest_location(),
                         reader: entry.reader.clone(),
                         interest: entry.interest.as_ref().map(TrackInterest::guard),
                         upstream: entry.upstream.clone(),
@@ -896,6 +900,7 @@ impl Locals {
 
         Some(LocalTrack {
             reader,
+            largest_location: None,
             interest: Some(guard),
             upstream: Some(upstream),
         })
@@ -948,6 +953,7 @@ impl Locals {
             match bucket.get(full_name) {
                 Some(entry) if !entry.reader.is_closed() => {
                     return Some(LocalTrack {
+                        largest_location: entry.reader.largest_location(),
                         reader: entry.reader.clone(),
                         interest: entry.interest.as_ref().map(TrackInterest::guard),
                         upstream: entry.upstream.clone(),
@@ -1373,6 +1379,39 @@ mod tests {
             no_second_request.is_err(),
             "cache hit should not request again"
         );
+    }
+
+    #[tokio::test]
+    async fn new_pull_through_track_keeps_its_pre_publish_snapshot() {
+        let mut locals = Locals::new();
+        let namespace = ns("room/snapshot");
+        let (_registration, mut requests) = locals
+            .register_namespace(None, namespace.clone())
+            .await
+            .expect("namespace source should register");
+
+        let local = locals
+            .get_or_request_track(None, namespace, "video")
+            .await
+            .expect("track should resolve through namespace source");
+        assert_eq!(local.largest_location, None);
+
+        let request = requests.recv().await.expect("source should get request");
+        let mut datagrams = request.writer.datagrams().unwrap();
+        datagrams
+            .write(moq_transport::serve::Datagram {
+                group_id: 2,
+                object_id: 3,
+                priority: 128,
+                status: moq_transport::data::ObjectStatus::NormalObject,
+                end_of_group: false,
+                payload: b"payload".to_vec().into(),
+                extension_headers: moq_transport::data::ExtensionHeaders::default(),
+            })
+            .unwrap();
+
+        assert_eq!(local.reader.largest_location(), Some(Location::new(2, 3)));
+        assert_eq!(local.largest_location, None);
     }
 
     #[tokio::test]

--- a/moq-relay-ietf/src/producer.rs
+++ b/moq-relay-ietf/src/producer.rs
@@ -349,6 +349,7 @@ impl Producer {
             };
 
             if let Some(local) = local {
+                let largest_location = local.largest_location;
                 let ns = namespace.to_utf8_path();
                 tracing::info!(namespace = %ns, track = %track_name, source = "local", "serving subscribe from local: {:?}", local.reader.info);
                 timing_guard.set_label("source", "local");
@@ -404,6 +405,7 @@ impl Producer {
                 return Self::serve_resolved_track(
                     subscribed,
                     local.reader,
+                    largest_location,
                     deadline,
                     &mut timing_guard,
                 )
@@ -452,6 +454,7 @@ impl Producer {
 
             match remote {
                 Ok(Some((track, interest_guard))) => {
+                    let largest_location = track.largest_location();
                     let ns = namespace.to_utf8_path();
                     tracing::info!(namespace = %ns, track = %track_name, source = "remote", "serving subscribe from remote: {:?}", track.info);
                     // Update label to indicate remote source, timing recorded on drop
@@ -466,6 +469,7 @@ impl Producer {
                     return Self::serve_resolved_track(
                         subscribed,
                         track,
+                        largest_location,
                         deadline,
                         &mut timing_guard,
                     )
@@ -639,14 +643,20 @@ impl Producer {
     async fn serve_resolved_track(
         subscribed: Subscribed,
         track: TrackReader,
+        largest_location: Option<moq_transport::coding::Location>,
         deadline: Option<tokio::time::Instant>,
         timing_guard: &mut TimingGuard,
     ) -> Result<(), anyhow::Error> {
         let Some(deadline) = deadline else {
-            return Ok(subscribed.serve(track).await?);
+            return Ok(subscribed
+                .serve_with_largest_location(track, largest_location)
+                .await?);
         };
 
-        match subscribed.serve_with_deadline(track, deadline).await {
+        match subscribed
+            .serve_with_deadline_and_largest_location(track, deadline, largest_location)
+            .await
+        {
             Ok(()) => Ok(()),
             Err(ServeWithDeadlineError::DeadlineExpired) => {
                 Self::record_rendezvous_timeout(timing_guard);

--- a/moq-transport/src/data/datagram.rs
+++ b/moq-transport/src/data/datagram.rs
@@ -5,6 +5,12 @@
 use crate::coding::{Decode, DecodeError, Encode, EncodeError};
 use crate::data::{ExtensionHeaders, ObjectStatus};
 
+const PROPERTIES: u64 = 0x01;
+const END_OF_GROUP: u64 = 0x02;
+const ZERO_OBJECT_ID: u64 = 0x04;
+const DEFAULT_PRIORITY: u64 = 0x08;
+const STATUS: u64 = 0x20;
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum DatagramType {
     ObjectIdPayload = 0x00,
@@ -15,24 +21,43 @@ pub enum DatagramType {
     PayloadExt = 0x05,
     PayloadEndOfGroup = 0x06,
     PayloadExtEndOfGroup = 0x07,
+    ObjectIdPayloadDefaultPriority = 0x08,
+    ObjectIdPayloadExtDefaultPriority = 0x09,
+    ObjectIdPayloadEndOfGroupDefaultPriority = 0x0a,
+    ObjectIdPayloadExtEndOfGroupDefaultPriority = 0x0b,
+    PayloadDefaultPriority = 0x0c,
+    PayloadExtDefaultPriority = 0x0d,
+    PayloadEndOfGroupDefaultPriority = 0x0e,
+    PayloadExtEndOfGroupDefaultPriority = 0x0f,
     ObjectIdStatus = 0x20,
     ObjectIdStatusExt = 0x21,
+    Status = 0x24,
+    StatusExt = 0x25,
+    ObjectIdStatusDefaultPriority = 0x28,
+    ObjectIdStatusExtDefaultPriority = 0x29,
+    StatusDefaultPriority = 0x2c,
+    StatusExtDefaultPriority = 0x2d,
 }
 
 impl DatagramType {
-    fn has_extension_headers(self) -> bool {
-        matches!(
-            self,
-            Self::ObjectIdPayloadExt
-                | Self::ObjectIdPayloadExtEndOfGroup
-                | Self::PayloadExt
-                | Self::PayloadExtEndOfGroup
-                | Self::ObjectIdStatusExt
-        )
+    pub fn has_properties(self) -> bool {
+        self as u64 & PROPERTIES != 0
     }
 
-    fn has_status(self) -> bool {
-        matches!(self, Self::ObjectIdStatus | Self::ObjectIdStatusExt)
+    pub fn end_of_group(self) -> bool {
+        !self.has_status() && self as u64 & END_OF_GROUP != 0
+    }
+
+    pub fn has_object_id(self) -> bool {
+        self as u64 & ZERO_OBJECT_ID == 0
+    }
+
+    pub fn uses_default_priority(self) -> bool {
+        self as u64 & DEFAULT_PRIORITY != 0
+    }
+
+    pub fn has_status(self) -> bool {
+        self as u64 & STATUS != 0
     }
 }
 
@@ -47,8 +72,22 @@ impl Decode for DatagramType {
             0x05 => Ok(Self::PayloadExt),
             0x06 => Ok(Self::PayloadEndOfGroup),
             0x07 => Ok(Self::PayloadExtEndOfGroup),
+            0x08 => Ok(Self::ObjectIdPayloadDefaultPriority),
+            0x09 => Ok(Self::ObjectIdPayloadExtDefaultPriority),
+            0x0a => Ok(Self::ObjectIdPayloadEndOfGroupDefaultPriority),
+            0x0b => Ok(Self::ObjectIdPayloadExtEndOfGroupDefaultPriority),
+            0x0c => Ok(Self::PayloadDefaultPriority),
+            0x0d => Ok(Self::PayloadExtDefaultPriority),
+            0x0e => Ok(Self::PayloadEndOfGroupDefaultPriority),
+            0x0f => Ok(Self::PayloadExtEndOfGroupDefaultPriority),
             0x20 => Ok(Self::ObjectIdStatus),
             0x21 => Ok(Self::ObjectIdStatusExt),
+            0x24 => Ok(Self::Status),
+            0x25 => Ok(Self::StatusExt),
+            0x28 => Ok(Self::ObjectIdStatusDefaultPriority),
+            0x29 => Ok(Self::ObjectIdStatusExtDefaultPriority),
+            0x2c => Ok(Self::StatusDefaultPriority),
+            0x2d => Ok(Self::StatusExtDefaultPriority),
             _ => Err(DecodeError::InvalidDatagramType),
         }
     }
@@ -56,36 +95,23 @@ impl Decode for DatagramType {
 
 impl Encode for DatagramType {
     fn encode<W: bytes::BufMut>(&self, w: &mut W) -> Result<(), EncodeError> {
-        let val = *self as u64;
-        val.encode(w)?;
-        Ok(())
+        (*self as u64).encode(w)
     }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Datagram {
-    /// The type of this datagram object
     pub datagram_type: DatagramType,
-
-    /// The track alias.
     pub track_alias: u64,
-
-    /// The sequence number within the track.
     pub group_id: u64,
 
-    /// The object ID within the group.
+    /// `None` when ZERO_OBJECT_ID is set; the semantic Object ID is zero.
     pub object_id: Option<u64>,
 
-    /// Publisher priority, where **smaller** values are sent first.
-    pub publisher_priority: u8,
-
-    /// Optional extension headers if type is 0x1 (NoEndOfGroupWithExtensions) or 0x3 (EndofGroupWithExtensions)
+    /// `None` when DEFAULT_PRIORITY is set; resolve it from Track Properties.
+    pub publisher_priority: Option<u8>,
     pub extension_headers: Option<ExtensionHeaders>,
-
-    /// The Object Status.
     pub status: Option<ObjectStatus>,
-
-    /// The payload.
     pub payload: Option<bytes::Bytes>,
 }
 
@@ -94,22 +120,15 @@ impl Decode for Datagram {
         let datagram_type = DatagramType::decode(r)?;
         let track_alias = u64::decode(r)?;
         let group_id = u64::decode(r)?;
+        let object_id = datagram_type
+            .has_object_id()
+            .then(|| u64::decode(r))
+            .transpose()?;
+        let publisher_priority = (!datagram_type.uses_default_priority())
+            .then(|| u8::decode(r))
+            .transpose()?;
 
-        // Decode Object Id if required
-        let object_id = match datagram_type {
-            DatagramType::ObjectIdPayload
-            | DatagramType::ObjectIdPayloadExt
-            | DatagramType::ObjectIdPayloadEndOfGroup
-            | DatagramType::ObjectIdPayloadExtEndOfGroup
-            | DatagramType::ObjectIdStatus
-            | DatagramType::ObjectIdStatusExt => Some(u64::decode(r)?),
-            _ => None,
-        };
-
-        let publisher_priority = u8::decode(r)?;
-
-        // Decode Extension Headers if required
-        let extension_headers = if datagram_type.has_extension_headers() {
+        let extension_headers = if datagram_type.has_properties() {
             let headers = ExtensionHeaders::decode(r)?;
             if headers.is_empty() {
                 return Err(DecodeError::InvalidValue);
@@ -119,30 +138,21 @@ impl Decode for Datagram {
             None
         };
 
-        // Decode Status if required
-        let status = if datagram_type.has_status() {
-            Some(ObjectStatus::decode(r)?)
+        let (status, payload) = if datagram_type.has_status() {
+            let status = ObjectStatus::decode(r)?;
+            if status != ObjectStatus::NormalObject && extension_headers.is_some() {
+                return Err(DecodeError::InvalidValue);
+            }
+            if r.has_remaining() {
+                return Err(DecodeError::InvalidValue);
+            }
+            (Some(status), None)
         } else {
-            None
-        };
-
-        if status.is_some_and(|status| status != ObjectStatus::NormalObject)
-            && extension_headers.is_some()
-        {
-            return Err(DecodeError::InvalidValue);
-        }
-
-        // Decode Payload if required
-        let payload = match datagram_type {
-            DatagramType::ObjectIdPayload
-            | DatagramType::ObjectIdPayloadExt
-            | DatagramType::ObjectIdPayloadEndOfGroup
-            | DatagramType::ObjectIdPayloadExtEndOfGroup
-            | DatagramType::Payload
-            | DatagramType::PayloadExt
-            | DatagramType::PayloadEndOfGroup
-            | DatagramType::PayloadExtEndOfGroup => Some(r.copy_to_bytes(r.remaining())),
-            _ => None,
+            let payload = r.copy_to_bytes(r.remaining());
+            if payload.is_empty() {
+                return Err(DecodeError::InvalidValue);
+            }
+            (None, Some(payload))
         };
 
         Ok(Self {
@@ -160,492 +170,320 @@ impl Decode for Datagram {
 
 impl Encode for Datagram {
     fn encode<W: bytes::BufMut>(&self, w: &mut W) -> Result<(), EncodeError> {
+        self.validate()?;
         self.datagram_type.encode(w)?;
         self.track_alias.encode(w)?;
         self.group_id.encode(w)?;
 
-        // Encode Object Id if required
-        match self.datagram_type {
-            DatagramType::ObjectIdPayload
-            | DatagramType::ObjectIdPayloadExt
-            | DatagramType::ObjectIdPayloadEndOfGroup
-            | DatagramType::ObjectIdPayloadExtEndOfGroup
-            | DatagramType::ObjectIdStatus
-            | DatagramType::ObjectIdStatusExt => {
-                if let Some(object_id) = &self.object_id {
-                    object_id.encode(w)?;
-                } else {
-                    return Err(EncodeError::MissingField("ObjectId".to_string()));
-                }
-            }
-            _ => {}
-        };
-
-        self.publisher_priority.encode(w)?;
-
-        // Encode Extension Headers if required
-        match self.datagram_type {
-            DatagramType::ObjectIdPayloadExt
-            | DatagramType::ObjectIdPayloadExtEndOfGroup
-            | DatagramType::PayloadExt
-            | DatagramType::PayloadExtEndOfGroup
-            | DatagramType::ObjectIdStatusExt => {
-                if let Some(extension_headers) = &self.extension_headers {
-                    if extension_headers.is_empty() {
-                        return Err(EncodeError::InvalidValue);
-                    }
-                    extension_headers.encode(w)?;
-                } else {
-                    return Err(EncodeError::MissingField("ExtensionHeaders".to_string()));
-                }
-            }
-            _ => {}
-        };
-
-        // Decode Status if required
-        match self.datagram_type {
-            DatagramType::ObjectIdStatus | DatagramType::ObjectIdStatusExt => {
-                if let Some(status) = &self.status {
-                    if self.extension_headers.is_some() && *status != ObjectStatus::NormalObject {
-                        return Err(EncodeError::InvalidValue);
-                    }
-                    status.encode(w)?;
-                } else {
-                    return Err(EncodeError::MissingField("Status".to_string()));
-                }
-            }
-            _ => {}
+        if let Some(object_id) = self.object_id {
+            object_id.encode(w)?;
         }
-
-        // Decode Payload if required
-        match self.datagram_type {
-            DatagramType::ObjectIdPayload
-            | DatagramType::ObjectIdPayloadExt
-            | DatagramType::ObjectIdPayloadEndOfGroup
-            | DatagramType::ObjectIdPayloadExtEndOfGroup
-            | DatagramType::Payload
-            | DatagramType::PayloadExt
-            | DatagramType::PayloadEndOfGroup
-            | DatagramType::PayloadExtEndOfGroup => {
-                if let Some(payload) = &self.payload {
-                    Self::encode_remaining(w, payload.len())?;
-                    w.put_slice(payload);
-                } else {
-                    return Err(EncodeError::MissingField("Payload".to_string()));
-                }
-            }
-            _ => {}
+        if let Some(priority) = self.publisher_priority {
+            priority.encode(w)?;
+        }
+        if let Some(properties) = &self.extension_headers {
+            properties.encode(w)?;
+        }
+        if let Some(status) = self.status {
+            status.encode(w)?;
+        }
+        if let Some(payload) = &self.payload {
+            Self::encode_remaining(w, payload.len())?;
+            w.put_slice(payload);
         }
 
         Ok(())
     }
 }
 
+impl Datagram {
+    fn validate(&self) -> Result<(), EncodeError> {
+        validate_field(
+            self.object_id.is_some(),
+            self.datagram_type.has_object_id(),
+            "ObjectId",
+        )?;
+        validate_field(
+            self.publisher_priority.is_some(),
+            !self.datagram_type.uses_default_priority(),
+            "PublisherPriority",
+        )?;
+        validate_field(
+            self.extension_headers.is_some(),
+            self.datagram_type.has_properties(),
+            "Properties",
+        )?;
+        validate_field(
+            self.status.is_some(),
+            self.datagram_type.has_status(),
+            "Status",
+        )?;
+        validate_field(
+            self.payload.is_some(),
+            !self.datagram_type.has_status(),
+            "Payload",
+        )?;
+        if self
+            .extension_headers
+            .as_ref()
+            .is_some_and(ExtensionHeaders::is_empty)
+        {
+            return Err(EncodeError::InvalidValue);
+        }
+        if self.payload.as_ref().is_some_and(bytes::Bytes::is_empty) {
+            return Err(EncodeError::InvalidValue);
+        }
+        if self
+            .status
+            .is_some_and(|status| status != ObjectStatus::NormalObject)
+            && self.extension_headers.is_some()
+        {
+            return Err(EncodeError::InvalidValue);
+        }
+        Ok(())
+    }
+}
+
+fn validate_field(present: bool, required: bool, name: &str) -> Result<(), EncodeError> {
+    match (present, required) {
+        (false, true) => Err(EncodeError::MissingField(name.to_string())),
+        (true, false) => Err(EncodeError::InvalidValue),
+        _ => Ok(()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bytes::Bytes;
-    use bytes::BytesMut;
+    use bytes::{Bytes, BytesMut};
 
-    #[test]
-    fn encode_decode_datagram_type() {
-        let mut buf = BytesMut::new();
+    const VALID_TYPES: &[(u64, DatagramType)] = &[
+        (0x00, DatagramType::ObjectIdPayload),
+        (0x01, DatagramType::ObjectIdPayloadExt),
+        (0x02, DatagramType::ObjectIdPayloadEndOfGroup),
+        (0x03, DatagramType::ObjectIdPayloadExtEndOfGroup),
+        (0x04, DatagramType::Payload),
+        (0x05, DatagramType::PayloadExt),
+        (0x06, DatagramType::PayloadEndOfGroup),
+        (0x07, DatagramType::PayloadExtEndOfGroup),
+        (0x08, DatagramType::ObjectIdPayloadDefaultPriority),
+        (0x09, DatagramType::ObjectIdPayloadExtDefaultPriority),
+        (0x0a, DatagramType::ObjectIdPayloadEndOfGroupDefaultPriority),
+        (
+            0x0b,
+            DatagramType::ObjectIdPayloadExtEndOfGroupDefaultPriority,
+        ),
+        (0x0c, DatagramType::PayloadDefaultPriority),
+        (0x0d, DatagramType::PayloadExtDefaultPriority),
+        (0x0e, DatagramType::PayloadEndOfGroupDefaultPriority),
+        (0x0f, DatagramType::PayloadExtEndOfGroupDefaultPriority),
+        (0x20, DatagramType::ObjectIdStatus),
+        (0x21, DatagramType::ObjectIdStatusExt),
+        (0x24, DatagramType::Status),
+        (0x25, DatagramType::StatusExt),
+        (0x28, DatagramType::ObjectIdStatusDefaultPriority),
+        (0x29, DatagramType::ObjectIdStatusExtDefaultPriority),
+        (0x2c, DatagramType::StatusDefaultPriority),
+        (0x2d, DatagramType::StatusExtDefaultPriority),
+    ];
 
-        let dt = DatagramType::ObjectIdPayload;
-        dt.encode(&mut buf).unwrap();
-        assert_eq!(buf.to_vec(), vec![0x00]);
-        let decoded = DatagramType::decode(&mut buf).unwrap();
-        assert_eq!(decoded, dt);
+    fn properties() -> ExtensionHeaders {
+        let mut properties = ExtensionHeaders::new();
+        properties.set_bytesvalue(3, b"property".to_vec());
+        properties
+    }
 
-        let dt = DatagramType::ObjectIdPayloadExt;
-        dt.encode(&mut buf).unwrap();
-        assert_eq!(buf.to_vec(), vec![0x01]);
-        let decoded = DatagramType::decode(&mut buf).unwrap();
-        assert_eq!(decoded, dt);
-
-        let dt = DatagramType::ObjectIdPayloadEndOfGroup;
-        dt.encode(&mut buf).unwrap();
-        assert_eq!(buf.to_vec(), vec![0x02]);
-        let decoded = DatagramType::decode(&mut buf).unwrap();
-        assert_eq!(decoded, dt);
-
-        let dt = DatagramType::ObjectIdPayloadExtEndOfGroup;
-        dt.encode(&mut buf).unwrap();
-        assert_eq!(buf.to_vec(), vec![0x03]);
-        let decoded = DatagramType::decode(&mut buf).unwrap();
-        assert_eq!(decoded, dt);
-
-        let dt = DatagramType::Payload;
-        dt.encode(&mut buf).unwrap();
-        assert_eq!(buf.to_vec(), vec![0x04]);
-        let decoded = DatagramType::decode(&mut buf).unwrap();
-        assert_eq!(decoded, dt);
-
-        let dt = DatagramType::PayloadExt;
-        dt.encode(&mut buf).unwrap();
-        assert_eq!(buf.to_vec(), vec![0x05]);
-        let decoded = DatagramType::decode(&mut buf).unwrap();
-        assert_eq!(decoded, dt);
-
-        let dt = DatagramType::PayloadEndOfGroup;
-        dt.encode(&mut buf).unwrap();
-        assert_eq!(buf.to_vec(), vec![0x06]);
-        let decoded = DatagramType::decode(&mut buf).unwrap();
-        assert_eq!(decoded, dt);
-
-        let dt = DatagramType::PayloadExtEndOfGroup;
-        dt.encode(&mut buf).unwrap();
-        assert_eq!(buf.to_vec(), vec![0x07]);
-        let decoded = DatagramType::decode(&mut buf).unwrap();
-        assert_eq!(decoded, dt);
-
-        let dt = DatagramType::ObjectIdStatus;
-        dt.encode(&mut buf).unwrap();
-        assert_eq!(buf.to_vec(), vec![0x20]);
-        let decoded = DatagramType::decode(&mut buf).unwrap();
-        assert_eq!(decoded, dt);
-
-        let dt = DatagramType::ObjectIdStatusExt;
-        dt.encode(&mut buf).unwrap();
-        assert_eq!(buf.to_vec(), vec![0x21]);
-        let decoded = DatagramType::decode(&mut buf).unwrap();
-        assert_eq!(decoded, dt);
+    fn datagram(datagram_type: DatagramType) -> Datagram {
+        Datagram {
+            datagram_type,
+            track_alias: 12,
+            group_id: 10,
+            object_id: datagram_type.has_object_id().then_some(1234),
+            publisher_priority: (!datagram_type.uses_default_priority()).then_some(200),
+            extension_headers: datagram_type.has_properties().then(properties),
+            status: datagram_type
+                .has_status()
+                .then_some(ObjectStatus::NormalObject),
+            payload: (!datagram_type.has_status()).then(|| Bytes::from_static(b"payload")),
+        }
     }
 
     #[test]
-    fn encode_decode_datagram() {
-        let mut buf = BytesMut::new();
-
-        // One ExtensionHeader for testing
-        let mut ext_hdrs = ExtensionHeaders::new();
-        ext_hdrs.set_bytesvalue(123, vec![0x00, 0x01, 0x02, 0x03]);
-
-        // DatagramType = ObjectIdPayload
-        let msg = Datagram {
-            datagram_type: DatagramType::ObjectIdPayload,
-            track_alias: 12,
-            group_id: 10,
-            object_id: Some(1234),
-            publisher_priority: 127,
-            extension_headers: None,
-            status: None,
-            payload: Some(Bytes::from("payload")),
-        };
-        msg.encode(&mut buf).unwrap();
-        // Length should be: Type(1)+Alias(1)+GroupId(1)+ObjectId(2)+Priority(1)+Payload(7) = 13
-        assert_eq!(13, buf.len());
-        let decoded = Datagram::decode(&mut buf).unwrap();
-        assert_eq!(decoded, msg);
-
-        // DatagramType = ObjectIdPayloadExt
-        let msg = Datagram {
-            datagram_type: DatagramType::ObjectIdPayloadExt,
-            track_alias: 12,
-            group_id: 10,
-            object_id: Some(1234),
-            publisher_priority: 127,
-            extension_headers: Some(ext_hdrs.clone()),
-            status: None,
-            payload: Some(Bytes::from("payload")),
-        };
-        msg.encode(&mut buf).unwrap();
-        // Length should be: Same as above plus NumExt(1),ExtensionKey(1),ExtensionValueLen(1),ExtensionValue(4) = 13 + 7 = 20
-        assert_eq!(20, buf.len());
-        let decoded = Datagram::decode(&mut buf).unwrap();
-        assert_eq!(decoded, msg);
-
-        // DatagramType = ObjectIdPayloadEndOfGroup
-        let msg = Datagram {
-            datagram_type: DatagramType::ObjectIdPayloadEndOfGroup,
-            track_alias: 12,
-            group_id: 10,
-            object_id: Some(1234),
-            publisher_priority: 127,
-            extension_headers: None,
-            status: None,
-            payload: Some(Bytes::from("payload")),
-        };
-        msg.encode(&mut buf).unwrap();
-        // Length should be: Type(1)+Alias(1)+GroupId(1)+ObjectId(2)+Priority(1)+Payload(7) = 13
-        assert_eq!(13, buf.len());
-        let decoded = Datagram::decode(&mut buf).unwrap();
-        assert_eq!(decoded, msg);
-
-        // DatagramType = ObjectIdPayloadExtEndOfGroup
-        let msg = Datagram {
-            datagram_type: DatagramType::ObjectIdPayloadExtEndOfGroup,
-            track_alias: 12,
-            group_id: 10,
-            object_id: Some(1234),
-            publisher_priority: 127,
-            extension_headers: Some(ext_hdrs.clone()),
-            status: None,
-            payload: Some(Bytes::from("payload")),
-        };
-        msg.encode(&mut buf).unwrap();
-        // Length should be: Same as above plus NumExt(1),ExtensionKey(1),ExtensionValueLen(1),ExtensionValue(4) = 13 + 7 = 20
-        assert_eq!(20, buf.len());
-        let decoded = Datagram::decode(&mut buf).unwrap();
-        assert_eq!(decoded, msg);
-
-        // DatagramType = ObjectIdStatus
-        let msg = Datagram {
-            datagram_type: DatagramType::ObjectIdStatus,
-            track_alias: 12,
-            group_id: 10,
-            object_id: Some(1234),
-            publisher_priority: 127,
-            extension_headers: None,
-            status: Some(ObjectStatus::NormalObject),
-            payload: None,
-        };
-        msg.encode(&mut buf).unwrap();
-        // Length should be: Type(1)+Alias(1)+GroupId(1)+ObjectId(2)+Priority(1)+Status(1) = 7
-        assert_eq!(7, buf.len());
-        let decoded = Datagram::decode(&mut buf).unwrap();
-        assert_eq!(decoded, msg);
-
-        // DatagramType = ObjectIdStatusExt
-        let msg = Datagram {
-            datagram_type: DatagramType::ObjectIdStatusExt,
-            track_alias: 12,
-            group_id: 10,
-            object_id: Some(1234),
-            publisher_priority: 127,
-            extension_headers: Some(ext_hdrs.clone()),
-            status: Some(ObjectStatus::NormalObject),
-            payload: None,
-        };
-        msg.encode(&mut buf).unwrap();
-        // Length should be: Same as above plus NumExt(1),ExtensionKey(1),ExtensionValueLen(1),ExtensionValue(4) = 7 + 7 = 14
-        assert_eq!(14, buf.len());
-        let decoded = Datagram::decode(&mut buf).unwrap();
-        assert_eq!(decoded, msg);
-
-        // DatagramType = Payload
-        let msg = Datagram {
-            datagram_type: DatagramType::Payload,
-            track_alias: 12,
-            group_id: 10,
-            object_id: None,
-            publisher_priority: 127,
-            extension_headers: None,
-            status: None,
-            payload: Some(Bytes::from("payload")),
-        };
-        msg.encode(&mut buf).unwrap();
-        // Length should be: Type(1)+Alias(1)+GroupId(1)+Priority(1)+Payload(7) = 11
-        assert_eq!(11, buf.len());
-        let decoded = Datagram::decode(&mut buf).unwrap();
-        assert_eq!(decoded, msg);
-
-        // DatagramType = PayloadExt
-        let msg = Datagram {
-            datagram_type: DatagramType::PayloadExt,
-            track_alias: 12,
-            group_id: 10,
-            object_id: None,
-            publisher_priority: 127,
-            extension_headers: Some(ext_hdrs.clone()),
-            status: None,
-            payload: Some(Bytes::from("payload")),
-        };
-        msg.encode(&mut buf).unwrap();
-        // Length should be: Same as above plus NumExt(1),ExtensionKey(1),ExtensionValueLen(1),ExtensionValue(4) = 11 + 7 = 18
-        assert_eq!(18, buf.len());
-        let decoded = Datagram::decode(&mut buf).unwrap();
-        assert_eq!(decoded, msg);
-
-        // DatagramType = PayloadEndOfGroup
-        let msg = Datagram {
-            datagram_type: DatagramType::PayloadEndOfGroup,
-            track_alias: 12,
-            group_id: 10,
-            object_id: None,
-            publisher_priority: 127,
-            extension_headers: None,
-            status: None,
-            payload: Some(Bytes::from("payload")),
-        };
-        msg.encode(&mut buf).unwrap();
-        // Length should be: Type(1)+Alias(1)+GroupId(1)+Priority(1)+Payload(7) = 11
-        assert_eq!(11, buf.len());
-        let decoded = Datagram::decode(&mut buf).unwrap();
-        assert_eq!(decoded, msg);
-
-        // DatagramType = PayloadExtEndOfGroup
-        let msg = Datagram {
-            datagram_type: DatagramType::PayloadExtEndOfGroup,
-            track_alias: 12,
-            group_id: 10,
-            object_id: None,
-            publisher_priority: 127,
-            extension_headers: Some(ext_hdrs.clone()),
-            status: None,
-            payload: Some(Bytes::from("payload")),
-        };
-        msg.encode(&mut buf).unwrap();
-        // Length should be: Same as above plus NumExt(1),ExtensionKey(1),ExtensionValueLen(1),ExtensionValue(4) = 11 + 7 = 18
-        assert_eq!(18, buf.len());
-        let decoded = Datagram::decode(&mut buf).unwrap();
-        assert_eq!(decoded, msg);
+    fn classifies_exact_draft_18_type_registry() {
+        for code in 0u8..=0x3f {
+            let mut encoded = Bytes::from(vec![code]);
+            let decoded = DatagramType::decode(&mut encoded);
+            let expected = VALID_TYPES
+                .iter()
+                .find(|(valid, _)| *valid == u64::from(code));
+            match expected {
+                Some((_, expected)) => assert_eq!(decoded.unwrap(), *expected),
+                None => assert!(matches!(decoded, Err(DecodeError::InvalidDatagramType))),
+            }
+        }
     }
 
     #[test]
-    fn encode_datagram_missing_fields() {
-        let mut buf = BytesMut::new();
-
-        // DatagramType = ObjectIdPayloadExt - missing extensions
-        let msg = Datagram {
-            datagram_type: DatagramType::ObjectIdPayloadExt,
-            track_alias: 12,
-            group_id: 10,
-            object_id: Some(1234),
-            publisher_priority: 127,
-            extension_headers: None,
-            status: None,
-            payload: Some(Bytes::from("payload")),
-        };
-        let encoded = msg.encode(&mut buf);
-        assert!(matches!(encoded.unwrap_err(), EncodeError::MissingField(_)));
-
-        // DatagramType = ObjectIdPayloadExtEndOfGroup - missing extensions
-        let msg = Datagram {
-            datagram_type: DatagramType::ObjectIdPayloadExtEndOfGroup,
-            track_alias: 12,
-            group_id: 10,
-            object_id: Some(1234),
-            publisher_priority: 127,
-            extension_headers: None,
-            status: None,
-            payload: Some(Bytes::from("payload")),
-        };
-        let encoded = msg.encode(&mut buf);
-        assert!(matches!(encoded.unwrap_err(), EncodeError::MissingField(_)));
-
-        // DatagramType = ObjectIdPayloadExtEndOfGroup - missing extensions
-        let msg = Datagram {
-            datagram_type: DatagramType::ObjectIdPayloadExtEndOfGroup,
-            track_alias: 12,
-            group_id: 10,
-            object_id: Some(1234),
-            publisher_priority: 127,
-            extension_headers: None,
-            status: Some(ObjectStatus::EndOfTrack),
-            payload: None,
-        };
-        let encoded = msg.encode(&mut buf);
-        assert!(matches!(encoded.unwrap_err(), EncodeError::MissingField(_)));
-
-        // DatagramType = Payload - missing payload
-        let msg = Datagram {
-            datagram_type: DatagramType::Payload,
-            track_alias: 12,
-            group_id: 10,
-            object_id: None,
-            publisher_priority: 127,
-            extension_headers: None,
-            status: None,
-            payload: None,
-        };
-        let encoded = msg.encode(&mut buf);
-        assert!(matches!(encoded.unwrap_err(), EncodeError::MissingField(_)));
-
-        // DatagramType = ObjectIdStatus - missing status
-        let msg = Datagram {
-            datagram_type: DatagramType::ObjectIdStatus,
-            track_alias: 12,
-            group_id: 10,
-            object_id: Some(1234),
-            publisher_priority: 127,
-            extension_headers: None,
-            status: None,
-            payload: None,
-        };
-        let encoded = msg.encode(&mut buf);
-        assert!(matches!(encoded.unwrap_err(), EncodeError::MissingField(_)));
-
-        // TODO SLG - add tests
+    fn round_trips_every_valid_type_and_field_shape() {
+        for (code, datagram_type) in VALID_TYPES {
+            let expected = datagram(*datagram_type);
+            let mut encoded = BytesMut::new();
+            expected.encode(&mut encoded).unwrap();
+            assert_eq!(encoded[0], *code as u8);
+            assert_eq!(Datagram::decode(&mut encoded).unwrap(), expected);
+        }
     }
 
     #[test]
-    fn decode_rejects_extension_bit_with_zero_length() {
-        let data = vec![
-            0x01, // ObjectIdPayloadExt
-            0x01, // track alias
-            0x01, // group id
-            0x01, // object id
-            0x7f, // publisher priority
-            0x00, // extension headers length
-        ];
-        let mut buf: Bytes = data.into();
+    fn decodes_zero_id_default_priority_fixture() {
+        let mut encoded = Bytes::from_static(&[
+            0x0c, // payload, Object ID zero, inherited priority
+            0x01, // Track Alias
+            0x02, // Group ID
+            b't', b'e', b's', b't',
+        ]);
+        let decoded = Datagram::decode(&mut encoded).unwrap();
+        assert_eq!(decoded.datagram_type, DatagramType::PayloadDefaultPriority);
+        assert_eq!(decoded.track_alias, 1);
+        assert_eq!(decoded.group_id, 2);
+        assert_eq!(decoded.object_id, None);
+        assert_eq!(decoded.publisher_priority, None);
+        assert_eq!(decoded.payload, Some(Bytes::from_static(b"test")));
+    }
 
+    #[test]
+    fn rejects_all_status_end_of_group_types() {
+        for code in [0x22, 0x23, 0x26, 0x27, 0x2a, 0x2b, 0x2e, 0x2f] {
+            let mut encoded = Bytes::from(vec![code]);
+            assert!(matches!(
+                DatagramType::decode(&mut encoded),
+                Err(DecodeError::InvalidDatagramType)
+            ));
+        }
+    }
+
+    #[test]
+    fn rejects_trailing_bytes_after_status() {
+        let mut encoded = Bytes::from_static(&[
+            0x20, // status with explicit Object ID and priority
+            0x01, // Track Alias
+            0x02, // Group ID
+            0x03, // Object ID
+            0x7f, // Publisher Priority
+            0x04, // End of Track
+            0xff, // illegal trailing payload
+        ]);
         assert!(matches!(
-            Datagram::decode(&mut buf).unwrap_err(),
-            DecodeError::InvalidValue
+            Datagram::decode(&mut encoded),
+            Err(DecodeError::InvalidValue)
         ));
     }
 
     #[test]
-    fn encode_rejects_extension_bit_with_empty_headers() {
-        let mut buf = BytesMut::new();
-        let msg = Datagram {
-            datagram_type: DatagramType::ObjectIdPayloadExt,
-            track_alias: 1,
-            group_id: 1,
-            object_id: Some(1),
-            publisher_priority: 1,
-            extension_headers: Some(ExtensionHeaders::default()),
-            status: None,
-            payload: Some(Bytes::new()),
-        };
-
+    fn zero_length_normal_object_requires_status_form() {
+        let mut payload_form = Bytes::from_static(&[
+            0x00, // payload with explicit Object ID and priority
+            0x01, // Track Alias
+            0x02, // Group ID
+            0x03, // Object ID
+            0x7f, // Publisher Priority
+        ]);
         assert!(matches!(
-            msg.encode(&mut buf).unwrap_err(),
-            EncodeError::InvalidValue
+            Datagram::decode(&mut payload_form),
+            Err(DecodeError::InvalidValue)
+        ));
+
+        let mut status_form = Bytes::from_static(&[
+            0x20, // status with explicit Object ID and priority
+            0x01, // Track Alias
+            0x02, // Group ID
+            0x03, // Object ID
+            0x7f, // Publisher Priority
+            0x00, // Normal Object
+        ]);
+        let decoded = Datagram::decode(&mut status_form).unwrap();
+        assert_eq!(decoded.status, Some(ObjectStatus::NormalObject));
+        assert_eq!(decoded.payload, None);
+
+        let mut empty_payload = datagram(DatagramType::ObjectIdPayloadEndOfGroup);
+        empty_payload.payload = Some(Bytes::new());
+        assert!(matches!(
+            empty_payload.encode(&mut BytesMut::new()),
+            Err(EncodeError::InvalidValue)
         ));
     }
 
     #[test]
-    fn decode_rejects_non_normal_status_with_extension_headers() {
-        let data = vec![
-            0x21, // ObjectIdStatusExt
-            0x01, // track alias
-            0x01, // group id
-            0x01, // object id
-            0x7f, // publisher priority
-            0x02, // extension headers byte length
-            0x00, // extension delta type
-            0x01, // extension value
-            0x04, // EndOfTrack
-        ];
-        let mut buf: Bytes = data.into();
-
+    fn rejects_non_normal_status_with_properties() {
+        let mut invalid = datagram(DatagramType::ObjectIdStatusExt);
+        invalid.status = Some(ObjectStatus::EndOfTrack);
+        let mut encoded = BytesMut::new();
         assert!(matches!(
-            Datagram::decode(&mut buf).unwrap_err(),
-            DecodeError::InvalidValue
+            invalid.encode(&mut encoded),
+            Err(EncodeError::InvalidValue)
+        ));
+
+        let mut wire = BytesMut::new();
+        DatagramType::ObjectIdStatusExt.encode(&mut wire).unwrap();
+        1u64.encode(&mut wire).unwrap();
+        2u64.encode(&mut wire).unwrap();
+        3u64.encode(&mut wire).unwrap();
+        127u8.encode(&mut wire).unwrap();
+        properties().encode(&mut wire).unwrap();
+        ObjectStatus::EndOfTrack.encode(&mut wire).unwrap();
+        assert!(matches!(
+            Datagram::decode(&mut wire),
+            Err(DecodeError::InvalidValue)
         ));
     }
 
     #[test]
-    fn encode_rejects_non_normal_status_with_extension_headers() {
-        let mut ext_hdrs = ExtensionHeaders::new();
-        ext_hdrs.set_intvalue(0, 1);
-        let mut buf = BytesMut::new();
-        let msg = Datagram {
-            datagram_type: DatagramType::ObjectIdStatusExt,
-            track_alias: 1,
-            group_id: 1,
-            object_id: Some(1),
-            publisher_priority: 1,
-            extension_headers: Some(ext_hdrs),
-            status: Some(ObjectStatus::EndOfTrack),
-            payload: None,
-        };
-
+    fn rejects_properties_bit_with_empty_properties() {
+        let mut encoded = Bytes::from_static(&[
+            0x01, // payload with Properties
+            0x01, // Track Alias
+            0x02, // Group ID
+            0x03, // Object ID
+            0x7f, // Publisher Priority
+            0x00, // Properties Length
+            b'x', // payload
+        ]);
         assert!(matches!(
-            msg.encode(&mut buf).unwrap_err(),
-            EncodeError::InvalidValue
+            Datagram::decode(&mut encoded),
+            Err(DecodeError::InvalidValue)
+        ));
+    }
+
+    #[test]
+    fn rejects_fields_that_disagree_with_type_bits() {
+        let mut encoded = BytesMut::new();
+
+        let mut missing_priority = datagram(DatagramType::ObjectIdPayload);
+        missing_priority.publisher_priority = None;
+        assert!(matches!(
+            missing_priority.encode(&mut encoded),
+            Err(EncodeError::MissingField(_))
+        ));
+
+        let mut unexpected_priority = datagram(DatagramType::PayloadDefaultPriority);
+        unexpected_priority.publisher_priority = Some(1);
+        assert!(matches!(
+            unexpected_priority.encode(&mut encoded),
+            Err(EncodeError::InvalidValue)
+        ));
+
+        let mut missing_properties = datagram(DatagramType::ObjectIdPayloadExt);
+        missing_properties.extension_headers = None;
+        assert!(matches!(
+            missing_properties.encode(&mut encoded),
+            Err(EncodeError::MissingField(_))
+        ));
+
+        let mut empty_properties = datagram(DatagramType::ObjectIdPayloadExt);
+        empty_properties.extension_headers = Some(ExtensionHeaders::default());
+        assert!(matches!(
+            empty_properties.encode(&mut encoded),
+            Err(EncodeError::InvalidValue)
         ));
     }
 }

--- a/moq-transport/src/serve/datagram.rs
+++ b/moq-transport/src/serve/datagram.rs
@@ -4,7 +4,7 @@
 
 use std::{fmt, sync::Arc};
 
-use crate::watch::State;
+use crate::{data, watch::State};
 
 use super::{ServeError, Track};
 
@@ -27,6 +27,9 @@ struct DatagramsState {
     // The latest datagram
     latest: Option<Datagram>,
 
+    // The greatest Object location observed, independent of arrival order.
+    largest: Option<(u64, u64)>,
+
     // Increased each time datagram changes.
     epoch: u64,
 
@@ -38,6 +41,7 @@ impl Default for DatagramsState {
     fn default() -> Self {
         Self {
             latest: None,
+            largest: None,
             epoch: 0,
             closed: Ok(()),
         }
@@ -57,6 +61,14 @@ impl DatagramsWriter {
     pub fn write(&mut self, datagram: Datagram) -> Result<(), ServeError> {
         let mut state = self.state.lock_mut().ok_or(ServeError::Cancel)?;
 
+        if datagram.status == data::ObjectStatus::NormalObject {
+            let location = (datagram.group_id, datagram.object_id);
+            state.largest = Some(
+                state
+                    .largest
+                    .map_or(location, |largest| largest.max(location)),
+            );
+        }
         state.latest = Some(datagram);
         state.epoch += 1;
 
@@ -113,10 +125,7 @@ impl DatagramsReader {
     // Returns the largest group/sequence
     pub fn latest(&self) -> Option<(u64, u64)> {
         let state = self.state.lock();
-        state
-            .latest
-            .as_ref()
-            .map(|datagram| (datagram.group_id, datagram.object_id))
+        state.largest
     }
 
     /// Check if the datagrams writer has been closed or dropped.
@@ -132,10 +141,26 @@ pub struct Datagram {
     pub group_id: u64,
     pub object_id: u64,
     pub priority: u8,
+    pub status: data::ObjectStatus,
+    pub end_of_group: bool,
     pub payload: bytes::Bytes,
 
     // Extension headers (for draft-14 compliance, particularly immutable extensions)
     pub extension_headers: crate::data::ExtensionHeaders,
+}
+
+impl Datagram {
+    pub(crate) fn from_data(datagram: data::Datagram, default_priority: u8) -> Self {
+        Self {
+            group_id: datagram.group_id,
+            object_id: datagram.object_id.unwrap_or(0),
+            priority: datagram.publisher_priority.unwrap_or(default_priority),
+            status: datagram.status.unwrap_or(data::ObjectStatus::NormalObject),
+            end_of_group: datagram.datagram_type.end_of_group(),
+            payload: datagram.payload.unwrap_or_default(),
+            extension_headers: datagram.extension_headers.unwrap_or_default(),
+        }
+    }
 }
 
 impl fmt::Debug for Datagram {
@@ -144,8 +169,69 @@ impl fmt::Debug for Datagram {
             .field("object_id", &self.object_id)
             .field("group_id", &self.group_id)
             .field("priority", &self.priority)
+            .field("status", &self.status)
+            .field("end_of_group", &self.end_of_group)
             .field("payload", &self.payload.len())
             .field("extension_headers", &self.extension_headers)
             .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn datagram(group_id: u64, object_id: u64) -> Datagram {
+        Datagram {
+            group_id,
+            object_id,
+            priority: 128,
+            status: data::ObjectStatus::NormalObject,
+            end_of_group: false,
+            payload: bytes::Bytes::from_static(b"payload"),
+            extension_headers: data::ExtensionHeaders::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn latest_delivery_and_largest_location_are_independent() {
+        let track = Arc::new(Track::new(
+            crate::coding::TrackNamespace::from_utf8_path("test"),
+            "datagram",
+        ));
+        let (mut writer, mut reader) = Datagrams { track }.produce();
+        writer.write(datagram(2, 0)).unwrap();
+        writer.write(datagram(1, 9)).unwrap();
+
+        let delivered = reader.read().await.unwrap().unwrap();
+        assert_eq!((delivered.group_id, delivered.object_id), (1, 9));
+        assert_eq!(reader.latest(), Some((2, 0)));
+    }
+
+    #[tokio::test]
+    async fn terminal_status_markers_do_not_advance_largest_location() {
+        let track = Arc::new(Track::new(
+            crate::coding::TrackNamespace::from_utf8_path("test"),
+            "datagram",
+        ));
+        let (mut writer, reader) = Datagrams { track }.produce();
+        writer.write(datagram(2, 0)).unwrap();
+
+        let mut end_of_group = datagram(3, 0);
+        end_of_group.status = data::ObjectStatus::EndOfGroup;
+        end_of_group.payload = bytes::Bytes::new();
+        writer.write(end_of_group).unwrap();
+        assert_eq!(reader.latest(), Some((2, 0)));
+
+        let mut zero_length = datagram(2, 5);
+        zero_length.payload = bytes::Bytes::new();
+        writer.write(zero_length).unwrap();
+        assert_eq!(reader.latest(), Some((2, 5)));
+
+        let mut end_of_track = datagram(4, 0);
+        end_of_track.status = data::ObjectStatus::EndOfTrack;
+        end_of_track.payload = bytes::Bytes::new();
+        writer.write(end_of_track).unwrap();
+        assert_eq!(reader.latest(), Some((2, 5)));
     }
 }

--- a/moq-transport/src/session/mod.rs
+++ b/moq-transport/src/session/mod.rs
@@ -2017,4 +2017,82 @@ mod tests {
         assert_eq!(close.error_code.into_inner(), 0x3);
         drop(client_session);
     }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn truncated_webtransport_datagram_closes_with_protocol_violation() {
+        let (client_transport, server_transport) = test_support::loopback_session_pair().await;
+        let client_peer = client_transport.clone();
+        let client_close = client_transport.clone();
+        let (client, server) = tokio::join!(
+            Session::connect(client_transport, None, Transport::WebTransport),
+            Session::accept(server_transport, None, Transport::WebTransport),
+        );
+        let (client_session, _client_publisher, _client_subscriber) = client.unwrap();
+        let (server_session, _server_publisher, _server_subscriber) = server.unwrap();
+
+        let send_invalid = async move {
+            client_peer
+                .send_datagram(bytes::Bytes::from_static(&[0x0e, 42]))
+                .await
+                .unwrap();
+            client_close.closed().await
+        };
+        let result = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            tokio::join!(server_session.run(), send_invalid)
+        })
+        .await
+        .unwrap();
+
+        assert!(matches!(
+            result.0,
+            Err(SessionError::ProtocolViolation(ref reason)) if reason == "truncated datagram"
+        ));
+        assert!(matches!(
+            result.1,
+            web_transport::Error::Session(web_transport::quinn::SessionError::WebTransportError(
+                web_transport::quinn::WebTransportError::Closed(0x3, _)
+            ))
+        ));
+        drop(client_session);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn truncated_raw_quic_datagram_closes_with_protocol_violation() {
+        let (client_transport, server_transport) = test_support::loopback_raw_session_pair().await;
+        let client_peer = client_transport.clone();
+        let client_close = client_transport.clone();
+        let (client, server) = tokio::join!(
+            Session::connect(client_transport, None, Transport::RawQuic),
+            Session::accept(server_transport, None, Transport::RawQuic),
+        );
+        let (client_session, _client_publisher, _client_subscriber) = client.unwrap();
+        let (server_session, _server_publisher, _server_subscriber) = server.unwrap();
+
+        let send_invalid = async move {
+            client_peer
+                .send_datagram(bytes::Bytes::from_static(&[0x0e, 42]))
+                .await
+                .unwrap();
+            client_close.closed().await
+        };
+        let result = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            tokio::join!(server_session.run(), send_invalid)
+        })
+        .await
+        .unwrap();
+        let (run_result, close_error) = result;
+
+        assert!(matches!(
+            run_result,
+            Err(SessionError::ProtocolViolation(ref reason)) if reason == "truncated datagram"
+        ));
+        let web_transport::Error::Session(web_transport::quinn::SessionError::ConnectionError(
+            web_transport::quinn::quinn::ConnectionError::ApplicationClosed(close),
+        )) = close_error
+        else {
+            panic!("expected raw QUIC application close, got {close_error:?}");
+        };
+        assert_eq!(close.error_code.into_inner(), 0x3);
+        drop(client_session);
+    }
 }

--- a/moq-transport/src/session/publish_received.rs
+++ b/moq-transport/src/session/publish_received.rs
@@ -388,29 +388,18 @@ impl PublishReceivedRecv {
     ///
     /// Mirrors `SubscribeRecv::datagram`.
     pub fn datagram(&mut self, datagram: data::Datagram) -> Result<(), ServeError> {
+        let datagram = serve::Datagram::from_data(datagram, self.default_publisher_priority);
         let writer = self.writer.take().ok_or(ServeError::Done)?;
 
         match writer {
             TrackWriterMode::Track(track) => {
                 let mut datagrams = track.datagrams()?;
-                datagrams.write(serve::Datagram {
-                    group_id: datagram.group_id,
-                    object_id: datagram.object_id.unwrap_or(0),
-                    priority: datagram.publisher_priority,
-                    payload: datagram.payload.unwrap_or_default(),
-                    extension_headers: datagram.extension_headers.unwrap_or_default(),
-                })?;
+                datagrams.write(datagram)?;
                 self.writer = Some(TrackWriterMode::Datagrams(datagrams));
                 Ok(())
             }
             TrackWriterMode::Datagrams(mut datagrams) => {
-                datagrams.write(serve::Datagram {
-                    group_id: datagram.group_id,
-                    object_id: datagram.object_id.unwrap_or(0),
-                    priority: datagram.publisher_priority,
-                    payload: datagram.payload.unwrap_or_default(),
-                    extension_headers: datagram.extension_headers.unwrap_or_default(),
-                })?;
+                datagrams.write(datagram)?;
                 self.writer = Some(TrackWriterMode::Datagrams(datagrams));
                 Ok(())
             }
@@ -568,6 +557,37 @@ mod tests {
             pr.take_reader().is_err(),
             "reader must only be given out once"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn datagram_resolves_publish_default_priority_and_preserves_status() {
+        let (mut publish, mut recv, _subscriber) = make_pair(13).await;
+        recv.default_publisher_priority = 200;
+        let reader = publish.take_reader().unwrap();
+
+        recv.datagram(data::Datagram {
+            datagram_type: data::DatagramType::StatusDefaultPriority,
+            track_alias: 42,
+            group_id: 8,
+            object_id: None,
+            publisher_priority: None,
+            extension_headers: None,
+            status: Some(data::ObjectStatus::EndOfTrack),
+            payload: None,
+        })
+        .unwrap();
+
+        let crate::serve::TrackReaderMode::Datagrams(mut datagrams) = reader.mode().await.unwrap()
+        else {
+            panic!("expected datagram mode");
+        };
+        let datagram = datagrams.read().await.unwrap().unwrap();
+        assert_eq!(datagram.group_id, 8);
+        assert_eq!(datagram.object_id, 0);
+        assert_eq!(datagram.priority, 200);
+        assert_eq!(datagram.status, data::ObjectStatus::EndOfTrack);
+        assert!(!datagram.end_of_group);
+        assert!(datagram.payload.is_empty());
     }
 
     fn subgroup_header(group_id: u64) -> data::SubgroupHeader {

--- a/moq-transport/src/session/subscribe.rs
+++ b/moq-transport/src/session/subscribe.rs
@@ -460,30 +460,19 @@ impl SubscribeRecv {
     }
 
     pub fn datagram(&mut self, datagram: data::Datagram) -> Result<(), ServeError> {
+        let datagram = serve::Datagram::from_data(datagram, self.default_publisher_priority);
         let writer = self.writer.take().ok_or(ServeError::Done)?;
 
         match writer {
             TrackWriterMode::Track(track) => {
                 // convert Track -> Datagrams writer, write, then put Datagrams back
                 let mut datagrams = track.datagrams()?;
-                datagrams.write(serve::Datagram {
-                    group_id: datagram.group_id,
-                    object_id: datagram.object_id.unwrap_or(0),
-                    priority: datagram.publisher_priority,
-                    payload: datagram.payload.unwrap_or_default(),
-                    extension_headers: datagram.extension_headers.unwrap_or_default(),
-                })?;
+                datagrams.write(datagram)?;
                 self.writer = Some(TrackWriterMode::Datagrams(datagrams));
                 Ok(())
             }
             TrackWriterMode::Datagrams(mut datagrams) => {
-                datagrams.write(serve::Datagram {
-                    group_id: datagram.group_id,
-                    object_id: datagram.object_id.unwrap_or(0),
-                    priority: datagram.publisher_priority,
-                    payload: datagram.payload.unwrap_or_default(),
-                    extension_headers: datagram.extension_headers.unwrap_or_default(),
-                })?;
+                datagrams.write(datagram)?;
                 self.writer = Some(TrackWriterMode::Datagrams(datagrams));
                 Ok(())
             }
@@ -510,7 +499,7 @@ mod tests {
         .unwrap()
     }
 
-    async fn test_recv() -> (Subscribe, SubscribeRecv) {
+    async fn test_recv_with_reader() -> (Subscribe, SubscribeRecv, serve::TrackReader) {
         let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
         let subscriber = crate::session::Subscriber::new(
             crate::watch::Queue::default(),
@@ -520,11 +509,48 @@ mod tests {
             crate::session::RequestId::new(0, 1),
             bidi_task_tx,
         );
-        let (writer, _reader) =
+        let (writer, reader) =
             crate::serve::Track::new(TrackNamespace::from_utf8_path("test"), "track").produce();
         let (send, recv, _msg) =
             Subscribe::new(subscriber, 0, writer, KeyValuePairs::default()).unwrap();
+        (send, recv, reader)
+    }
+
+    async fn test_recv() -> (Subscribe, SubscribeRecv) {
+        let (send, recv, _reader) = test_recv_with_reader().await;
         (send, recv)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn datagram_resolves_default_priority_and_preserves_semantics() {
+        let (_send, mut recv, reader) = test_recv_with_reader().await;
+        recv.ok(42, 200).unwrap();
+
+        let mut properties = data::ExtensionHeaders::new();
+        properties.set_intvalue(2, 7);
+        recv.datagram(data::Datagram {
+            datagram_type: data::DatagramType::PayloadExtEndOfGroupDefaultPriority,
+            track_alias: 42,
+            group_id: 3,
+            object_id: None,
+            publisher_priority: None,
+            extension_headers: Some(properties),
+            status: None,
+            payload: Some(bytes::Bytes::from_static(b"payload")),
+        })
+        .unwrap();
+
+        let serve::TrackReaderMode::Datagrams(mut datagrams) = reader.mode().await.unwrap() else {
+            panic!("expected datagram mode");
+        };
+        let datagram = datagrams.read().await.unwrap().unwrap();
+        assert_eq!(datagram.group_id, 3);
+        assert_eq!(datagram.object_id, 0);
+        assert_eq!(datagram.priority, 200);
+        assert_eq!(datagram.status, data::ObjectStatus::NormalObject);
+        assert!(datagram.end_of_group);
+        assert_eq!(datagram.payload, bytes::Bytes::from_static(b"payload"));
+        assert!(datagram.extension_headers.has(2));
     }
 
     /// §10.11: the request stream can die while a data stream is still being

--- a/moq-transport/src/session/subscribed.rs
+++ b/moq-transport/src/session/subscribed.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, Mutex};
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 
-use crate::coding::{Encode, KeyValuePairs, Location, ReasonPhrase};
+use crate::coding::{Encode, EncodeError, KeyValuePairs, Location, ReasonPhrase};
 use crate::message::RequestErrorCode;
 use crate::mlog;
 use crate::serve::{ServeError, TrackReaderMode};
@@ -36,12 +36,11 @@ impl ObjectForwarderState {
     }
 
     fn update_largest_location(&mut self, group_id: u64, object_id: u64) -> Result<(), ServeError> {
-        if let Some(current_largest_location) = self.largest_location {
-            let update_largest_location = Location::new(group_id, object_id);
-            if update_largest_location > current_largest_location {
-                self.largest_location = Some(update_largest_location);
-            }
-        }
+        let location = Location::new(group_id, object_id);
+        self.largest_location = Some(
+            self.largest_location
+                .map_or(location, |largest| largest.max(location)),
+        );
 
         Ok(())
     }
@@ -283,16 +282,44 @@ impl Subscribed {
     }
 
     pub async fn serve(self, track: serve::TrackReader) -> Result<(), SessionError> {
-        self.serve_before(track, None).await
+        let largest_location = track.largest_location();
+        self.serve_with_largest_location(track, largest_location)
+            .await
+    }
+
+    /// Serve using the track position captured when the subscription resolved.
+    ///
+    /// Relays can wait for an upstream subscription after resolving a local
+    /// track. Objects arriving during that wait are part of this subscription,
+    /// not cached history against which its filter should be evaluated again.
+    pub async fn serve_with_largest_location(
+        self,
+        track: serve::TrackReader,
+        largest_location: Option<Location>,
+    ) -> Result<(), SessionError> {
+        self.serve_before(track, None, largest_location).await
     }
 
     /// Serve a track only if acceptance is committed before `deadline`.
     pub async fn serve_with_deadline(
-        mut self,
+        self,
         track: serve::TrackReader,
         deadline: tokio::time::Instant,
     ) -> Result<(), ServeWithDeadlineError> {
-        let result = self.serve_inner(track, Some(deadline)).await;
+        let largest_location = track.largest_location();
+        self.serve_with_deadline_and_largest_location(track, deadline, largest_location)
+            .await
+    }
+
+    pub async fn serve_with_deadline_and_largest_location(
+        mut self,
+        track: serve::TrackReader,
+        deadline: tokio::time::Instant,
+        largest_location: Option<Location>,
+    ) -> Result<(), ServeWithDeadlineError> {
+        let result = self
+            .serve_inner(track, Some(deadline), largest_location)
+            .await;
         let deadline_expired =
             !self.ok && matches!(result, Err(SessionError::Serve(ServeError::Timeout)));
 
@@ -315,8 +342,9 @@ impl Subscribed {
         mut self,
         track: serve::TrackReader,
         deadline: Option<tokio::time::Instant>,
+        largest_location: Option<Location>,
     ) -> Result<(), SessionError> {
-        let res = self.serve_inner(track, deadline).await;
+        let res = self.serve_inner(track, deadline, largest_location).await;
         if let Err(err) = &res {
             self.close(err.clone().into())?;
         }
@@ -328,9 +356,8 @@ impl Subscribed {
         &mut self,
         track: serve::TrackReader,
         deadline: Option<tokio::time::Instant>,
+        largest_location: Option<Location>,
     ) -> Result<(), SessionError> {
-        // Update largest location before sending SubscribeOk
-        let largest_location = track.largest_location();
         self.forwarder
             .prepare_subscribe_ok(largest_location, deadline)?;
 
@@ -782,12 +809,20 @@ impl ObjectForwarder {
                 continue;
             }
 
-            // Determine datagram type based on extension headers presence
             let has_extension_headers = !datagram.extension_headers.is_empty();
-            let datagram_type = if has_extension_headers {
-                data::DatagramType::ObjectIdPayloadExt
-            } else {
-                data::DatagramType::ObjectIdPayload
+            if datagram.status != data::ObjectStatus::NormalObject && !datagram.payload.is_empty() {
+                return Err(EncodeError::InvalidValue.into());
+            }
+            let has_status =
+                datagram.status != data::ObjectStatus::NormalObject || datagram.payload.is_empty();
+            let datagram_type = match (has_status, has_extension_headers, datagram.end_of_group) {
+                (true, _, true) => return Err(EncodeError::InvalidValue.into()),
+                (true, true, false) => data::DatagramType::ObjectIdStatusExt,
+                (true, false, false) => data::DatagramType::ObjectIdStatus,
+                (false, true, true) => data::DatagramType::ObjectIdPayloadExtEndOfGroup,
+                (false, false, true) => data::DatagramType::ObjectIdPayloadEndOfGroup,
+                (false, true, false) => data::DatagramType::ObjectIdPayloadExt,
+                (false, false, false) => data::DatagramType::ObjectIdPayload,
             };
 
             // Bound locally so the logging and largest-location updates below
@@ -798,14 +833,14 @@ impl ObjectForwarder {
                 track_alias: self.track_alias,
                 group_id: datagram.group_id,
                 object_id: Some(object_id),
-                publisher_priority: datagram.priority,
+                publisher_priority: Some(datagram.priority),
                 extension_headers: if has_extension_headers {
                     Some(datagram.extension_headers.clone())
                 } else {
                     None
                 },
-                status: None,
-                payload: Some(datagram.payload),
+                status: has_status.then_some(datagram.status),
+                payload: (!has_status).then_some(datagram.payload),
             };
 
             let payload_len = encoded_datagram
@@ -817,7 +852,7 @@ impl ObjectForwarder {
             encoded_datagram.encode(&mut buffer)?;
 
             tracing::trace!(
-                "[PUBLISHER] serve_datagrams: sending datagram #{} - track_alias={}, group_id={}, object_id={}, priority={}, payload_len={}, extension_headers={:?}, total_encoded_len={}",
+                "[PUBLISHER] serve_datagrams: sending datagram #{} - track_alias={}, group_id={}, object_id={}, priority={:?}, payload_len={}, extension_headers={:?}, total_encoded_len={}",
                 datagram_count + 1,
                 encoded_datagram.track_alias,
                 encoded_datagram.group_id,
@@ -843,10 +878,12 @@ impl ObjectForwarder {
 
             self.publisher.send_datagram(buffer.into()).await?;
 
-            self.state
-                .lock_mut()
-                .ok_or(ServeError::Done)?
-                .update_largest_location(encoded_datagram.group_id, object_id)?;
+            if datagram.status == data::ObjectStatus::NormalObject {
+                self.state
+                    .lock_mut()
+                    .ok_or(ServeError::Done)?
+                    .update_largest_location(encoded_datagram.group_id, object_id)?;
+            }
 
             datagram_count += 1;
         }
@@ -881,7 +918,8 @@ impl ObjectForwarderRecv {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::session::test_support::loopback_session_pair;
+    use crate::coding::Decode;
+    use crate::session::test_support::{loopback_raw_session_pair, loopback_session_pair};
     use crate::session::Reader;
     use bytes::Bytes;
 
@@ -911,6 +949,286 @@ mod tests {
         )
         .unwrap();
         (subscribed, recv, outgoing_recv)
+    }
+
+    async fn forward_datagram(
+        publisher_session: web_transport::Session,
+        peer_session: web_transport::Session,
+        datagram: serve::Datagram,
+    ) -> (data::Datagram, Option<Location>) {
+        let (outgoing, _outgoing_recv) = crate::watch::Queue::default().split();
+        let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+        let publisher = Publisher::new(
+            outgoing,
+            publisher_session,
+            None,
+            crate::session::RequestId::new(0, 1),
+            bidi_task_tx,
+        );
+        let (mut forwarder, _recv) = ObjectForwarder::new(publisher, 42, None);
+        let (writer, reader) = serve::Track::new(
+            crate::coding::TrackNamespace::from_utf8_path("test"),
+            "datagram",
+        )
+        .produce();
+        let mut writer = writer.datagrams().unwrap();
+        writer.write(datagram).unwrap();
+        drop(writer);
+        let serve::TrackReaderMode::Datagrams(reader) = reader.mode().await.unwrap() else {
+            panic!("expected datagram mode");
+        };
+
+        let send = forwarder.serve_datagrams(
+            reader,
+            DeliveryFilter {
+                forward: true,
+                start_location: None,
+                end_group_id: None,
+            },
+        );
+        let receive = async move {
+            let mut encoded = tokio::time::timeout(
+                std::time::Duration::from_secs(2),
+                peer_session.recv_datagram(),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+            data::Datagram::decode(&mut encoded).unwrap()
+        };
+        let (send, received) = tokio::join!(send, receive);
+        send.unwrap();
+        let largest_location = forwarder.state.lock().largest_location;
+        (received, largest_location)
+    }
+
+    fn payload_datagram() -> serve::Datagram {
+        let mut properties = data::ExtensionHeaders::new();
+        properties.set_intvalue(2, 7);
+        serve::Datagram {
+            group_id: 3,
+            object_id: 0,
+            priority: 200,
+            status: data::ObjectStatus::NormalObject,
+            end_of_group: true,
+            payload: Bytes::from_static(b"payload"),
+            extension_headers: properties,
+        }
+    }
+
+    fn assert_payload_datagram((received, largest): (data::Datagram, Option<Location>)) {
+        assert_eq!(
+            received.datagram_type,
+            data::DatagramType::ObjectIdPayloadExtEndOfGroup
+        );
+        assert_eq!(received.track_alias, 42);
+        assert_eq!(received.group_id, 3);
+        assert_eq!(received.object_id, Some(0));
+        assert_eq!(received.publisher_priority, Some(200));
+        assert_eq!(received.status, None);
+        assert_eq!(received.payload, Some(Bytes::from_static(b"payload")));
+        assert!(received.extension_headers.unwrap().has(2));
+        assert_eq!(largest, Some(Location::new(3, 0)));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn forwards_datagram_semantics_over_webtransport() {
+        let (publisher, peer) = loopback_session_pair().await;
+        assert_payload_datagram(forward_datagram(publisher, peer, payload_datagram()).await);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn forwards_datagram_semantics_over_raw_quic() {
+        let (publisher, peer) = loopback_raw_session_pair().await;
+        assert_payload_datagram(forward_datagram(publisher, peer, payload_datagram()).await);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn forwards_datagram_status_without_payload() {
+        let (publisher, peer) = loopback_session_pair().await;
+        let (received, largest) = forward_datagram(
+            publisher,
+            peer,
+            serve::Datagram {
+                group_id: 8,
+                object_id: 9,
+                priority: 201,
+                status: data::ObjectStatus::EndOfTrack,
+                end_of_group: false,
+                payload: Bytes::new(),
+                extension_headers: data::ExtensionHeaders::default(),
+            },
+        )
+        .await;
+        assert_eq!(received.datagram_type, data::DatagramType::ObjectIdStatus);
+        assert_eq!(received.object_id, Some(9));
+        assert_eq!(received.publisher_priority, Some(201));
+        assert_eq!(received.status, Some(data::ObjectStatus::EndOfTrack));
+        assert_eq!(received.payload, None);
+        assert_eq!(largest, None);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn subscription_filter_uses_pre_wait_track_position() {
+        let (publisher_session, peer_session) = loopback_session_pair().await;
+        let (outgoing, mut outgoing_recv) = crate::watch::Queue::default().split();
+        let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+        let publisher = Publisher::new(
+            outgoing,
+            publisher_session,
+            None,
+            crate::session::RequestId::new(0, 1),
+            bidi_task_tx,
+        );
+        let mut params = KeyValuePairs::default();
+        params
+            .set_subscription_filter(&message::SubscriptionFilter {
+                filter_type: message::FilterType::NextGroupStart,
+                start_location: None,
+                end_group_id: None,
+            })
+            .unwrap();
+        let (subscribed, _recv) = Subscribed::new(
+            publisher,
+            message::Subscribe {
+                id: 0,
+                track_namespace: crate::coding::TrackNamespace::from_utf8_path("test"),
+                track_name: "datagram".into(),
+                params,
+            },
+            None,
+        )
+        .unwrap();
+        let (writer, reader) = serve::Track::new(
+            crate::coding::TrackNamespace::from_utf8_path("test"),
+            "datagram",
+        )
+        .produce();
+        let mut writer = writer.datagrams().unwrap();
+        writer.write(payload_datagram()).unwrap();
+        drop(writer);
+
+        let serve = subscribed.serve_with_largest_location(reader, None);
+        let accept = async move {
+            assert!(matches!(
+                outgoing_recv.pop().await,
+                Some(message::Message::SubscribeOk(_))
+            ));
+        };
+        let receive = async move {
+            tokio::time::timeout(
+                std::time::Duration::from_secs(2),
+                peer_session.recv_datagram(),
+            )
+            .await
+            .unwrap()
+            .unwrap()
+        };
+        let (serve, _, mut received) = tokio::join!(serve, accept, receive);
+        serve.unwrap();
+        let received = data::Datagram::decode(&mut received).unwrap();
+        assert_eq!(received.group_id, 3);
+        assert_eq!(received.object_id, Some(0));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn rejects_status_datagram_with_end_of_group_bit() {
+        let (publisher_session, _peer_session) = loopback_session_pair().await;
+        let (outgoing, _outgoing_recv) = crate::watch::Queue::default().split();
+        let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+        let publisher = Publisher::new(
+            outgoing,
+            publisher_session,
+            None,
+            crate::session::RequestId::new(0, 1),
+            bidi_task_tx,
+        );
+        let (mut forwarder, _recv) = ObjectForwarder::new(publisher, 42, None);
+        let (writer, reader) = serve::Track::new(
+            crate::coding::TrackNamespace::from_utf8_path("test"),
+            "datagram",
+        )
+        .produce();
+        let mut writer = writer.datagrams().unwrap();
+        writer
+            .write(serve::Datagram {
+                group_id: 1,
+                object_id: 2,
+                priority: 200,
+                status: data::ObjectStatus::EndOfTrack,
+                end_of_group: true,
+                payload: Bytes::new(),
+                extension_headers: data::ExtensionHeaders::default(),
+            })
+            .unwrap();
+        drop(writer);
+        let serve::TrackReaderMode::Datagrams(reader) = reader.mode().await.unwrap() else {
+            panic!("expected datagram mode");
+        };
+
+        assert!(matches!(
+            forwarder
+                .serve_datagrams(
+                    reader,
+                    DeliveryFilter {
+                        forward: true,
+                        start_location: None,
+                        end_group_id: None,
+                    },
+                )
+                .await,
+            Err(SessionError::Encode(EncodeError::InvalidValue))
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn rejects_non_normal_status_with_payload() {
+        let (publisher_session, _peer_session) = loopback_session_pair().await;
+        let (outgoing, _outgoing_recv) = crate::watch::Queue::default().split();
+        let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+        let publisher = Publisher::new(
+            outgoing,
+            publisher_session,
+            None,
+            crate::session::RequestId::new(0, 1),
+            bidi_task_tx,
+        );
+        let (mut forwarder, _recv) = ObjectForwarder::new(publisher, 42, None);
+        let (writer, reader) = serve::Track::new(
+            crate::coding::TrackNamespace::from_utf8_path("test"),
+            "datagram",
+        )
+        .produce();
+        let mut writer = writer.datagrams().unwrap();
+        writer
+            .write(serve::Datagram {
+                group_id: 1,
+                object_id: 2,
+                priority: 200,
+                status: data::ObjectStatus::EndOfTrack,
+                end_of_group: false,
+                payload: Bytes::from_static(b"invalid"),
+                extension_headers: data::ExtensionHeaders::default(),
+            })
+            .unwrap();
+        drop(writer);
+        let serve::TrackReaderMode::Datagrams(reader) = reader.mode().await.unwrap() else {
+            panic!("expected datagram mode");
+        };
+
+        assert!(matches!(
+            forwarder
+                .serve_datagrams(
+                    reader,
+                    DeliveryFilter {
+                        forward: true,
+                        start_location: None,
+                        end_group_id: None,
+                    },
+                )
+                .await,
+            Err(SessionError::Encode(EncodeError::InvalidValue))
+        ));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/moq-transport/src/session/subscriber.rs
+++ b/moq-transport/src/session/subscriber.rs
@@ -1863,7 +1863,12 @@ impl Subscriber {
     /// Handle reception of a datagram from the QUIC session.
     pub async fn recv_datagram(&mut self, datagram: bytes::Bytes) -> Result<(), SessionError> {
         let mut cursor = io::Cursor::new(datagram);
-        let datagram = data::Datagram::decode(&mut cursor)?;
+        let datagram = data::Datagram::decode(&mut cursor).map_err(|err| match err {
+            crate::coding::DecodeError::More(_) => {
+                SessionError::ProtocolViolation("truncated datagram".to_string())
+            }
+            err => SessionError::Decode(err),
+        })?;
 
         if let Some(ref mlog) = self.mlog {
             if let Ok(mut mlog_guard) = mlog.lock() {
@@ -1925,7 +1930,7 @@ impl Subscriber {
                     .and_then(|s| s.get_mut(&subscribe_id))
                 {
                     tracing::trace!(
-                        "[SUBSCRIBER] recv_datagram (SUBSCRIBE): track_alias={}, group_id={}, object_id={}, publisher_priority={}, status={}, payload_length={}",
+                        "[SUBSCRIBER] recv_datagram (SUBSCRIBE): track_alias={}, group_id={}, object_id={}, publisher_priority={:?}, status={}, payload_length={}",
                         datagram.track_alias,
                         datagram.group_id,
                         datagram.object_id.unwrap_or(0),
@@ -1944,7 +1949,7 @@ impl Subscriber {
                     .and_then(|m| m.get_mut(&publish_id))
                 {
                     tracing::trace!(
-                        "[SUBSCRIBER] recv_datagram (PUBLISH): track_alias={}, group_id={}, object_id={}, publisher_priority={}, status={}, payload_length={}",
+                        "[SUBSCRIBER] recv_datagram (PUBLISH): track_alias={}, group_id={}, object_id={}, publisher_priority={:?}, status={}, payload_length={}",
                         datagram.track_alias,
                         datagram.group_id,
                         datagram.object_id.unwrap_or(0),
@@ -1956,7 +1961,7 @@ impl Subscriber {
             }
             None => {
                 tracing::warn!(
-                    "[SUBSCRIBER] recv_datagram: discarded due to unknown track_alias: track_alias={}, group_id={}, object_id={}, publisher_priority={}, status={}, payload_length={}",
+                    "[SUBSCRIBER] recv_datagram: discarded due to unknown track_alias: track_alias={}, group_id={}, object_id={}, publisher_priority={:?}, status={}, payload_length={}",
                     datagram.track_alias,
                     datagram.group_id,
                     datagram.object_id.unwrap_or(0),
@@ -1973,19 +1978,163 @@ impl Subscriber {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::session::test_support::{loopback_session, loopback_session_pair};
+    use crate::session::test_support::{
+        loopback_raw_session_pair, loopback_session, loopback_session_pair,
+    };
 
     fn test_subscriber(session: web_transport::Session) -> Subscriber {
+        test_subscriber_for_transport(session, super::super::Transport::WebTransport)
+    }
+
+    fn test_subscriber_for_transport(
+        session: web_transport::Session,
+        transport: super::super::Transport,
+    ) -> Subscriber {
         let outgoing = Queue::default().split().0;
         let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
         Subscriber::new(
             outgoing,
             session,
-            super::super::Transport::WebTransport,
+            transport,
             None,
             RequestId::new(0, 1),
             bidi_task_tx,
         )
+    }
+
+    async fn assert_compact_datagram_ingress(
+        receiver_session: web_transport::Session,
+        peer_session: web_transport::Session,
+        transport: super::super::Transport,
+    ) {
+        let subscriber = test_subscriber_for_transport(receiver_session.clone(), transport);
+        let (track_writer, track_reader) =
+            serve::Track::new(TrackNamespace::from_utf8_path("test/ns"), "datagram").produce();
+        let _subscribe =
+            register_test_subscribe_with_priority(&subscriber, track_writer, 0, 42, 200);
+        let receive = tokio::spawn(super::super::Session::run_datagrams(
+            receiver_session,
+            Some(subscriber),
+        ));
+
+        peer_session
+            .send_datagram(bytes::Bytes::from_static(&[
+                0x0e, // payload, EOG, Object ID zero, inherited priority
+                42,   // Track Alias
+                3,    // Group ID
+                b'x',
+            ]))
+            .await
+            .unwrap();
+
+        let mode = tokio::time::timeout(std::time::Duration::from_secs(2), track_reader.mode())
+            .await
+            .unwrap()
+            .unwrap();
+        let serve::TrackReaderMode::Datagrams(mut datagrams) = mode else {
+            panic!("expected datagram delivery");
+        };
+        let datagram = tokio::time::timeout(std::time::Duration::from_secs(2), datagrams.read())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(datagram.group_id, 3);
+        assert_eq!(datagram.object_id, 0);
+        assert_eq!(datagram.priority, 200);
+        assert_eq!(datagram.status, data::ObjectStatus::NormalObject);
+        assert!(datagram.end_of_group);
+        assert_eq!(datagram.payload, bytes::Bytes::from_static(b"x"));
+        receive.abort();
+        assert!(receive.await.unwrap_err().is_cancelled());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn receives_compact_datagram_over_webtransport() {
+        let (receiver, peer) = loopback_session_pair().await;
+        assert_compact_datagram_ingress(receiver, peer, super::super::Transport::WebTransport)
+            .await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn receives_compact_datagram_over_raw_quic() {
+        let (receiver, peer) = loopback_raw_session_pair().await;
+        assert_compact_datagram_ingress(receiver, peer, super::super::Transport::RawQuic).await;
+    }
+
+    async fn assert_compact_publish_datagram_ingress(
+        receiver_session: web_transport::Session,
+        peer_session: web_transport::Session,
+        transport: super::super::Transport,
+    ) {
+        let mut subscriber = test_subscriber_for_transport(receiver_session.clone(), transport);
+        let mut track_extensions = message::TrackExtensions::default();
+        track_extensions.set_default_publisher_priority(200);
+        subscriber
+            .recv_publish(&message::Publish {
+                id: 1,
+                track_namespace: TrackNamespace::from_utf8_path("test/ns"),
+                track_name: "datagram".into(),
+                track_alias: 42,
+                params: KeyValuePairs::default(),
+                track_extensions,
+            })
+            .unwrap();
+        let mut publish = subscriber.publish_received().await.unwrap();
+        let track_reader = publish.take_reader().unwrap();
+        let receive = tokio::spawn(super::super::Session::run_datagrams(
+            receiver_session,
+            Some(subscriber),
+        ));
+
+        peer_session
+            .send_datagram(bytes::Bytes::from_static(&[
+                0x0e, // payload, EOG, Object ID zero, inherited priority
+                42,   // Track Alias
+                3,    // Group ID
+                b'x',
+            ]))
+            .await
+            .unwrap();
+
+        let mode = tokio::time::timeout(std::time::Duration::from_secs(2), track_reader.mode())
+            .await
+            .unwrap()
+            .unwrap();
+        let serve::TrackReaderMode::Datagrams(mut datagrams) = mode else {
+            panic!("expected datagram delivery");
+        };
+        let datagram = tokio::time::timeout(std::time::Duration::from_secs(2), datagrams.read())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(datagram.group_id, 3);
+        assert_eq!(datagram.object_id, 0);
+        assert_eq!(datagram.priority, 200);
+        assert_eq!(datagram.status, data::ObjectStatus::NormalObject);
+        assert!(datagram.end_of_group);
+        assert_eq!(datagram.payload, bytes::Bytes::from_static(b"x"));
+        receive.abort();
+        assert!(receive.await.unwrap_err().is_cancelled());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn receives_compact_publish_datagram_over_webtransport() {
+        let (receiver, peer) = loopback_session_pair().await;
+        assert_compact_publish_datagram_ingress(
+            receiver,
+            peer,
+            super::super::Transport::WebTransport,
+        )
+        .await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn receives_compact_publish_datagram_over_raw_quic() {
+        let (receiver, peer) = loopback_raw_session_pair().await;
+        assert_compact_publish_datagram_ingress(receiver, peer, super::super::Transport::RawQuic)
+            .await;
     }
 
     /// Like `test_subscriber`, but keeps the background-task receiver alive.


### PR DESCRIPTION
## Summary

Draft-18 defines `OBJECT_DATAGRAM` type bits for Object Properties, End of Group, an implicit zero Object ID, inherited Publisher Priority, and Object Status. The existing codec represented only a subset of the valid combinations and could not preserve every Object field through relay forwarding.

This change:

- recognizes all 24 valid `OBJECT_DATAGRAM` types from §11.3.1
- resolves omitted Object IDs and Publisher Priority as specified
- preserves Object Properties, End of Group, Object Status, priority, and location through forwarding
- emits explicit Object ID and Publisher Priority downstream
- rejects invalid status-plus-End-of-Group combinations, truncated datagrams, trailing status payloads, and inconsistent field layouts
- tracks Largest Object using Normal Objects only and preserves the subscription-time snapshot while waiting for an upstream publisher

## Validation

- exhaustive codec coverage for every valid and invalid type
- raw QUIC and WebTransport session tests
- SUBSCRIBE and PUBLISH alias-routing tests
- `cargo test -p moq-transport`
- `cargo test -p moq-relay-ietf`
- `cargo test -p moq-clock-ietf`
- `cargo build --workspace`