### PR TITLE
fix(moq-transport): await publish terminal delivery

### DIFF
--- a/moq-transport/src/session/mod.rs
+++ b/moq-transport/src/session/mod.rs
@@ -25,7 +25,7 @@ pub(crate) use name_registry::NameRegistry;
 pub use publish_namespace::*;
 pub use publish_received::PublishReceived;
 pub(crate) use publish_received::PublishReceivedRecv;
-pub(crate) use published::{split_published_state, PublishedRecv, RequestStreamSink};
+pub(crate) use published::{split_published_state, PublishedRecv};
 pub use published::{Published, PublishedInfo};
 pub use published_namespace::*;
 pub use publisher::*;
@@ -54,11 +54,115 @@ use crate::watch::Queue;
 use crate::{message, setup};
 use std::path::PathBuf;
 
+pub(crate) struct BidiResponse {
+    message: Message,
+    completion: Option<tokio::sync::oneshot::Sender<Result<(), DeliveryError>>>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(crate) enum DeliveryError {
+    Cancelled,
+    Failed,
+}
+
+impl DeliveryError {
+    fn from_session_error(err: &SessionError) -> Self {
+        if err.is_stream_error() {
+            Self::Cancelled
+        } else {
+            Self::Failed
+        }
+    }
+
+    pub(crate) fn into_session_error(self) -> SessionError {
+        match self {
+            Self::Cancelled => SessionError::Serve(crate::serve::ServeError::Cancel),
+            Self::Failed => SessionError::Internal,
+        }
+    }
+}
+
+impl BidiResponse {
+    pub(crate) fn new(message: Message) -> Self {
+        Self {
+            message,
+            completion: None,
+        }
+    }
+
+    pub(crate) fn with_completion(
+        message: Message,
+    ) -> (
+        Self,
+        tokio::sync::oneshot::Receiver<Result<(), DeliveryError>>,
+    ) {
+        let (completion, receipt) = tokio::sync::oneshot::channel();
+        (
+            Self {
+                message,
+                completion: Some(completion),
+            },
+            receipt,
+        )
+    }
+
+    fn complete(&mut self, result: Result<(), DeliveryError>) {
+        if let Some(completion) = self.completion.take() {
+            let _ = completion.send(result);
+        }
+    }
+}
+
+pub(crate) type RequestStreamSink = tokio::sync::mpsc::UnboundedSender<BidiResponse>;
+
 /// Registry mapping bidi-request IDs to a channel for forwarding responses.
 /// When `run_send` pops a response message from the outgoing queue, it checks
 /// this map: if the response's target request ID has a registered sender, the
 /// response is forwarded to the bidi handler task that owns the Writer.
-type BidiResponseMap = Arc<Mutex<HashMap<u64, tokio::sync::mpsc::UnboundedSender<Message>>>>;
+pub(crate) type BidiResponseMap = Arc<Mutex<HashMap<u64, RequestStreamSink>>>;
+
+#[derive(Clone, Copy)]
+enum BidiRequestKind {
+    Subscribe,
+    Publish,
+    Other,
+}
+
+#[derive(Clone, Copy)]
+enum FollowupEnd {
+    PublishDone,
+    OtherTerminal,
+    Cancelled,
+}
+
+struct BidiRequestCleanup {
+    id: u64,
+    kind: BidiRequestKind,
+    publisher: Option<Publisher>,
+    subscriber: Option<Subscriber>,
+    responses: BidiResponseMap,
+}
+
+impl Drop for BidiRequestCleanup {
+    fn drop(&mut self) {
+        if let Ok(mut responses) = self.responses.lock() {
+            responses.remove(&self.id);
+        }
+        match self.kind {
+            BidiRequestKind::Subscribe => {
+                if let Some(publisher) = &self.publisher {
+                    publisher.cancel_subscribe(self.id);
+                }
+            }
+            BidiRequestKind::Publish => {
+                if let Some(subscriber) = &self.subscriber {
+                    subscriber.abort_publish_received(self.id);
+                }
+            }
+            BidiRequestKind::Other => {}
+        }
+    }
+}
 
 /// A bidi response reader future handed from Publisher/Subscriber to
 /// `Session::run`. Boxed so the publisher and subscriber reader loops can
@@ -492,6 +596,10 @@ impl Session {
             request_id.clone(),
             bidi_task_tx.clone(),
         ));
+        let bidi_response_map = publisher
+            .as_ref()
+            .map(|publisher| publisher.bidi_response_map.clone())
+            .unwrap_or_default();
         let subscriber = Some(Subscriber::new(
             outgoing.0,
             webtransport.clone(),
@@ -499,6 +607,7 @@ impl Session {
             mlog_shared.clone(),
             request_id.clone(),
             bidi_task_tx,
+            bidi_response_map.clone(),
         ));
 
         let session = Self {
@@ -513,7 +622,7 @@ impl Session {
             transport,
             connection_path,
             bidi_task_rx,
-            bidi_response_map: Arc::new(Mutex::new(HashMap::new())),
+            bidi_response_map,
         };
 
         (session, publisher, subscriber)
@@ -833,7 +942,7 @@ impl Session {
                     .get(&target_id)
                     .cloned();
                 if let Some(tx) = tx_opt {
-                    if tx.send(msg).is_err() {
+                    if tx.send(BidiResponse::new(msg)).is_err() {
                         tracing::warn!(target_id, "bidi response channel closed, dropping message");
                     }
                 } else {
@@ -940,7 +1049,7 @@ impl Session {
         mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
     ) -> Result<(), SessionError> {
         let mut reader = Reader::new(recv_stream);
-        let mut writer = Writer::new(send_stream);
+        let writer = Writer::new(send_stream);
 
         // Read the first (request) message from the bidi stream. Bound this so a
         // peer that opens a bidi stream but never sends a complete request
@@ -984,12 +1093,18 @@ impl Session {
                 .recv_subscribe_namespace(msg)?;
             return recv.run(writer, reader, mlog).await;
         }
+        let mut writer = ResetOnDropWriter::new(writer);
 
         // Classify the request. One-shot request/response flows are bounded in
         // the response phase below; long-lived flows (SUBSCRIBE, PUBLISH,
         // PUBLISH_NAMESPACE, FETCH) may legitimately stay open until an explicit
         // terminal message and are therefore not bounded.
         let bounded_response = matches!(&msg, Message::TrackStatus(_) | Message::RequestUpdate(_));
+        let request_kind = match &msg {
+            Message::Subscribe(_) => BidiRequestKind::Subscribe,
+            Message::Publish(_) => BidiRequestKind::Publish,
+            _ => BidiRequestKind::Other,
+        };
 
         let req_id = msg.sequenced_request_id();
 
@@ -997,7 +1112,7 @@ impl Session {
         let mut rx = if let Some(id) = req_id {
             request_id.validate_incoming(id)?;
 
-            let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<Message>();
+            let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<BidiResponse>();
             bidi_response_map
                 .lock()
                 .map_err(|_| SessionError::Internal)?
@@ -1006,6 +1121,13 @@ impl Session {
         } else {
             None
         };
+        let _cleanup = req_id.map(|id| BidiRequestCleanup {
+            id,
+            kind: request_kind,
+            publisher: publisher.as_ref().cloned(),
+            subscriber: subscriber.as_ref().cloned(),
+            responses: bidi_response_map.clone(),
+        });
 
         // Dispatch to the appropriate role handler (same as run_recv).
         // Capture the result so cleanup runs unconditionally on error.
@@ -1039,53 +1161,100 @@ impl Session {
 
         // Wait for responses only if dispatch succeeded; otherwise the
         // handlers didn't register anything to respond to.
+        let mut writer_closed = false;
         if dispatch_result.is_ok() {
             if let Some(id) = req_id {
                 if let Some(ref mut rx) = rx {
-                    let pump = async {
-                        while let Some(response) = rx.recv().await {
-                            // One-shot requests (TRACK_STATUS, REQUEST_UPDATE) get
-                            // exactly one reply, so REQUEST_OK ends them just as
-                            // REQUEST_ERROR does. Draft-18 requires the stream be
-                            // FINned after TRACK_STATUS_OK or REQUEST_ERROR
-                            // (§10.14). Treating only the error as terminal held the
-                            // handler slot until BIDI_REQUEST_TIMEOUT, so 128 cheap
-                            // TRACK_STATUS requests could occupy every slot for 30s
-                            // even when the application answered immediately.
-                            let is_terminal = matches!(
-                                response,
-                                Message::RequestError(_)
-                                    | Message::PublishDone(_)
-                                    | Message::PublishNamespaceDone(_)
-                                    | Message::Unsubscribe(_)
-                            ) || (bounded_response
-                                && matches!(response, Message::RequestOk(_)));
-                            if let Err(e) = Self::encode_bidi_response(&mut writer, &response).await
-                            {
-                                tracing::warn!(error = %e, "failed to write bidi response");
-                                break;
-                            }
-                            if is_terminal {
-                                // Give Quinn's connection driver a scheduling
-                                // opportunity to transmit the STREAM data before
-                                // the Writer is dropped (which sends FIN).
-                                tokio::time::sleep(std::time::Duration::ZERO).await;
-                                break;
-                            }
-                        }
-                    };
-
                     let follow_ups =
                         Self::read_request_follow_ups(&mut reader, id, publisher, subscriber);
+                    tokio::pin!(follow_ups);
 
-                    // Whichever side finishes first ends the request, so the
-                    // other is cancelled. `follow_ups` is not cancellation-safe
-                    // (a partly-read frame is lost), which is fine only because
-                    // neither `reader` nor `writer` is used again afterwards.
-                    let both = async {
-                        tokio::select! {
-                            () = pump => Ok(()),
-                            res = follow_ups => res,
+                    // Keep a selected response write indivisible with respect
+                    // to peer follow-ups. Cancelling a partially written frame
+                    // and then FINning would make the peer decode truncated data.
+                    let responses = async {
+                        let mut deferred_publish_done = false;
+                        let mut publish_response_sent = false;
+                        loop {
+                            tokio::select! {
+                                biased;
+                                outgoing = rx.recv() => {
+                                    let Some(mut response) = outgoing else {
+                                        return Ok(false);
+                                    };
+                                    // One-shot requests (TRACK_STATUS, REQUEST_UPDATE) get
+                                    // exactly one reply, so REQUEST_OK ends them just as
+                                    // REQUEST_ERROR does.
+                                    let is_terminal = matches!(
+                                        response.message,
+                                        Message::RequestError(_)
+                                            | Message::PublishDone(_)
+                                            | Message::PublishNamespaceDone(_)
+                                            | Message::Unsubscribe(_)
+                                    ) || (bounded_response
+                                        && matches!(response.message, Message::RequestOk(_)));
+                                    if let Err(err) = Self::encode_bidi_response(
+                                        &mut writer,
+                                        &response.message,
+                                    )
+                                    .await
+                                    {
+                                        response.complete(Err(DeliveryError::from_session_error(&err)));
+                                        tracing::warn!(error = %err, "failed to write bidi response");
+                                        writer.reset(0);
+                                        return Ok(true);
+                                    }
+                                    if is_terminal {
+                                        let finish = writer.finish();
+                                        response.complete(
+                                            finish
+                                                .as_ref()
+                                                .map(|_| ())
+                                                .map_err(DeliveryError::from_session_error),
+                                        );
+                                        if let Err(err) = finish {
+                                            tracing::debug!(error = %err, "failed to FIN bidi response stream");
+                                        }
+                                        return Ok(true);
+                                    }
+                                    if matches!(request_kind, BidiRequestKind::Publish)
+                                        && matches!(response.message, Message::RequestOk(_))
+                                    {
+                                        publish_response_sent = true;
+                                    }
+                                    response.complete(Ok(()));
+                                    if deferred_publish_done {
+                                        return Ok(false);
+                                    }
+                                }
+                                res = &mut follow_ups, if !deferred_publish_done => {
+                                    match res {
+                                        Ok(FollowupEnd::PublishDone)
+                                            if matches!(request_kind, BidiRequestKind::Publish) =>
+                                        {
+                                            // PUBLISH always receives REQUEST_OK or REQUEST_ERROR,
+                                            // even when the publisher sent an early PUBLISH_DONE.
+                                            if publish_response_sent {
+                                                return Ok(false);
+                                            }
+                                            deferred_publish_done = true;
+                                        }
+                                        Ok(FollowupEnd::PublishDone | FollowupEnd::OtherTerminal | FollowupEnd::Cancelled) => {
+                                            return Ok(false);
+                                        }
+                                        Err(err) => return Err(err),
+                                    }
+                                }
+                                stopped = writer.closed() => {
+                                    match stopped {
+                                        Ok(_) => {
+                                            writer.reset(0);
+                                            return Ok(true);
+                                        }
+                                        Err(err) => return Err(err),
+                                    }
+                                }
+                            }
                         }
                     };
 
@@ -1095,39 +1264,33 @@ impl Session {
                     // A protocol violation seen while reading follow-ups has to
                     // reach the caller, which closes the session. Timing out is
                     // not a violation: the slot is reclaimed and the session lives.
-                    dispatch_result = if bounded_response {
-                        match tokio::time::timeout(Self::BIDI_REQUEST_TIMEOUT, both).await {
+                    let request_result = if bounded_response {
+                        match tokio::time::timeout(Self::BIDI_REQUEST_TIMEOUT, responses).await {
                             Ok(res) => res,
                             Err(_) => {
                                 tracing::debug!(
                                     ?req_id,
                                     "one-shot bidi request timed out awaiting response; reclaiming slot"
                                 );
-                                Ok(())
+                                writer.reset(0);
+                                Ok(true)
                             }
                         }
                     } else {
-                        both.await
+                        responses.await
                     };
+                    match request_result {
+                        Ok(closed) => writer_closed = closed,
+                        Err(err) => dispatch_result = Err(err),
+                    }
                 }
             }
         }
 
-        // The request stream is over. Release everything keyed by this request
-        // ID — a stream that dies without a terminal message would otherwise
-        // leak its state (and leave the application blocked on `closed()`) for
-        // the life of the session. Runs on both success and error paths.
-        if let Some(id) = req_id {
-            if let Some(subscriber) = subscriber.as_ref() {
-                subscriber.abort_publish_received(id);
-            }
-            if let Ok(mut map) = bidi_response_map.lock() {
-                map.remove(&id);
-            }
-        }
-
         // Explicitly finish the stream and yield for Quinn to flush.
-        let _ = writer.finish();
+        if !writer_closed {
+            let _ = writer.finish();
+        }
         tokio::task::yield_now().await;
 
         dispatch_result
@@ -1155,7 +1318,7 @@ impl Session {
         request_id: u64,
         publisher: &mut Option<Publisher>,
         subscriber: &mut Option<Subscriber>,
-    ) -> Result<(), SessionError> {
+    ) -> Result<FollowupEnd, SessionError> {
         loop {
             let msg = match Self::decode_bidi_response(reader, request_id).await {
                 Ok(msg) => msg,
@@ -1164,7 +1327,7 @@ impl Session {
                 // let a peer pin one slot per reset stream.
                 Err(err) if err.is_stream_error() => {
                     tracing::debug!(request_id, error = %err, "request stream reset by peer");
-                    return Ok(());
+                    return Ok(FollowupEnd::Cancelled);
                 }
                 // A clean FIN of the requester's send half is different: it only
                 // means no more requests are coming on this stream, not that the
@@ -1173,20 +1336,20 @@ impl Session {
                 // keeps the response side alive.
                 Err(err) if err.is_stream_ended() => {
                     tracing::trace!(request_id, error = %err, "request stream send half finished");
-                    std::future::pending::<()>().await;
-                    return Ok(());
+                    return std::future::pending::<Result<FollowupEnd, SessionError>>().await;
                 }
                 // Draft-18 requires closing the session on an unknown message
                 // type, so an undecodable frame is not something to skip past.
                 Err(err) => return Err(err),
             };
 
-            let terminal = matches!(
-                msg,
-                Message::PublishDone(_)
-                    | Message::PublishNamespaceDone(_)
-                    | Message::Unsubscribe(_)
-            );
+            let terminal = match &msg {
+                Message::PublishDone(_) => Some(FollowupEnd::PublishDone),
+                Message::PublishNamespaceDone(_) | Message::Unsubscribe(_) => {
+                    Some(FollowupEnd::OtherTerminal)
+                }
+                _ => None,
+            };
 
             let dispatched = match TryInto::<message::Publisher>::try_into(msg) {
                 Ok(msg) => subscriber
@@ -1215,8 +1378,8 @@ impl Session {
                 return Err(err);
             }
 
-            if terminal {
-                return Ok(());
+            if let Some(terminal) = terminal {
+                return Ok(terminal);
             }
         }
     }
@@ -1716,6 +1879,521 @@ pub(crate) mod test_support {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    async fn open_inbound_subscribe() -> (
+        web_transport::Session,
+        Publisher,
+        Subscribed,
+        Writer,
+        Reader,
+        tokio::task::JoinHandle<Result<(), SessionError>>,
+    ) {
+        let (requester, responder) = test_support::loopback_session_pair().await;
+        let (outgoing, _outgoing_recv) = Queue::default().split();
+        let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+        let request_ids = RequestId::new(1, 0);
+        let mut publisher = Publisher::new(
+            outgoing,
+            responder.clone(),
+            None,
+            request_ids.clone(),
+            bidi_task_tx,
+        );
+        let responses = publisher.bidi_response_map.clone();
+        let (send_stream, recv_stream) = requester.open_bi().await.unwrap();
+        let mut request_writer = Writer::new(send_stream);
+        request_writer
+            .encode(&Message::Subscribe(message::Subscribe {
+                id: 0,
+                track_namespace: crate::coding::TrackNamespace::from_utf8_path("test"),
+                track_name: "track".into(),
+                params: KeyValuePairs::default(),
+            }))
+            .await
+            .unwrap();
+        let response_reader = Reader::new(recv_stream);
+        let (response_stream, request_stream) = responder.accept_bi().await.unwrap();
+        let handler_publisher = publisher.clone();
+        let handler = tokio::spawn(async move {
+            let mut publisher = Some(handler_publisher);
+            let mut subscriber = None;
+            Session::handle_bidi_request(
+                response_stream,
+                request_stream,
+                &mut publisher,
+                &mut subscriber,
+                &request_ids,
+                &responses,
+                None,
+            )
+            .await
+        });
+        let subscribed =
+            tokio::time::timeout(std::time::Duration::from_secs(2), publisher.subscribed())
+                .await
+                .unwrap()
+                .unwrap();
+        (
+            requester,
+            publisher,
+            subscribed,
+            request_writer,
+            response_reader,
+            handler,
+        )
+    }
+
+    fn create_subgroup(
+        subgroups: &mut crate::serve::SubgroupsWriter,
+        group_id: u64,
+    ) -> crate::serve::SubgroupWriter {
+        let mut subgroup = subgroups
+            .create(crate::serve::Subgroup {
+                group_id,
+                subgroup_id: 0,
+                priority: 128,
+            })
+            .unwrap();
+        subgroup.write(bytes::Bytes::from_static(b"x")).unwrap();
+        subgroup
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn inbound_subscribe_orders_ok_before_done_and_fins_with_exact_stream_count() {
+        for expected_stream_count in [0, 2] {
+            let (
+                requester,
+                _publisher,
+                subscribed,
+                mut request_writer,
+                mut response_reader,
+                handler,
+            ) = open_inbound_subscribe().await;
+            request_writer.finish().unwrap();
+            let (writer, reader) = crate::serve::Track::new(
+                crate::coding::TrackNamespace::from_utf8_path("test"),
+                "track",
+            )
+            .produce();
+            let mut subgroups = writer.subgroups().unwrap();
+            let serve = tokio::spawn(subscribed.serve(reader));
+
+            assert!(matches!(
+                Session::decode_bidi_response(&mut response_reader, 0)
+                    .await
+                    .unwrap(),
+                Message::SubscribeOk(_)
+            ));
+            for group_id in 0..expected_stream_count {
+                drop(create_subgroup(&mut subgroups, group_id));
+                let stream = requester.accept_uni().await.unwrap();
+                let mut reader = Reader::new(stream);
+                let _: crate::data::StreamHeader = reader.decode().await.unwrap();
+                let object: crate::data::SubgroupObjectExt = reader.decode().await.unwrap();
+                assert_eq!(
+                    reader
+                        .read_chunk(object.payload_length)
+                        .await
+                        .unwrap()
+                        .unwrap(),
+                    b"x"[..]
+                );
+                assert!(reader.done().await.unwrap());
+            }
+            drop(subgroups);
+
+            let Message::PublishDone(done) = Session::decode_bidi_response(&mut response_reader, 0)
+                .await
+                .unwrap()
+            else {
+                panic!("expected PUBLISH_DONE after SUBSCRIBE_OK");
+            };
+            assert_eq!(done.stream_count, expected_stream_count);
+            assert!(response_reader.done().await.unwrap());
+            serve.await.unwrap().unwrap();
+            handler.await.unwrap().unwrap();
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn inbound_subscribe_source_failure_sends_done_before_returning_error() {
+        let (_requester, _publisher, subscribed, mut request_writer, mut response_reader, handler) =
+            open_inbound_subscribe().await;
+        request_writer.finish().unwrap();
+        let (writer, reader) = crate::serve::Track::new(
+            crate::coding::TrackNamespace::from_utf8_path("test"),
+            "track",
+        )
+        .produce();
+        let subgroups = writer.subgroups().unwrap();
+        let serve = tokio::spawn(subscribed.serve(reader));
+        assert!(matches!(
+            Session::decode_bidi_response(&mut response_reader, 0)
+                .await
+                .unwrap(),
+            Message::SubscribeOk(_)
+        ));
+        subgroups
+            .close(crate::serve::ServeError::Closed(0x42))
+            .unwrap();
+
+        let Message::PublishDone(done) = Session::decode_bidi_response(&mut response_reader, 0)
+            .await
+            .unwrap()
+        else {
+            panic!("expected PUBLISH_DONE for source failure");
+        };
+        assert_eq!(done.status_code, 0x42);
+        assert_eq!(done.stream_count, 0);
+        assert!(response_reader.done().await.unwrap());
+        assert!(matches!(
+            serve.await.unwrap(),
+            Err(SessionError::Serve(crate::serve::ServeError::Closed(0x42)))
+        ));
+        handler.await.unwrap().unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn inbound_subscribe_peer_stop_cancels_and_resets_incomplete_subgroup() {
+        let (requester, _publisher, subscribed, _request_writer, mut response_reader, handler) =
+            open_inbound_subscribe().await;
+        let (writer, reader) = crate::serve::Track::new(
+            crate::coding::TrackNamespace::from_utf8_path("test"),
+            "track",
+        )
+        .produce();
+        let mut subgroups = writer.subgroups().unwrap();
+        let serve = tokio::spawn(subscribed.serve(reader));
+        assert!(matches!(
+            Session::decode_bidi_response(&mut response_reader, 0)
+                .await
+                .unwrap(),
+            Message::SubscribeOk(_)
+        ));
+        let subgroup = create_subgroup(&mut subgroups, 0);
+        let stream = requester.accept_uni().await.unwrap();
+        let mut data_reader = Reader::new(stream);
+        let _: crate::data::StreamHeader = data_reader.decode().await.unwrap();
+        let object: crate::data::SubgroupObjectExt = data_reader.decode().await.unwrap();
+        assert_eq!(
+            data_reader
+                .read_chunk(object.payload_length)
+                .await
+                .unwrap()
+                .unwrap(),
+            b"x"[..]
+        );
+
+        response_reader.stop(0);
+        assert!(matches!(
+            serve.await.unwrap(),
+            Err(SessionError::Serve(crate::serve::ServeError::Cancel))
+        ));
+        assert!(matches!(
+            data_reader.done().await,
+            Err(SessionError::WebTransport(web_transport::Error::Read(
+                web_transport::quinn::ReadError::Reset(0)
+            )))
+        ));
+        handler.await.unwrap().unwrap();
+        drop(subgroup);
+        drop(subgroups);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn dropping_inbound_driver_cancels_active_subscribe() {
+        let (requester, _publisher, subscribed, _request_writer, mut response_reader, handler) =
+            open_inbound_subscribe().await;
+        let (writer, reader) = crate::serve::Track::new(
+            crate::coding::TrackNamespace::from_utf8_path("test"),
+            "track",
+        )
+        .produce();
+        let mut subgroups = writer.subgroups().unwrap();
+        let serve = tokio::spawn(subscribed.serve(reader));
+        assert!(matches!(
+            Session::decode_bidi_response(&mut response_reader, 0)
+                .await
+                .unwrap(),
+            Message::SubscribeOk(_)
+        ));
+        let subgroup = create_subgroup(&mut subgroups, 0);
+        let stream = requester.accept_uni().await.unwrap();
+        let mut data_reader = Reader::new(stream);
+        let _: crate::data::StreamHeader = data_reader.decode().await.unwrap();
+        let object: crate::data::SubgroupObjectExt = data_reader.decode().await.unwrap();
+        let _ = data_reader
+            .read_chunk(object.payload_length)
+            .await
+            .unwrap()
+            .unwrap();
+
+        handler.abort();
+        assert!(handler.await.unwrap_err().is_cancelled());
+        assert!(matches!(
+            serve.await.unwrap(),
+            Err(SessionError::Serve(crate::serve::ServeError::Cancel))
+        ));
+        assert!(matches!(
+            data_reader.done().await,
+            Err(SessionError::WebTransport(web_transport::Error::Read(
+                web_transport::quinn::ReadError::Reset(0)
+            )))
+        ));
+        drop(subgroup);
+        drop(subgroups);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn inbound_publish_early_done_still_receives_mandatory_response() {
+        let (requester, responder) = test_support::loopback_session_pair().await;
+        let (outgoing, _outgoing_recv) = Queue::default().split();
+        let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+        let request_ids = RequestId::new(1, 0);
+        let responses = BidiResponseMap::default();
+        let mut subscriber = Subscriber::new(
+            outgoing,
+            responder.clone(),
+            Transport::WebTransport,
+            None,
+            request_ids.clone(),
+            bidi_task_tx,
+            responses.clone(),
+        );
+        let (send_stream, recv_stream) = requester.open_bi().await.unwrap();
+        let mut request_writer = Writer::new(send_stream);
+        request_writer
+            .encode(&Message::Publish(message::Publish {
+                id: 0,
+                track_namespace: crate::coding::TrackNamespace::from_utf8_path("test"),
+                track_name: "track".into(),
+                track_alias: 0,
+                params: KeyValuePairs::default(),
+                track_extensions: Default::default(),
+            }))
+            .await
+            .unwrap();
+        Session::encode_bidi_response(
+            &mut request_writer,
+            &Message::PublishDone(message::PublishDone {
+                id: 0,
+                status_code: message::PublishDoneCode::TrackEnded as u64,
+                stream_count: 0,
+                reason: Default::default(),
+            }),
+        )
+        .await
+        .unwrap();
+        request_writer.finish().unwrap();
+        let mut response_reader = Reader::new(recv_stream);
+        let (response_stream, request_stream) = responder.accept_bi().await.unwrap();
+        let handler_subscriber = subscriber.clone();
+        let handler = tokio::spawn(async move {
+            let mut publisher = None;
+            let mut subscriber = Some(handler_subscriber);
+            Session::handle_bidi_request(
+                response_stream,
+                request_stream,
+                &mut publisher,
+                &mut subscriber,
+                &request_ids,
+                &responses,
+                None,
+            )
+            .await
+        });
+
+        let mut publish = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            subscriber.publish_received(),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        publish.accept(true).unwrap();
+        assert!(matches!(
+            Session::decode_bidi_response(&mut response_reader, 0)
+                .await
+                .unwrap(),
+            Message::RequestOk(_)
+        ));
+        assert!(response_reader.done().await.unwrap());
+        handler.await.unwrap().unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn inbound_publish_response_before_done_fins_and_cleans_up() {
+        let (requester, responder) = test_support::loopback_session_pair().await;
+        let (outgoing, _outgoing_recv) = Queue::default().split();
+        let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+        let request_ids = RequestId::new(1, 0);
+        let responses = BidiResponseMap::default();
+        let mut subscriber = Subscriber::new(
+            outgoing,
+            responder.clone(),
+            Transport::WebTransport,
+            None,
+            request_ids.clone(),
+            bidi_task_tx,
+            responses.clone(),
+        );
+        let (send_stream, recv_stream) = requester.open_bi().await.unwrap();
+        let mut request_writer = Writer::new(send_stream);
+        request_writer
+            .encode(&Message::Publish(message::Publish {
+                id: 0,
+                track_namespace: crate::coding::TrackNamespace::from_utf8_path("test"),
+                track_name: "track".into(),
+                track_alias: 0,
+                params: KeyValuePairs::default(),
+                track_extensions: Default::default(),
+            }))
+            .await
+            .unwrap();
+        let mut response_reader = Reader::new(recv_stream);
+        let (response_stream, request_stream) = responder.accept_bi().await.unwrap();
+        let handler_subscriber = subscriber.clone();
+        let handler_responses = responses.clone();
+        let handler = tokio::spawn(async move {
+            let mut publisher = None;
+            let mut subscriber = Some(handler_subscriber);
+            Session::handle_bidi_request(
+                response_stream,
+                request_stream,
+                &mut publisher,
+                &mut subscriber,
+                &request_ids,
+                &handler_responses,
+                None,
+            )
+            .await
+        });
+
+        let mut publish = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            subscriber.publish_received(),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        publish.accept(true).unwrap();
+        assert!(matches!(
+            Session::decode_bidi_response(&mut response_reader, 0)
+                .await
+                .unwrap(),
+            Message::RequestOk(_)
+        ));
+        assert!(!handler.is_finished());
+
+        Session::encode_bidi_response(
+            &mut request_writer,
+            &Message::PublishDone(message::PublishDone {
+                id: 0,
+                status_code: message::PublishDoneCode::TrackEnded as u64,
+                stream_count: 0,
+                reason: Default::default(),
+            }),
+        )
+        .await
+        .unwrap();
+        request_writer.finish().unwrap();
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), publish.closed())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_secs(2), response_reader.done())
+                .await
+                .unwrap()
+                .unwrap()
+        );
+        tokio::time::timeout(std::time::Duration::from_secs(2), handler)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert!(responses.lock().unwrap().is_empty());
+        assert!(
+            !subscriber.has_subscriber_name(&crate::serve::FullTrackName {
+                namespace: crate::coding::TrackNamespace::from_utf8_path("test"),
+                name: "track".into(),
+            })
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn inbound_publish_rejection_uses_request_stream_fin_and_cleans_up() {
+        let (requester, responder) = test_support::loopback_session_pair().await;
+        let (outgoing, _outgoing_recv) = Queue::default().split();
+        let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+        let request_ids = RequestId::new(1, 0);
+        let responses = BidiResponseMap::default();
+        let mut subscriber = Subscriber::new(
+            outgoing,
+            responder.clone(),
+            Transport::WebTransport,
+            None,
+            request_ids.clone(),
+            bidi_task_tx,
+            responses.clone(),
+        );
+        let (send_stream, recv_stream) = requester.open_bi().await.unwrap();
+        let mut request_writer = Writer::new(send_stream);
+        request_writer
+            .encode(&Message::Publish(message::Publish {
+                id: 0,
+                track_namespace: crate::coding::TrackNamespace::from_utf8_path("test"),
+                track_name: "track".into(),
+                track_alias: 0,
+                params: KeyValuePairs::default(),
+                track_extensions: Default::default(),
+            }))
+            .await
+            .unwrap();
+        request_writer.finish().unwrap();
+        let mut response_reader = Reader::new(recv_stream);
+        let (response_stream, request_stream) = responder.accept_bi().await.unwrap();
+        let handler_subscriber = subscriber.clone();
+        let handler = tokio::spawn(async move {
+            let mut publisher = None;
+            let mut subscriber = Some(handler_subscriber);
+            Session::handle_bidi_request(
+                response_stream,
+                request_stream,
+                &mut publisher,
+                &mut subscriber,
+                &request_ids,
+                &responses,
+                None,
+            )
+            .await
+        });
+
+        drop(
+            tokio::time::timeout(
+                std::time::Duration::from_secs(2),
+                subscriber.publish_received(),
+            )
+            .await
+            .unwrap()
+            .unwrap(),
+        );
+        assert!(matches!(
+            Session::decode_bidi_response(&mut response_reader, 0)
+                .await
+                .unwrap(),
+            Message::RequestError(_)
+        ));
+        assert!(response_reader.done().await.unwrap());
+        handler.await.unwrap().unwrap();
+        assert!(
+            !subscriber.has_subscriber_name(&crate::serve::FullTrackName {
+                namespace: crate::coding::TrackNamespace::from_utf8_path("test"),
+                name: "track".into(),
+            })
+        );
+    }
 
     // ========================================================================
     // normalize_connection_path

--- a/moq-transport/src/session/publish_received.rs
+++ b/moq-transport/src/session/publish_received.rs
@@ -136,10 +136,13 @@ impl PublishReceived {
         let mut params = KeyValuePairs::default();
         params.set_forward(forward);
 
-        self.session.send_message(message::RequestOk {
-            id: self.request_id,
-            params,
-        });
+        self.session.send_publish_response(
+            message::RequestOk {
+                id: self.request_id,
+                params,
+            }
+            .into(),
+        )?;
         self.ok = true;
 
         Ok(())
@@ -227,18 +230,21 @@ impl Drop for PublishReceived {
             _ => RequestErrorCode::InternalError as u64,
         };
 
-        self.session.send_request_error(
-            "publish",
+        if let Err(err) = self.session.send_publish_response(
             message::RequestError {
                 id: self.request_id,
                 error_code,
                 retry_interval: 0,
                 reason: ReasonPhrase("uninterested".to_string()),
-            },
-        );
-
-        // Clean up subscriber-side state for this PUBLISH.
-        self.session.remove_publish_received(self.request_id);
+            }
+            .into(),
+        ) {
+            tracing::debug!(
+                request_id = self.request_id,
+                error = %err,
+                "failed to send inbound PUBLISH rejection"
+            );
+        }
     }
 }
 
@@ -508,7 +514,7 @@ mod tests {
         PublishReceivedRecv,
         crate::session::Subscriber,
     ) {
-        let (pr, recv, subscriber, _outgoing) = make_pair_with_outgoing(request_id).await;
+        let (pr, recv, subscriber, _responses) = make_pair_with_outgoing(request_id).await;
         (pr, recv, subscriber)
     }
 
@@ -520,10 +526,11 @@ mod tests {
         PublishReceived,
         PublishReceivedRecv,
         crate::session::Subscriber,
-        Queue<message::Message>,
+        tokio::sync::mpsc::UnboundedReceiver<crate::session::BidiResponse>,
     ) {
         let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
         let outgoing = Queue::default();
+        let response_map: crate::session::BidiResponseMap = Default::default();
         let subscriber = crate::session::Subscriber::new(
             outgoing.clone(),
             loopback_session().await,
@@ -531,7 +538,10 @@ mod tests {
             None,
             RequestId::new(0, 1),
             bidi_task_tx,
+            response_map.clone(),
         );
+        let (response_tx, response_rx) = tokio::sync::mpsc::unbounded_channel();
+        response_map.lock().unwrap().insert(request_id, response_tx);
         let (writer, reader) =
             Track::new(TrackNamespace::from_utf8_path("test"), "0.mp4").produce();
         let (pr, recv) = PublishReceivedRecv::produce(
@@ -546,7 +556,7 @@ mod tests {
             writer,
             reader,
         );
-        (pr, recv, subscriber, outgoing)
+        (pr, recv, subscriber, response_rx)
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -870,19 +880,20 @@ mod tests {
     /// never resolved.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn accept_answers_with_request_ok() {
-        let (mut pr, _recv, _sub, mut outgoing) = make_pair_with_outgoing(6).await;
+        let (mut pr, _recv, _sub, mut responses) = make_pair_with_outgoing(6).await;
 
         pr.accept(false).expect("accept a fresh PUBLISH");
 
-        let sent = outgoing
-            .pop()
+        let sent = responses
+            .recv()
             .await
             .expect("acceptance is sent to the peer");
-        let message::Message::RequestOk(msg) = sent else {
-            panic!(
+        let msg = match sent.message {
+            message::Message::RequestOk(msg) => msg,
+            other => panic!(
                 "PUBLISH must be accepted with REQUEST_OK, got {}",
-                sent.name()
-            );
+                other.name()
+            ),
         };
         assert_eq!(msg.id, 6, "the response carries the request it answers");
         assert_eq!(

--- a/moq-transport/src/session/published.rs
+++ b/moq-transport/src/session/published.rs
@@ -15,15 +15,15 @@ use std::ops;
 
 use crate::{
     coding::{Location, ReasonPhrase, TrackName, TrackNamespace},
-    message::{self, Message},
+    message,
     serve::{ServeError, TrackReader},
     watch::State,
 };
 
-use super::{DeliveryFilter, ObjectForwarder, Publisher, SessionError};
-
-/// Sink for messages this endpoint writes on its own PUBLISH request stream.
-pub(crate) type RequestStreamSink = tokio::sync::mpsc::UnboundedSender<Message>;
+use super::{
+    BidiResponse, DeliveryError, DeliveryFilter, ObjectForwarder, Publisher, RequestStreamSink,
+    SessionError, StreamCount,
+};
 
 #[derive(Debug, Clone)]
 pub struct PublishedInfo {
@@ -41,12 +41,6 @@ pub(crate) struct PublishedState {
     forward: bool,
     unsubscribed: bool,
     closed: Result<(), ServeError>,
-    /// Subgroup streams opened while serving, recorded when the forwarder
-    /// finishes so `Drop` can report it. Draft-18 requires PUBLISH_DONE to carry
-    /// the exact count, because the subscriber uses it to know how many streams
-    /// may still arrive; reporting 0 tells it to discard state immediately and
-    /// drop objects that were legitimately sent.
-    stream_count: u64,
 }
 
 impl PublishedState {
@@ -56,23 +50,23 @@ impl PublishedState {
             forward,
             unsubscribed: false,
             closed: Ok(()),
-            stream_count: 0,
         }
     }
 }
 
 /// Outbound PUBLISH created by [`Publisher::publish`].
 ///
-/// Dropping without calling [`serve`](Self::serve) sends PUBLISH_DONE with a
-/// generic terminal status. Calling `serve` runs the shared object forwarder;
-/// dropping after the data-plane loop has stopped sends PUBLISH_DONE from this
-/// handle.
+/// Calling [`serve`](Self::serve) runs the shared object forwarder and waits
+/// until PUBLISH_DONE and the request-stream FIN have been committed. Dropping
+/// before that normal terminal path starts makes one guarded best-effort send.
 #[must_use = "serve or drop to send PUBLISH_DONE"]
 pub struct Published {
     publisher: Publisher,
     stream: RequestStreamSink,
     state: State<PublishedState>,
     track: Option<TrackReader>,
+    stream_count: StreamCount,
+    terminal_started: bool,
 
     pub info: PublishedInfo,
 }
@@ -90,6 +84,8 @@ impl Published {
             stream,
             state,
             track: Some(track),
+            stream_count: StreamCount::default(),
+            terminal_started: false,
             info,
         }
     }
@@ -137,10 +133,10 @@ impl Published {
     pub async fn serve(mut self) -> Result<(), SessionError> {
         let res = self.serve_inner().await;
         if let Err(err) = &res {
-            self.close_state(err.clone().into())?;
+            let _ = self.close_state(err.clone().into());
         }
-
-        res
+        let terminal = self.finish().await;
+        res.and(terminal)
     }
 
     async fn serve_inner(&mut self) -> Result<(), SessionError> {
@@ -162,6 +158,7 @@ impl Published {
         let track = self.track.take().ok_or(SessionError::Internal)?;
         let (mut forwarder, recv) =
             ObjectForwarder::new(self.publisher.clone(), self.info.track_alias, None);
+        self.stream_count = forwarder.stream_count_handle();
         self.publisher
             .register_published_subscription(self.info.id, recv)?;
 
@@ -178,25 +175,36 @@ impl Published {
             res => res,
         };
 
-        // Record the count before the forwarder goes out of scope; `Drop` needs
-        // it for PUBLISH_DONE and has no other way to reach it.
-        self.record_stream_count(forwarder.stream_count());
-
         result
     }
 
-    /// Store the number of subgroup streams opened, for PUBLISH_DONE on drop.
-    fn record_stream_count(&self, stream_count: u64) {
-        let Ok(state) = self.state.try_lock() else {
-            tracing::error!(
-                request_id = self.info.id,
-                "published state lock poisoned; PUBLISH_DONE will under-report stream count"
-            );
-            return;
+    async fn finish(&mut self) -> Result<(), SessionError> {
+        let (err, stream_count) = {
+            let state = self.state.lock();
+            let Some(err) = publish_done_error_on_drop(&state) else {
+                return Ok(());
+            };
+            (err, self.stream_count.get())
         };
-        if let Some(mut state) = state.into_mut() {
-            state.stream_count = stream_count;
-        }
+
+        self.terminal_started = true;
+        let (response, receipt) = BidiResponse::with_completion(
+            message::PublishDone {
+                id: self.info.id,
+                status_code: publish_done_code(&err),
+                stream_count,
+                reason: ReasonPhrase("publish ended".to_string()),
+            }
+            .into(),
+        );
+        self.stream
+            .send(response)
+            .map_err(|_| DeliveryError::Cancelled.into_session_error())?;
+        let result = receipt
+            .await
+            .map_err(|_| DeliveryError::Cancelled.into_session_error())?
+            .map_err(DeliveryError::into_session_error);
+        result
     }
 
     pub fn close(self, err: ServeError) -> Result<(), ServeError> {
@@ -227,6 +235,10 @@ impl ops::Deref for Published {
 
 impl Drop for Published {
     fn drop(&mut self) {
+        if self.terminal_started {
+            return;
+        }
+
         let state = match self.state.try_lock() {
             Ok(state) => state,
             Err(_) => {
@@ -240,14 +252,12 @@ impl Drop for Published {
         let Some(err) = publish_done_error_on_drop(&state) else {
             return;
         };
-        let stream_count = state.stream_count;
+        let stream_count = self.stream_count.get();
         drop(state);
-
-        self.publisher.drop_published(self.info.id);
 
         if self
             .stream
-            .send(
+            .send(BidiResponse::new(
                 message::PublishDone {
                     id: self.info.id,
                     status_code: publish_done_code(&err),
@@ -255,7 +265,7 @@ impl Drop for Published {
                     reason: ReasonPhrase("publish ended".to_string()),
                 }
                 .into(),
-            )
+            ))
             .is_err()
         {
             tracing::debug!(

--- a/moq-transport/src/session/publisher.rs
+++ b/moq-transport/src/session/publisher.rs
@@ -19,10 +19,10 @@ use crate::{
 use crate::watch::Queue;
 
 use super::{
-    split_published_state, NameRegistry, ObjectForwarderRecv, PublishNamespace,
-    PublishNamespaceRecv, Published, PublishedInfo, PublishedRecv, RequestId, Session,
-    SessionError, Subscribed, SubscribedNamespace, SubscribedNamespaceInfo,
-    SubscribedNamespaceRecv, TrackStatusRequested,
+    split_published_state, BidiResponse, BidiResponseMap, DeliveryError, NameRegistry,
+    ObjectForwarderRecv, PublishNamespace, PublishNamespaceRecv, Published, PublishedInfo,
+    PublishedRecv, RequestId, Session, SessionError, Subscribed, SubscribedNamespace,
+    SubscribedNamespaceInfo, SubscribedNamespaceRecv, TrackStatusRequested,
 };
 use crate::message::RequestErrorCode;
 
@@ -49,6 +49,33 @@ impl PublishedEntry {
             forwarder.recv_unsubscribe()?;
         }
         Ok(())
+    }
+}
+
+struct AbortPublishedOnDrop {
+    publisher: Publisher,
+    request_id: Option<u64>,
+}
+
+impl AbortPublishedOnDrop {
+    fn complete(&mut self) {
+        if let Some(request_id) = self.request_id.take() {
+            self.publisher.drop_published(request_id);
+        }
+    }
+
+    fn cancel_from_peer(&mut self) {
+        if let Some(request_id) = self.request_id.take() {
+            self.publisher.cancel_published(request_id);
+        }
+    }
+}
+
+impl Drop for AbortPublishedOnDrop {
+    fn drop(&mut self) {
+        if let Some(request_id) = self.request_id.take() {
+            self.publisher.abort_published(request_id);
+        }
     }
 }
 
@@ -103,6 +130,10 @@ pub struct Publisher {
     /// Channel for sending bidi reader futures to `Session::run`, which polls
     /// them cooperatively under structured concurrency (no task is spawned).
     bidi_task_tx: super::BidiTaskSender,
+
+    /// Inbound request streams owned by `Session::run`. Normal serving waits
+    /// for the owning writer to encode its terminal message and send FIN.
+    pub(super) bidi_response_map: BidiResponseMap,
 }
 
 impl Publisher {
@@ -128,6 +159,7 @@ impl Publisher {
             request_id,
             mlog,
             bidi_task_tx,
+            bidi_response_map: Default::default(),
         }
     }
 
@@ -279,7 +311,7 @@ impl Publisher {
     ///
     /// The request gets its own bidi stream: PUBLISH goes out on it, PUBLISH_OK
     /// / REQUEST_ERROR / UNSUBSCRIBE come back on it, and PUBLISH_DONE is
-    /// written on it when the returned handle is dropped. `Session::run` must
+    /// written on it when serving completes. `Session::run` must
     /// be driven concurrently, since it polls the stream's reader.
     ///
     /// `Published::ok()` is unbounded, matching `Subscriber::subscribe_open`.
@@ -369,14 +401,11 @@ impl Publisher {
             params,
             track_extensions: Default::default(),
         };
-
-        let stream = match self.open_publish_stream(request_id, msg).await {
-            Ok(stream) => stream,
-            Err(err) => {
-                self.drop_published(request_id);
-                return Err(err);
-            }
+        let abort = AbortPublishedOnDrop {
+            publisher: self.clone(),
+            request_id: Some(request_id),
         };
+        let stream = self.open_publish_stream(request_id, msg, abort).await?;
 
         Ok(Published::new(
             self.clone(),
@@ -397,39 +426,60 @@ impl Publisher {
         &mut self,
         request_id: u64,
         msg: message::Publish,
+        abort: AbortPublishedOnDrop,
     ) -> Result<super::RequestStreamSink, SessionError> {
         // Validate local parameters before consuming a peer request-stream slot.
         let frame = super::encode_request_frame(&Message::Publish(msg))?;
         let (send_stream, recv_stream) = self.webtransport.open_bi().await?;
-        let mut writer = super::Writer::new(send_stream);
+        let mut writer = super::ResetOnDropWriter::new(super::Writer::new(send_stream));
         writer.write(&frame).await?;
 
-        let (stream_tx, mut stream_rx) = tokio::sync::mpsc::unbounded_channel::<Message>();
+        let (stream_tx, mut stream_rx) = tokio::sync::mpsc::unbounded_channel::<BidiResponse>();
         let mut this = self.clone();
 
         if self
             .bidi_task_tx
             .send(Box::pin(async move {
+                let mut abort = abort;
                 let mut reader = super::Reader::new(recv_stream);
                 // The peer may finish its half as soon as it has replied
                 // PUBLISH_OK. That does not end the request, so reading stops
                 // while the write half stays open for PUBLISH_DONE.
                 let mut reading = true;
+                let mut writer_closed = false;
 
                 let result = loop {
                     tokio::select! {
                         // Messages we write on our own request stream
                         // (PUBLISH_DONE). Draft-18 omits the Request ID here.
                         outgoing = stream_rx.recv() => {
-                            let Some(outgoing) = outgoing else { break Ok(()) };
-                            let terminal = matches!(outgoing, Message::PublishDone(_));
-                            if let Err(err) = Session::encode_bidi_response(&mut writer, &outgoing).await {
+                            let Some(mut outgoing) = outgoing else { break Ok(()) };
+                            let terminal = matches!(outgoing.message, Message::PublishDone(_));
+                            if let Err(err) = Session::encode_bidi_response(&mut writer, &outgoing.message).await {
+                                outgoing.complete(Err(DeliveryError::from_session_error(&err)));
                                 tracing::debug!(request_id, error = %err, "failed writing on PUBLISH request stream");
+                                writer.reset(0);
+                                writer_closed = true;
                                 break Ok(());
                             }
                             if terminal {
+                                let finish = writer.finish();
+                                writer_closed = true;
+                                if finish.is_ok() {
+                                    abort.complete();
+                                }
+                                outgoing.complete(
+                                    finish
+                                        .as_ref()
+                                        .map(|_| ())
+                                        .map_err(DeliveryError::from_session_error),
+                                );
+                                if let Err(err) = finish {
+                                    tracing::debug!(request_id, error = %err, "failed to FIN PUBLISH request stream");
+                                }
                                 break Ok(());
                             }
+                            outgoing.complete(Ok(()));
                         }
                         // Not cancellation-safe: a frame half-read when the
                         // write branch wins is lost. Safe only because that
@@ -448,6 +498,11 @@ impl Publisher {
                                         "unexpected message on PUBLISH request stream"
                                     ),
                                 },
+                                Err(err) if err.is_stream_error() => {
+                                    tracing::debug!(request_id, error = %err, "PUBLISH response stream reset by peer");
+                                    abort.cancel_from_peer();
+                                    break Ok(());
+                                }
                                 Err(err) if err.is_stream_ended() => {
                                     tracing::debug!(request_id, error = %err, "PUBLISH response reader ended");
                                     reading = false;
@@ -458,14 +513,23 @@ impl Publisher {
                                 Err(err) => break Err(err),
                             }
                         }
+                        stopped = writer.closed() => {
+                            match stopped {
+                                Ok(_) => {
+                                    abort.cancel_from_peer();
+                                    writer.reset(0);
+                                    writer_closed = true;
+                                    break Ok(());
+                                }
+                                Err(err) => break Err(err),
+                            }
+                        }
                     }
                 };
 
-                // Fail the handle if the stream died before PUBLISH_DONE, so a
-                // caller waiting on `ok()` or `closed()` is not stuck forever.
-                // Runs on every exit path, including the error ones.
-                this.abort_published(request_id);
-                let _ = writer.finish();
+                if !writer_closed {
+                    let _ = writer.finish();
+                }
                 result
             }))
             .is_err()
@@ -484,7 +548,9 @@ impl Publisher {
         forwarder: ObjectForwarderRecv,
     ) -> Result<(), SessionError> {
         let mut publisheds = self.publisheds.lock().map_err(|_| SessionError::Internal)?;
-        let entry = publisheds.get_mut(&id).ok_or(SessionError::Internal)?;
+        let entry = publisheds
+            .get_mut(&id)
+            .ok_or(SessionError::Serve(ServeError::Cancel))?;
         entry.forwarder = Some(forwarder);
         Ok(())
     }
@@ -493,9 +559,55 @@ impl Publisher {
         let _ = self.remove_published(id);
     }
 
-    /// Fail an outbound PUBLISH whose request stream ended without a terminal
-    /// message. A no-op once the handle has been dropped, since `Published`
-    /// removes its own entry when it sends PUBLISH_DONE.
+    fn send_bidi_response(
+        &mut self,
+        message: Message,
+    ) -> Result<tokio::sync::oneshot::Receiver<Result<(), DeliveryError>>, SessionError> {
+        let id = message.response_target_id().ok_or(SessionError::Internal)?;
+        Session::log_control_message(&message, "sent");
+        if let Message::SubscribeOk(msg) = &message {
+            self.add_mlog_event(|time| mlog::events::subscribe_ok_created(time, msg.id, msg));
+        }
+
+        let stream = self
+            .bidi_response_map
+            .lock()
+            .map_err(|_| SessionError::Internal)?
+            .get(&id)
+            .cloned()
+            .ok_or_else(|| DeliveryError::Cancelled.into_session_error())?;
+        let (response, receipt) = BidiResponse::with_completion(message);
+        stream
+            .send(response)
+            .map_err(|_| DeliveryError::Cancelled.into_session_error())?;
+        Ok(receipt)
+    }
+
+    async fn send_bidi_response_and_wait(&mut self, message: Message) -> Result<(), SessionError> {
+        let receipt = self.send_bidi_response(message)?;
+        receipt
+            .await
+            .map_err(|_| DeliveryError::Cancelled.into_session_error())?
+            .map_err(DeliveryError::into_session_error)
+    }
+
+    pub(super) fn send_subscribe_ok(
+        &mut self,
+        msg: message::SubscribeOk,
+    ) -> Result<tokio::sync::oneshot::Receiver<Result<(), DeliveryError>>, SessionError> {
+        self.send_bidi_response(msg.into())
+    }
+
+    pub(super) async fn send_publish_done_and_wait(
+        &mut self,
+        msg: message::PublishDone,
+    ) -> Result<(), SessionError> {
+        self.send_bidi_response_and_wait(msg.into()).await
+    }
+
+    /// Fail an outbound PUBLISH whose request stream ended without completing
+    /// terminal delivery. Successful PUBLISH_DONE delivery removes the entry
+    /// before disarming the request-stream guard, making this a no-op.
     fn abort_published(&self, id: u64) {
         let Some(mut published) = self.remove_published(id) else {
             return;
@@ -507,6 +619,15 @@ impl Publisher {
         );
         if let Err(err) = published.recv.recv_error(ServeError::Cancel) {
             tracing::debug!(request_id = id, error = %err, "failed to fail aborted PUBLISH");
+        }
+    }
+
+    fn cancel_published(&self, id: u64) {
+        let Some(mut published) = self.remove_published(id) else {
+            return;
+        };
+        if let Err(err) = published.recv_unsubscribe() {
+            tracing::debug!(request_id = id, error = %err, "failed to cancel reset PUBLISH");
         }
     }
 
@@ -995,14 +1116,10 @@ impl Publisher {
         msg: T,
     ) -> message::Publisher {
         let msg = msg.into();
-        match &msg {
-            message::Publisher::PublishDone(m) => self.drop_subscribe(m.id),
-            // Draft-16: PUBLISH_NAMESPACE_DONE carries Request ID, not namespace.
-            // Dropping the recv state signals that the namespace is done.
-            message::Publisher::PublishNamespaceDone(m) => {
-                let _ = self.drop_publish_namespace(m.id);
-            }
-            _ => {}
+        // Draft-16: PUBLISH_NAMESPACE_DONE carries Request ID, not namespace.
+        // Dropping the recv state signals that the namespace is done.
+        if let message::Publisher::PublishNamespaceDone(m) = &msg {
+            let _ = self.drop_publish_namespace(m.id);
         }
         msg
     }
@@ -1013,20 +1130,17 @@ impl Publisher {
         self.outgoing.push(msg.into()).ok();
     }
 
-    /// Enqueue a control message and wait until it has been dequeued for sending.
-    pub(super) async fn send_message_and_wait<T: Into<message::Publisher> + Into<Message>>(
-        &mut self,
-        msg: T,
-    ) {
-        let msg = self.act_on_message_to_send(msg);
-        self.outgoing
-            .push_and_wait_until_popped(msg.into())
-            .await
-            .ok();
-    }
-
     pub(super) fn drop_subscribe(&mut self, id: u64) {
         let _ = self.remove_subscribe(id);
+    }
+
+    pub(super) fn cancel_subscribe(&self, id: u64) {
+        if let Ok(mut subscribeds) = self.subscribeds.lock() {
+            if let Some(mut subscribed) = subscribeds.remove(&id) {
+                let _ = subscribed.recv_unsubscribe();
+            }
+        }
+        let _ = Self::drop_subscribed_name(&self.subscribed_names, id);
     }
 
     fn remove_subscribe(&mut self, id: u64) -> Result<(), SessionError> {
@@ -1077,17 +1191,29 @@ mod tests {
 
     use crate::{
         coding::{KeyValuePairs, TrackName, TrackNamespace},
+        data,
         message::{self, Message},
-        serve::FullTrackName,
+        serve::{self, FullTrackName},
+        session::{test_support::loopback_session_pair, Reader, RequestId, Session, Writer},
     };
+    use bytes::Bytes;
 
-    use super::{NameRegistry, Publisher};
+    use super::{
+        split_published_state, AbortPublishedOnDrop, NameRegistry, PublishedEntry, PublishedRecv,
+        Publisher,
+    };
 
     fn full_track_name(namespace: &str, name: &str) -> FullTrackName {
         FullTrackName {
             namespace: TrackNamespace::from_utf8_path(namespace),
             name: TrackName::from(name),
         }
+    }
+
+    fn subgroup_track() -> (serve::SubgroupsWriter, serve::TrackReader) {
+        let (writer, reader) =
+            serve::Track::new(TrackNamespace::from_utf8_path("test"), "track").produce();
+        (writer.subgroups().unwrap(), reader)
     }
 
     #[test]
@@ -1128,5 +1254,330 @@ mod tests {
                 crate::coding::EncodeError::InvalidValue
             ))
         ));
+    }
+
+    #[tokio::test]
+    async fn publish_reservation_guard_cleans_up_before_driver_installation() {
+        let (publisher_session, _peer_session) = loopback_session_pair().await;
+        let (outgoing, _outgoing_recv) = crate::watch::Queue::default().split();
+        let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+        let publisher = Publisher::new(
+            outgoing,
+            publisher_session,
+            None,
+            RequestId::new(0, 1),
+            bidi_task_tx,
+        );
+        let request_id = 0;
+        let track = full_track_name("test", "track");
+        publisher
+            .published_names
+            .lock()
+            .unwrap()
+            .insert(track.clone(), request_id);
+        let (_state, recv_state) = split_published_state(true);
+        publisher.publisheds.lock().unwrap().insert(
+            request_id,
+            PublishedEntry::new(PublishedRecv::new(recv_state)),
+        );
+
+        drop(AbortPublishedOnDrop {
+            publisher: publisher.clone(),
+            request_id: Some(request_id),
+        });
+
+        assert!(!publisher
+            .published_names
+            .lock()
+            .unwrap()
+            .contains_name(&track));
+        assert!(!publisher
+            .publisheds
+            .lock()
+            .unwrap()
+            .contains_key(&request_id));
+    }
+
+    #[tokio::test]
+    async fn cancellation_before_forwarder_registration_is_not_internal() {
+        let (publisher_session, _peer_session) = loopback_session_pair().await;
+        let (outgoing, _outgoing_recv) = crate::watch::Queue::default().split();
+        let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut publisher = Publisher::new(
+            outgoing,
+            publisher_session,
+            None,
+            RequestId::new(0, 1),
+            bidi_task_tx,
+        );
+        let (_forwarder, recv) = super::super::ObjectForwarder::new(publisher.clone(), 0, None);
+
+        assert!(matches!(
+            publisher.register_published_subscription(0, recv),
+            Err(crate::session::SessionError::Serve(
+                serve::ServeError::Cancel
+            ))
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn direct_publish_waits_for_encoded_done_and_fin_with_exact_stream_count() {
+        for expected_stream_count in [0, 2] {
+            let (publisher_session, peer_session) = loopback_session_pair().await;
+            let (outgoing, _outgoing_recv) = crate::watch::Queue::default().split();
+            let (bidi_task_tx, mut bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+            let mut publisher = Publisher::new(
+                outgoing,
+                publisher_session,
+                None,
+                RequestId::new(0, 1),
+                bidi_task_tx,
+            );
+            let request_peer = peer_session.clone();
+            let request = tokio::spawn(async move {
+                let (send_stream, recv_stream) = request_peer.accept_bi().await.unwrap();
+                let mut reader = Reader::new(recv_stream);
+                let Message::Publish(publish) = reader.decode().await.unwrap() else {
+                    panic!("expected PUBLISH request");
+                };
+                let mut writer = Writer::new(send_stream);
+                Session::encode_bidi_response(
+                    &mut writer,
+                    &Message::RequestOk(message::RequestOk {
+                        id: publish.id,
+                        params: KeyValuePairs::default(),
+                    }),
+                )
+                .await
+                .unwrap();
+                writer.finish().unwrap();
+                (publish.id, reader)
+            });
+
+            let (mut subgroups, track) = subgroup_track();
+            let published = publisher
+                .publish(track, KeyValuePairs::default())
+                .await
+                .unwrap();
+            let (request_id, mut request_reader) = request.await.unwrap();
+            let request_driver = tokio::spawn(bidi_task_rx.recv().await.unwrap());
+            let serve = tokio::spawn(published.serve());
+            for group_id in 0..expected_stream_count {
+                let mut subgroup = subgroups
+                    .create(serve::Subgroup {
+                        group_id,
+                        subgroup_id: 0,
+                        priority: 128,
+                    })
+                    .unwrap();
+                subgroup.write(Bytes::from_static(b"x")).unwrap();
+                drop(subgroup);
+                let stream = peer_session.accept_uni().await.unwrap();
+                let mut reader = Reader::new(stream);
+                let _: data::StreamHeader = reader.decode().await.unwrap();
+                let object: data::SubgroupObjectExt = reader.decode().await.unwrap();
+                assert_eq!(
+                    reader
+                        .read_chunk(object.payload_length)
+                        .await
+                        .unwrap()
+                        .unwrap(),
+                    b"x"[..]
+                );
+                assert!(reader.done().await.unwrap());
+            }
+            drop(subgroups);
+
+            let Message::PublishDone(done) =
+                Session::decode_bidi_response(&mut request_reader, request_id)
+                    .await
+                    .unwrap()
+            else {
+                panic!("expected PUBLISH_DONE response");
+            };
+            assert_eq!(done.stream_count, expected_stream_count);
+            assert!(request_reader.done().await.unwrap());
+            serve.await.unwrap().unwrap();
+            request_driver.await.unwrap().unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn dropping_direct_publish_driver_unblocks_serve() {
+        let (publisher_session, _peer_session) = loopback_session_pair().await;
+        let (outgoing, _outgoing_recv) = crate::watch::Queue::default().split();
+        let (bidi_task_tx, mut bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut publisher = Publisher::new(
+            outgoing,
+            publisher_session,
+            None,
+            RequestId::new(0, 1),
+            bidi_task_tx,
+        );
+        let (subgroups, track) = subgroup_track();
+        let published = publisher
+            .publish(track, KeyValuePairs::default())
+            .await
+            .unwrap();
+        let driver = bidi_task_rx.recv().await.unwrap();
+        drop(driver);
+        drop(subgroups);
+
+        assert!(matches!(
+            tokio::time::timeout(std::time::Duration::from_secs(2), published.serve())
+                .await
+                .unwrap(),
+            Err(crate::session::SessionError::Serve(
+                serve::ServeError::Cancel
+            ))
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn direct_publish_source_failure_sends_done_before_returning_error() {
+        let (publisher_session, peer_session) = loopback_session_pair().await;
+        let (outgoing, _outgoing_recv) = crate::watch::Queue::default().split();
+        let (bidi_task_tx, mut bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut publisher = Publisher::new(
+            outgoing,
+            publisher_session,
+            None,
+            RequestId::new(0, 1),
+            bidi_task_tx,
+        );
+        let request_peer = peer_session.clone();
+        let request = tokio::spawn(async move {
+            let (send_stream, recv_stream) = request_peer.accept_bi().await.unwrap();
+            let mut reader = Reader::new(recv_stream);
+            let Message::Publish(publish) = reader.decode().await.unwrap() else {
+                panic!("expected PUBLISH request");
+            };
+            let mut writer = Writer::new(send_stream);
+            Session::encode_bidi_response(
+                &mut writer,
+                &Message::RequestOk(message::RequestOk {
+                    id: publish.id,
+                    params: KeyValuePairs::default(),
+                }),
+            )
+            .await
+            .unwrap();
+            writer.finish().unwrap();
+            (publish.id, reader)
+        });
+        let (subgroups, track) = subgroup_track();
+        let published = publisher
+            .publish(track, KeyValuePairs::default())
+            .await
+            .unwrap();
+        let (request_id, mut request_reader) = request.await.unwrap();
+        let request_driver = tokio::spawn(bidi_task_rx.recv().await.unwrap());
+        let serve = tokio::spawn(published.serve());
+        subgroups.close(serve::ServeError::Closed(0x42)).unwrap();
+
+        let Message::PublishDone(done) =
+            Session::decode_bidi_response(&mut request_reader, request_id)
+                .await
+                .unwrap()
+        else {
+            panic!("expected PUBLISH_DONE for source failure");
+        };
+        assert_eq!(done.status_code, 0x42);
+        assert_eq!(done.stream_count, 0);
+        assert!(request_reader.done().await.unwrap());
+        assert!(matches!(
+            serve.await.unwrap(),
+            Err(crate::session::SessionError::Serve(
+                serve::ServeError::Closed(0x42)
+            ))
+        ));
+        request_driver.await.unwrap().unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn direct_publish_peer_cancellation_suppresses_publish_done() {
+        let (publisher_session, peer_session) = loopback_session_pair().await;
+        let (outgoing, _outgoing_recv) = crate::watch::Queue::default().split();
+        let (bidi_task_tx, mut bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut publisher = Publisher::new(
+            outgoing,
+            publisher_session,
+            None,
+            RequestId::new(0, 1),
+            bidi_task_tx,
+        );
+        let request_peer = peer_session.clone();
+        let (cancel_request, wait_to_cancel) = tokio::sync::oneshot::channel();
+        let request = tokio::spawn(async move {
+            let (send_stream, recv_stream) = request_peer.accept_bi().await.unwrap();
+            let mut reader = Reader::new(recv_stream);
+            let Message::Publish(publish) = reader.decode().await.unwrap() else {
+                panic!("expected PUBLISH request");
+            };
+            let mut writer = Writer::new(send_stream);
+            Session::encode_bidi_response(
+                &mut writer,
+                &Message::RequestOk(message::RequestOk {
+                    id: publish.id,
+                    params: KeyValuePairs::default(),
+                }),
+            )
+            .await
+            .unwrap();
+            wait_to_cancel.await.unwrap();
+            writer.reset(0);
+            reader
+        });
+
+        let (mut subgroups, reader) = subgroup_track();
+        let published = publisher
+            .publish(reader, KeyValuePairs::default())
+            .await
+            .unwrap();
+        let request_driver = tokio::spawn(bidi_task_rx.recv().await.unwrap());
+        let serve = tokio::spawn(published.serve());
+        let mut subgroup = subgroups
+            .create(serve::Subgroup {
+                group_id: 0,
+                subgroup_id: 0,
+                priority: 128,
+            })
+            .unwrap();
+        subgroup.write(Bytes::from_static(b"x")).unwrap();
+        let stream = peer_session.accept_uni().await.unwrap();
+        let mut data_reader = Reader::new(stream);
+        let _: data::StreamHeader = data_reader.decode().await.unwrap();
+        let object: data::SubgroupObjectExt = data_reader.decode().await.unwrap();
+        assert_eq!(
+            data_reader
+                .read_chunk(object.payload_length)
+                .await
+                .unwrap()
+                .unwrap(),
+            b"x"[..]
+        );
+        cancel_request.send(()).unwrap();
+
+        let result = tokio::time::timeout(std::time::Duration::from_secs(2), serve)
+            .await
+            .unwrap()
+            .unwrap();
+        result.unwrap();
+        assert!(matches!(
+            data_reader.done().await,
+            Err(crate::session::SessionError::WebTransport(
+                web_transport::Error::Read(web_transport::quinn::ReadError::Reset(0))
+            ))
+        ));
+        let mut request_reader = request.await.unwrap();
+        assert!(request_reader.done().await.unwrap());
+        request_driver.await.unwrap().unwrap();
+        assert!(!publisher
+            .published_names
+            .lock()
+            .unwrap()
+            .contains_name(&full_track_name("test", "track")));
+        drop(subgroup);
+        drop(subgroups);
     }
 }

--- a/moq-transport/src/session/subscribe.rs
+++ b/moq-transport/src/session/subscribe.rs
@@ -508,6 +508,7 @@ mod tests {
             None,
             crate::session::RequestId::new(0, 1),
             bidi_task_tx,
+            Default::default(),
         );
         let (writer, reader) =
             crate::serve::Track::new(TrackNamespace::from_utf8_path("test"), "track").produce();

--- a/moq-transport/src/session/subscribe_namespace.rs
+++ b/moq-transport/src/session/subscribe_namespace.rs
@@ -443,6 +443,7 @@ mod tests {
             None,
             RequestId::new(0, 1),
             bidi_task_tx,
+            Default::default(),
         )
     }
 

--- a/moq-transport/src/session/subscribed.rs
+++ b/moq-transport/src/session/subscribed.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use std::ops;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use futures::stream::FuturesUnordered;
@@ -15,14 +16,16 @@ use crate::serve::{ServeError, TrackReaderMode};
 use crate::watch::State;
 use crate::{data, message, serve};
 
-use super::{DeliveryFilter, Publisher, SessionError, SubscribeInfo, Writer};
+use super::{
+    DeliveryError, DeliveryFilter, Publisher, ResetOnDropWriter, SessionError, SubscribeInfo,
+    Writer,
+};
 
 // This file defines Publisher handling of inbound Subscriptions
 
 #[derive(Debug)]
 struct ObjectForwarderState {
     largest_location: Option<Location>,
-    stream_count: u64,
     retry_interval: u64,
     /// Set to true when UNSUBSCRIBE is received.  When true, Drop skips sending
     /// PUBLISH_DONE or REQUEST_ERROR because the subscriber already terminated.
@@ -31,10 +34,6 @@ struct ObjectForwarderState {
 }
 
 impl ObjectForwarderState {
-    fn record_stream_opened(&mut self) {
-        self.stream_count = self.stream_count.saturating_add(1);
-    }
-
     fn update_largest_location(&mut self, group_id: u64, object_id: u64) -> Result<(), ServeError> {
         let location = Location::new(group_id, object_id);
         self.largest_location = Some(
@@ -50,7 +49,6 @@ impl Default for ObjectForwarderState {
     fn default() -> Self {
         Self {
             largest_location: None,
-            stream_count: 0,
             retry_interval: 0,
             unsubscribed: false,
             closed: Ok(()),
@@ -65,9 +63,30 @@ pub struct Subscribed {
     /// Data-plane half, shared with outbound PUBLISH serving.
     forwarder: ObjectForwarder,
 
-    /// Tracks if SubscribeOk has been sent yet or not. Used to send
-    /// PUBLISH_DONE vs REQUEST_ERROR on drop.
+    /// Tracks whether SubscribeOk was enqueued, which selects PUBLISH_DONE instead
+    /// of REQUEST_ERROR for both normal and abnormal termination.
     ok: bool,
+
+    /// Set before awaiting the terminal receipt so cancellation cannot make
+    /// Drop enqueue a duplicate terminal message.
+    terminal_started: bool,
+}
+
+#[derive(Clone, Default)]
+pub(super) struct StreamCount(Arc<AtomicU64>);
+
+impl StreamCount {
+    fn opened(&self) {
+        let _ = self
+            .0
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |count| {
+                count.checked_add(1)
+            });
+    }
+
+    pub(super) fn get(&self) -> u64 {
+        self.0.load(Ordering::Relaxed)
+    }
 }
 
 /// Failure while serving a track under a pre-acceptance deadline.
@@ -99,52 +118,8 @@ pub(super) struct ObjectForwarder {
 
     /// Optional mlog writer for logging transport events
     mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
-}
 
-struct ResetOnDropWriter {
-    writer: Writer,
-    closed: bool,
-}
-
-impl ResetOnDropWriter {
-    fn new(writer: Writer) -> Self {
-        Self {
-            writer,
-            closed: false,
-        }
-    }
-
-    fn finish(&mut self) -> Result<(), SessionError> {
-        self.closed = true;
-        self.writer.finish()
-    }
-
-    fn reset(&mut self, code: u32) {
-        self.writer.reset(code);
-        self.closed = true;
-    }
-}
-
-impl std::ops::Deref for ResetOnDropWriter {
-    type Target = Writer;
-
-    fn deref(&self) -> &Self::Target {
-        &self.writer
-    }
-}
-
-impl std::ops::DerefMut for ResetOnDropWriter {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.writer
-    }
-}
-
-impl Drop for ResetOnDropWriter {
-    fn drop(&mut self) {
-        if !self.closed {
-            self.writer.reset(0);
-        }
-    }
+    stream_count: StreamCount,
 }
 
 impl ObjectForwarder {
@@ -159,6 +134,7 @@ impl ObjectForwarder {
             state: send,
             track_alias,
             mlog,
+            stream_count: StreamCount::default(),
         };
         let recv = ObjectForwarderRecv { state: recv };
         (send, recv)
@@ -193,11 +169,8 @@ impl ObjectForwarder {
         Ok(())
     }
 
-    /// Subgroup streams opened so far. The PUBLISH path needs this separately
-    /// from [`Self::terminal_state`], because there the terminal message is sent
-    /// by `Published::drop` after the forwarder is gone.
-    pub(super) fn stream_count(&self) -> u64 {
-        self.state.lock().stream_count
+    pub(super) fn stream_count_handle(&self) -> StreamCount {
+        self.stream_count.clone()
     }
 
     /// Snapshot the fields a terminal message needs, without holding the lock
@@ -212,7 +185,7 @@ impl ObjectForwarder {
             .unwrap_or(ServeError::Done);
         (
             err,
-            state.stream_count,
+            self.stream_count.get(),
             state.retry_interval,
             state.unsubscribed,
         )
@@ -276,6 +249,7 @@ impl Subscribed {
             info,
             forwarder,
             ok: false,
+            terminal_started: false,
         };
 
         Ok((send, recv))
@@ -323,19 +297,23 @@ impl Subscribed {
         let deadline_expired =
             !self.ok && matches!(result, Err(SessionError::Serve(ServeError::Timeout)));
 
-        let Err(err) = result else {
-            return Ok(());
-        };
-
         if deadline_expired {
             // A simultaneous UNSUBSCRIBE may have closed the shared state first,
             // but the relay still needs the deadline result for its response and metric.
-            let _ = self.close(err.clone().into());
+            if let Err(err) = &result {
+                let _ = self.forwarder.close(err.clone().into(), 0);
+            }
             return Err(ServeWithDeadlineError::DeadlineExpired);
         }
 
-        self.close(err.clone().into()).map_err(SessionError::from)?;
-        Err(err.into())
+        if let Err(err) = &result {
+            let _ = self.forwarder.close(err.clone().into(), 0);
+        }
+        let terminal = self.finish().await;
+        match result {
+            Ok(()) => terminal.map_err(ServeWithDeadlineError::Session),
+            Err(err) => Err(ServeWithDeadlineError::Session(err)),
+        }
     }
 
     async fn serve_before(
@@ -346,10 +324,10 @@ impl Subscribed {
     ) -> Result<(), SessionError> {
         let res = self.serve_inner(track, deadline, largest_location).await;
         if let Err(err) = &res {
-            self.close(err.clone().into())?;
+            let _ = self.forwarder.close(err.clone().into(), 0);
         }
-
-        res
+        let terminal = self.finish().await;
+        res.and(terminal)
     }
 
     async fn serve_inner(
@@ -361,9 +339,8 @@ impl Subscribed {
         self.forwarder
             .prepare_subscribe_ok(largest_location, deadline)?;
 
-        // Send SubscribeOk using send_message_and_wait to ensure it is sent at least to the QUIC stack before
-        // we start serving the track.  If a subscriber gets the stream before SubscribeOk
-        // then they won't recognize the track_alias in the stream header.
+        // Wait until SUBSCRIBE_OK is encoded before serving. Otherwise a data
+        // stream or an immediate PUBLISH_DONE could overtake acceptance.
         let mut params = KeyValuePairs::default();
         if let Some(largest) = largest_location {
             params
@@ -371,17 +348,21 @@ impl Subscribed {
                 .map_err(|_| SessionError::Internal)?;
         }
 
-        self.forwarder
+        let acceptance = self
+            .forwarder
             .publisher
-            .send_message_and_wait(message::SubscribeOk {
+            .send_subscribe_ok(message::SubscribeOk {
                 id: self.info.id,
                 track_alias: self.info.id, // use subscription id as track alias
                 params,
                 track_extensions: Default::default(),
-            })
-            .await;
+            })?;
 
-        self.ok = true; // So we send SubscribeDone on drop
+        self.ok = true;
+        acceptance
+            .await
+            .map_err(|_| DeliveryError::Cancelled.into_session_error())?
+            .map_err(DeliveryError::into_session_error)?;
 
         let delivery_filter = self.info.delivery_filter(largest_location);
 
@@ -403,6 +384,27 @@ impl Subscribed {
     pub async fn closed(&self) -> Result<(), ServeError> {
         self.forwarder.closed().await
     }
+
+    async fn finish(&mut self) -> Result<(), SessionError> {
+        let (err, stream_count, _, unsubscribed) = self.forwarder.terminal_state();
+        if !self.ok || unsubscribed {
+            return Ok(());
+        }
+
+        self.terminal_started = true;
+        let result = self
+            .forwarder
+            .publisher
+            .send_publish_done_and_wait(message::PublishDone {
+                id: self.info.id,
+                status_code: Self::publish_done_code(&err),
+                stream_count,
+                reason: ReasonPhrase(err.to_string()),
+            })
+            .await;
+        self.forwarder.publisher.drop_subscribe(self.info.id);
+        result
+    }
 }
 
 impl ops::Deref for Subscribed {
@@ -417,8 +419,12 @@ impl Drop for Subscribed {
     fn drop(&mut self) {
         let (err, stream_count, retry_interval, unsubscribed) = self.forwarder.terminal_state();
 
-        // Subscriber already sent UNSUBSCRIBE — no terminal message needed.
+        // Normal completion owns an async receipt. Drop only handles abnormal
+        // cancellation before that terminal delivery starts.
         if unsubscribed {
+            return;
+        }
+        if self.terminal_started {
             return;
         }
 
@@ -521,9 +527,10 @@ impl ObjectForwarder {
                         let info = subgroup.info.clone();
                         let mlog = self.mlog.clone();
                         let track_alias = self.track_alias;
+                        let stream_count = self.stream_count.clone();
 
                         tasks.push(async move {
-                            let res = Self::serve_subgroup(track_alias, subgroup, publisher, state, mlog, delivery_filter).await;
+                            let res = Self::serve_subgroup(track_alias, subgroup, publisher, state, stream_count, mlog, delivery_filter).await;
                             if let Err(err) = &res {
                                 if Subscribed::is_expected_serve_shutdown(err) {
                                     tracing::debug!(subgroup_info = ?info, error = %err, "stopped serving subgroup");
@@ -569,6 +576,7 @@ impl ObjectForwarder {
         mut subgroup_reader: serve::SubgroupReader,
         mut publisher: Publisher,
         state: State<ObjectForwarderState>,
+        stream_count: StreamCount,
         mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
         delivery_filter: DeliveryFilter,
     ) -> Result<(), SessionError> {
@@ -625,14 +633,11 @@ impl ObjectForwarder {
                 // TODO figure out u32 vs u64 priority
                 send_stream.set_priority(subgroup_reader.priority as i32);
                 let mut new_writer = ResetOnDropWriter::new(Writer::new(send_stream));
+                stream_count.opened();
 
                 {
                     let locked = state.lock();
                     let closed = locked.closed.clone();
-                    locked
-                        .into_mut()
-                        .ok_or(ServeError::Done)?
-                        .record_stream_opened();
                     closed?;
                 }
 
@@ -927,6 +932,7 @@ mod tests {
         Subscribed,
         ObjectForwarderRecv,
         crate::watch::Queue<message::Message>,
+        tokio::sync::mpsc::UnboundedReceiver<crate::session::BidiResponse>,
     ) {
         let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
         let (outgoing, outgoing_recv) = crate::watch::Queue::default().split();
@@ -937,6 +943,12 @@ mod tests {
             crate::session::RequestId::new(0, 1),
             bidi_task_tx,
         );
+        let (response_tx, response_rx) = tokio::sync::mpsc::unbounded_channel();
+        publisher
+            .bidi_response_map
+            .lock()
+            .unwrap()
+            .insert(0, response_tx);
         let (subscribed, recv) = Subscribed::new(
             publisher,
             message::Subscribe {
@@ -948,7 +960,15 @@ mod tests {
             None,
         )
         .unwrap();
-        (subscribed, recv, outgoing_recv)
+        (subscribed, recv, outgoing_recv, response_rx)
+    }
+
+    async fn accept_subscription(
+        responses: &mut tokio::sync::mpsc::UnboundedReceiver<crate::session::BidiResponse>,
+    ) {
+        let mut response = responses.recv().await.unwrap();
+        assert!(matches!(response.message, message::Message::SubscribeOk(_)));
+        response.complete(Ok(()));
     }
 
     async fn forward_datagram(
@@ -1016,6 +1036,28 @@ mod tests {
         }
     }
 
+    fn closed_subgroup_track(stream_count: u64) -> serve::TrackReader {
+        let (writer, reader) = serve::Track::new(
+            crate::coding::TrackNamespace::from_utf8_path("test"),
+            "track",
+        )
+        .produce();
+        let mut subgroups = writer.subgroups().unwrap();
+        for group_id in 0..stream_count {
+            let mut subgroup = subgroups
+                .create(serve::Subgroup {
+                    group_id,
+                    subgroup_id: 0,
+                    priority: 128,
+                })
+                .unwrap();
+            let mut object = subgroup.create_with_id(0, 1, None).unwrap();
+            object.write(Bytes::from_static(b"x")).unwrap();
+        }
+        drop(subgroups);
+        reader
+    }
+
     fn assert_payload_datagram((received, largest): (data::Datagram, Option<Location>)) {
         assert_eq!(
             received.datagram_type,
@@ -1071,7 +1113,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn subscription_filter_uses_pre_wait_track_position() {
         let (publisher_session, peer_session) = loopback_session_pair().await;
-        let (outgoing, mut outgoing_recv) = crate::watch::Queue::default().split();
+        let (outgoing, _outgoing_recv) = crate::watch::Queue::default().split();
         let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
         let publisher = Publisher::new(
             outgoing,
@@ -1080,6 +1122,12 @@ mod tests {
             crate::session::RequestId::new(0, 1),
             bidi_task_tx,
         );
+        let (response_tx, mut response_rx) = tokio::sync::mpsc::unbounded_channel();
+        publisher
+            .bidi_response_map
+            .lock()
+            .unwrap()
+            .insert(0, response_tx);
         let mut params = KeyValuePairs::default();
         params
             .set_subscription_filter(&message::SubscriptionFilter {
@@ -1110,10 +1158,16 @@ mod tests {
 
         let serve = subscribed.serve_with_largest_location(reader, None);
         let accept = async move {
+            accept_subscription(&mut response_rx).await;
+            let mut response = response_rx.recv().await.unwrap();
             assert!(matches!(
-                outgoing_recv.pop().await,
-                Some(message::Message::SubscribeOk(_))
+                response.message,
+                message::Message::PublishDone(message::PublishDone {
+                    stream_count: 0,
+                    ..
+                })
             ));
+            response.complete(Ok(()));
         };
         let receive = async move {
             tokio::time::timeout(
@@ -1306,6 +1360,7 @@ mod tests {
             source_reader,
             forwarder.publisher.clone(),
             forwarder.state.clone(),
+            forwarder.stream_count.clone(),
             None,
             filter,
         );
@@ -1401,6 +1456,7 @@ mod tests {
                 source_reader,
                 forwarder.publisher.clone(),
                 forwarder.state.clone(),
+                forwarder.stream_count.clone(),
                 None,
                 filter,
             );
@@ -1474,6 +1530,7 @@ mod tests {
             source_reader,
             forwarder.publisher.clone(),
             forwarder.state.clone(),
+            forwarder.stream_count.clone(),
             None,
             DeliveryFilter {
                 forward: true,
@@ -1740,7 +1797,7 @@ mod tests {
 
     #[tokio::test]
     async fn deadline_prevents_subscribe_ok() {
-        let (subscribed, _recv, _outgoing) = test_subscribed().await;
+        let (subscribed, _recv, _outgoing, _responses) = test_subscribed().await;
         let (_writer, reader) = serve::Track::new(
             crate::coding::TrackNamespace::from_utf8_path("test"),
             "track",
@@ -1757,7 +1814,7 @@ mod tests {
 
     #[tokio::test]
     async fn withdrawal_prevents_subscribe_ok() {
-        let (subscribed, mut recv, _outgoing) = test_subscribed().await;
+        let (subscribed, mut recv, _outgoing, _responses) = test_subscribed().await;
         recv.recv_unsubscribe().unwrap();
         let (_writer, reader) = serve::Track::new(
             crate::coding::TrackNamespace::from_utf8_path("test"),
@@ -1779,11 +1836,163 @@ mod tests {
         ));
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn serve_waits_for_terminal_receipt_with_exact_zero_and_two_stream_counts() {
+        for expected_stream_count in [0, 2] {
+            let (subscribed, _recv, _outgoing, mut responses) = test_subscribed().await;
+            let stream_count = subscribed.forwarder.stream_count_handle();
+            let (writer, reader) = serve::Track::new(
+                crate::coding::TrackNamespace::from_utf8_path("test"),
+                "track",
+            )
+            .produce();
+            let mut subgroups = writer.subgroups().unwrap();
+            let serve = tokio::spawn(subscribed.serve(reader));
+
+            accept_subscription(&mut responses).await;
+            for group_id in 0..expected_stream_count {
+                let mut subgroup = subgroups
+                    .create(serve::Subgroup {
+                        group_id,
+                        subgroup_id: 0,
+                        priority: 128,
+                    })
+                    .unwrap();
+                subgroup.write(Bytes::from_static(b"x")).unwrap();
+                drop(subgroup);
+                tokio::time::timeout(std::time::Duration::from_secs(2), async {
+                    while stream_count.get() != group_id + 1 {
+                        tokio::task::yield_now().await;
+                    }
+                })
+                .await
+                .unwrap();
+            }
+            drop(subgroups);
+            let mut response =
+                tokio::time::timeout(std::time::Duration::from_secs(2), responses.recv())
+                    .await
+                    .unwrap()
+                    .unwrap();
+            let message::Message::PublishDone(done) = &response.message else {
+                panic!("expected PUBLISH_DONE, got {:?}", response.message);
+            };
+            assert_eq!(done.stream_count, expected_stream_count);
+            assert!(!serve.is_finished());
+
+            response.complete(Ok(()));
+            serve.await.unwrap().unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn immediate_driver_cancellation_fails_terminal_delivery() {
+        let (subscribed, _recv, mut outgoing, mut responses) = test_subscribed().await;
+        let serve = tokio::spawn(subscribed.serve(closed_subgroup_track(0)));
+
+        accept_subscription(&mut responses).await;
+        drop(responses);
+
+        assert!(matches!(
+            serve.await.unwrap(),
+            Err(SessionError::Serve(ServeError::Cancel))
+        ));
+        if let Ok(Some(message)) =
+            tokio::time::timeout(std::time::Duration::from_millis(20), outgoing.pop()).await
+        {
+            panic!("unexpected terminal queue message: {message:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn cancellation_after_subscribe_ok_enqueue_does_not_reject_accepted_request() {
+        let (subscribed, _recv, mut outgoing, mut responses) = test_subscribed().await;
+        let _publisher = subscribed.forwarder.publisher.clone();
+        let serve = tokio::spawn(subscribed.serve(closed_subgroup_track(0)));
+        let response = responses.recv().await.unwrap();
+        assert!(matches!(response.message, message::Message::SubscribeOk(_)));
+
+        serve.abort();
+        assert!(serve.await.unwrap_err().is_cancelled());
+        let terminal = tokio::time::timeout(std::time::Duration::from_secs(2), outgoing.pop())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(matches!(terminal, message::Message::PublishDone(_)));
+        drop(response);
+    }
+
+    #[tokio::test]
+    async fn source_failure_is_reported_after_publish_done_receipt() {
+        let (subscribed, _recv, _outgoing, mut responses) = test_subscribed().await;
+        let (writer, reader) = serve::Track::new(
+            crate::coding::TrackNamespace::from_utf8_path("test"),
+            "track",
+        )
+        .produce();
+        writer
+            .subgroups()
+            .unwrap()
+            .close(ServeError::Closed(0x42))
+            .unwrap();
+        let serve = tokio::spawn(subscribed.serve(reader));
+
+        accept_subscription(&mut responses).await;
+        let mut response = responses.recv().await.unwrap();
+        let message::Message::PublishDone(done) = &response.message else {
+            panic!("expected PUBLISH_DONE, got {:?}", response.message);
+        };
+        assert_eq!(done.status_code, 0x42);
+        assert_eq!(done.stream_count, 0);
+        assert!(!serve.is_finished());
+
+        response.complete(Ok(()));
+        assert!(matches!(
+            serve.await.unwrap(),
+            Err(SessionError::Serve(ServeError::Closed(0x42)))
+        ));
+    }
+
+    #[tokio::test]
+    async fn peer_cancellation_suppresses_publish_done() {
+        let (subscribed, mut recv, _outgoing, mut responses) = test_subscribed().await;
+        let (writer, reader) = serve::Track::new(
+            crate::coding::TrackNamespace::from_utf8_path("test"),
+            "track",
+        )
+        .produce();
+        let mut subgroups = writer.subgroups().unwrap();
+        let mut subgroup = subgroups
+            .create(serve::Subgroup {
+                group_id: 0,
+                subgroup_id: 0,
+                priority: 128,
+            })
+            .unwrap();
+        subgroup.write(Bytes::from_static(b"x")).unwrap();
+        let serve = tokio::spawn(subscribed.serve(reader));
+
+        accept_subscription(&mut responses).await;
+        recv.recv_unsubscribe().unwrap();
+        assert!(matches!(
+            serve.await.unwrap(),
+            Err(SessionError::Serve(ServeError::Cancel))
+        ));
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(20), responses.recv())
+                .await
+                .unwrap()
+                .is_none()
+        );
+        drop(subgroup);
+        drop(subgroups);
+    }
+
     /// A publisher-side timeout after SUBSCRIBE_OK is a track failure, not an
     /// expired rendezvous window.
     #[tokio::test]
     async fn accepted_track_timeout_is_not_a_deadline_expiration() {
-        let (subscribed, _recv, mut outgoing) = test_subscribed().await;
+        let (subscribed, _recv, _outgoing, mut responses) = test_subscribed().await;
         let (writer, reader) = serve::Track::new(
             crate::coding::TrackNamespace::from_utf8_path("test"),
             "track",
@@ -1795,11 +2004,11 @@ mod tests {
             tokio::time::Instant::now() + std::time::Duration::from_secs(1),
         );
         let close_after_accept = async move {
-            assert!(matches!(
-                outgoing.pop().await,
-                Some(message::Message::SubscribeOk(_))
-            ));
+            accept_subscription(&mut responses).await;
             writer.close(ServeError::Timeout).unwrap();
+            let mut response = responses.recv().await.unwrap();
+            assert!(matches!(response.message, message::Message::PublishDone(_)));
+            response.complete(Ok(()));
         };
 
         let (result, ()) = tokio::join!(serve, close_after_accept);
@@ -1811,7 +2020,7 @@ mod tests {
 
     #[tokio::test]
     async fn rejection_preserves_retry_interval() {
-        let (subscribed, _recv, mut outgoing) = test_subscribed().await;
+        let (subscribed, _recv, mut outgoing, _responses) = test_subscribed().await;
         // The session retains a Publisher while individual requests come and go.
         let _publisher = subscribed.forwarder.publisher.clone();
         let retry_interval = 1_500;
@@ -1833,14 +2042,25 @@ mod tests {
 
     #[test]
     fn subscribed_state_counts_opened_streams() {
-        let mut state = ObjectForwarderState::default();
-        assert_eq!(state.stream_count, 0);
+        let stream_count = StreamCount::default();
+        assert_eq!(stream_count.get(), 0);
 
-        state.record_stream_opened();
-        assert_eq!(state.stream_count, 1);
+        stream_count.opened();
+        assert_eq!(stream_count.get(), 1);
 
-        state.record_stream_opened();
-        assert_eq!(state.stream_count, 2);
+        stream_count.opened();
+        assert_eq!(stream_count.get(), 2);
+    }
+
+    #[test]
+    fn stream_count_does_not_wrap() {
+        let stream_count = StreamCount(Arc::new(AtomicU64::new(u64::MAX - 1)));
+
+        stream_count.opened();
+        assert_eq!(stream_count.get(), u64::MAX);
+
+        stream_count.opened();
+        assert_eq!(stream_count.get(), u64::MAX);
     }
 
     #[test]

--- a/moq-transport/src/session/subscriber.rs
+++ b/moq-transport/src/session/subscriber.rs
@@ -22,9 +22,9 @@ use crate::{
 use crate::watch::Queue;
 
 use super::{
-    DoneOutcome, NameRegistry, PublishReceived, PublishReceivedRecv, PublishedNamespace,
-    PublishedNamespaceRecv, Reader, RequestId, Session, SessionError, Subscribe,
-    SubscribeNamespace, SubscribeNamespaceInfo, SubscribeRecv, Writer,
+    BidiResponse, BidiResponseMap, DoneOutcome, NameRegistry, PublishReceived, PublishReceivedRecv,
+    PublishedNamespace, PublishedNamespaceRecv, Reader, RequestId, Session, SessionError,
+    Subscribe, SubscribeNamespace, SubscribeNamespaceInfo, SubscribeRecv, Writer,
 };
 
 // Default timeout for waiting for subscribe aliases to become available via SUBSCRIBE_OK (1 second)
@@ -182,6 +182,10 @@ pub struct Subscriber {
     /// will process the queue and send the message on the control stream.
     outgoing: Queue<Message>,
 
+    /// Response streams for peer-initiated requests. PUBLISH decisions use the
+    /// request-local channel so they cannot be overtaken by PUBLISH_DONE.
+    bidi_response_map: BidiResponseMap,
+
     /// WebTransport session, used to open bidi streams for requests (draft-18).
     webtransport: web_transport::Session,
 
@@ -245,6 +249,7 @@ impl Subscriber {
         mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
         request_id: RequestId,
         bidi_task_tx: super::BidiTaskSender,
+        bidi_response_map: BidiResponseMap,
     ) -> Self {
         Self {
             published_namespaces: Default::default(),
@@ -262,6 +267,7 @@ impl Subscriber {
             publishes_received: Default::default(),
             publish_received_queue: Default::default(),
             bidi_task_tx,
+            bidi_response_map,
         }
     }
 
@@ -320,6 +326,36 @@ impl Subscriber {
     pub(super) fn send_request_error(&mut self, request_kind: &str, msg: message::RequestError) {
         self.log_request_error_created(request_kind, &msg);
         self.send_message(msg);
+    }
+
+    pub(super) fn send_publish_response(&mut self, message: Message) -> Result<(), ServeError> {
+        let request_id = message
+            .response_target_id()
+            .ok_or_else(|| ServeError::internal_ctx("PUBLISH response has no request ID"))?;
+        match &message {
+            Message::RequestOk(msg) => self.add_mlog_event(|time| {
+                mlog::events::request_ok_created(time, request_id, "publish", msg)
+            }),
+            Message::RequestError(msg) => self.add_mlog_event(|time| {
+                mlog::events::request_error_created(time, request_id, "publish", msg)
+            }),
+            _ => {
+                return Err(ServeError::internal_ctx(
+                    "invalid response type for inbound PUBLISH",
+                ))
+            }
+        }
+        Session::log_control_message(&message, "sent");
+        let stream = self
+            .bidi_response_map
+            .lock()
+            .map_err(|_| ServeError::internal_ctx("bidi response map lock poisoned"))?
+            .get(&request_id)
+            .cloned()
+            .ok_or(ServeError::Cancel)?;
+        stream
+            .send(BidiResponse::new(message))
+            .map_err(|_| ServeError::Cancel)
     }
 
     /// Allocate the next outbound request ID.
@@ -1278,6 +1314,14 @@ impl Subscriber {
         self.publish_received_queue.pop().await
     }
 
+    #[cfg(test)]
+    pub(super) fn has_subscriber_name(&self, name: &FullTrackName) -> bool {
+        self.subscriber_names
+            .lock()
+            .map(|names| names.contains_name(name))
+            .unwrap_or(false)
+    }
+
     /// Abandon an inbound PUBLISH whose request stream closed without
     /// PUBLISH_DONE.
     ///
@@ -1327,7 +1371,7 @@ impl Subscriber {
 
     /// Remove all subscriber-side state for an inbound PUBLISH.
     ///
-    /// Called by `PublishReceived::drop` when the app did not call `ok()`.
+    /// Used when an inbound PUBLISH cannot be queued for the application.
     pub(super) fn remove_publish_received(&self, request_id: u64) {
         if let Err(err) = self.remove_publish_received_state(request_id) {
             tracing::error!(request_id, error = %err, "failed to remove inbound PUBLISH state");
@@ -1999,6 +2043,7 @@ mod tests {
             None,
             RequestId::new(0, 1),
             bidi_task_tx,
+            Default::default(),
         )
     }
 
@@ -2157,6 +2202,7 @@ mod tests {
                 None,
                 RequestId::new(0, 1),
                 bidi_task_tx,
+                Default::default(),
             ),
             bidi_task_rx,
         )

--- a/moq-transport/src/session/writer.rs
+++ b/moq-transport/src/session/writer.rs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2023-2024 Luke Curley and contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::io;
+use std::{io, ops};
 
 use crate::coding::{Encode, EncodeError};
 
@@ -101,5 +101,57 @@ impl Writer {
     /// Used to tear down a single request stream without closing the session.
     pub fn reset(&mut self, code: u32) {
         self.stream.reset(code);
+    }
+
+    /// Wait until the peer stops receiving this stream or it is closed.
+    pub async fn closed(&mut self) -> Result<Option<u8>, SessionError> {
+        Ok(self.stream.closed().await?)
+    }
+}
+
+pub(super) struct ResetOnDropWriter {
+    writer: Writer,
+    closed: bool,
+}
+
+impl ResetOnDropWriter {
+    pub fn new(writer: Writer) -> Self {
+        Self {
+            writer,
+            closed: false,
+        }
+    }
+
+    pub fn finish(&mut self) -> Result<(), SessionError> {
+        self.writer.finish()?;
+        self.closed = true;
+        Ok(())
+    }
+
+    pub fn reset(&mut self, code: u32) {
+        self.writer.reset(code);
+        self.closed = true;
+    }
+}
+
+impl ops::Deref for ResetOnDropWriter {
+    type Target = Writer;
+
+    fn deref(&self) -> &Self::Target {
+        &self.writer
+    }
+}
+
+impl ops::DerefMut for ResetOnDropWriter {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.writer
+    }
+}
+
+impl Drop for ResetOnDropWriter {
+    fn drop(&mut self) {
+        if !self.closed {
+            self.writer.reset(0);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- wait for request-local `SUBSCRIBE_OK` and `PUBLISH_DONE` delivery receipts before serving resolves
- acknowledge terminal delivery only after encoding and successful request-stream FIN
- preserve the exact subgroup Stream Count
- reset incomplete subgroup streams on cancellation
- suppress `PUBLISH_DONE` after peer cancellation
- preserve mandatory inbound `PUBLISH` responses for both `PUBLISH_DONE` orderings
- keep Stream Count monotonic and non-wrapping at the `u64` boundary

## Why

Serving could previously resolve after `PUBLISH_DONE` was queued but before it was encoded and the request stream successfully sent FIN. Cancellation during that window could lose terminal delivery or release request state too early.

Inbound `PUBLISH` could also retain a request handler indefinitely when `REQUEST_OK` was sent before `PUBLISH_DONE`.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p moq-transport` — 384 passed
- `cargo build --workspace`
- boundary regression verifies `u64::MAX - 1 → u64::MAX → u64::MAX`
- lifecycle and code-quality review