### PR TITLE
fix: preserve ordered rendezvous teardown

### DIFF
--- a/moq-relay-ietf/src/consumer.rs
+++ b/moq-relay-ietf/src/consumer.rs
@@ -8,16 +8,81 @@ use futures::{stream::FuturesUnordered, FutureExt, StreamExt};
 use moq_transport::{
     message::RequestErrorCode,
     serve::{ServeError, Tracks},
-    session::{PublishReceived, PublishedNamespace, SessionError, Subscriber},
+    session::{PublishReceived, PublishedNamespace, SessionError, Subscribe, Subscriber},
 };
 use tokio::sync::Semaphore;
 
 use crate::{
-    metrics::GaugeGuard, Coordinator, Locals, Producer, RemoteManager, SessionContext,
+    metrics::GaugeGuard, CacheLease, Coordinator, Locals, Producer, RemoteManager, SessionContext,
     SessionInterface, TrackRequest,
 };
 
 const MAX_INBOUND_PUBLISH_TRACKS_PER_SESSION: usize = 1024;
+
+struct CacheSubscriptionCleanup {
+    subscribe: Option<Subscribe>,
+    lease: Option<CacheLease>,
+}
+
+impl CacheSubscriptionCleanup {
+    fn new(lease: CacheLease) -> Self {
+        Self {
+            subscribe: None,
+            lease: Some(lease),
+        }
+    }
+
+    fn attach(&mut self, subscribe: Subscribe) {
+        self.subscribe = Some(subscribe);
+    }
+
+    fn handles(&self) -> Result<(&Subscribe, &CacheLease), ServeError> {
+        match (self.subscribe.as_ref(), self.lease.as_ref()) {
+            (Some(subscribe), Some(lease)) => Ok((subscribe, lease)),
+            _ => Err(ServeError::Internal(
+                "cache subscription cleanup is missing ownership".to_string(),
+            )),
+        }
+    }
+
+    fn finish(mut self) -> Option<tokio::task::JoinHandle<()>> {
+        let subscribe = self.subscribe.take();
+        let lease = self.lease.take()?;
+        Some(tokio::spawn(async move {
+            if let Some(subscribe) = subscribe {
+                subscribe.unsubscribe().await;
+            }
+            lease.finish_release();
+        }))
+    }
+}
+
+impl Drop for CacheSubscriptionCleanup {
+    fn drop(&mut self) {
+        let Some(lease) = self.lease.take() else {
+            return;
+        };
+        let subscribe = self.subscribe.take();
+
+        if let Some(subscribe) = subscribe {
+            if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+                std::mem::drop(runtime.spawn(async move {
+                    subscribe.unsubscribe().await;
+                    lease.finish_release();
+                }));
+                return;
+            }
+
+            tracing::warn!(
+                request_id = subscribe.id,
+                "could not wait for cache subscription teardown outside a Tokio runtime"
+            );
+            drop(subscribe);
+        }
+
+        lease.finish_release();
+    }
+}
 
 /// Consumer of tracks from a remote Publisher
 #[derive(Clone)]
@@ -111,17 +176,14 @@ impl Consumer {
     /// The peer that forwarded this is not the origin, it is relaying on the
     /// origin's behalf, so this relay must not present itself as a source. It
     /// registers the namespace the same way the SUBSCRIBE_NAMESPACE pull path
-    /// does — visible to `list_namespaces_matching`, absent from
-    /// `route_namespace` — so a downstream SUBSCRIBE misses locally and resolves
-    /// through the coordinator to whoever actually owns it.
+    /// does. The namespace is visible to discovery but absent from local routing,
+    /// so a downstream SUBSCRIBE resolves through the coordinator to its owner.
     ///
     /// Deliberately absent, each for its own reason:
     ///
     /// * **No coordinator registration.** Ownership is the origin's. Claiming it
-    ///   here races the origin for one key and loses, and the losing path
-    ///   unwinds the local registration it had already published — which
-    ///   downstream reads as the namespace being withdrawn milliseconds after
-    ///   it appeared, while the publisher is still live.
+    ///   here races the origin for one key and loses. The losing path then
+    ///   unwinds the local registration while the publisher is still live.
     ///
     /// * **No request queue.** With no local route nothing can queue against
     ///   this session, so there is no queue to strand and no need to drain one.
@@ -129,9 +191,8 @@ impl Consumer {
     /// * **No subscribe reaching this session.** That matters twice over: the
     ///   forwarding peer publishes a placeholder track container whose request
     ///   channel is closed at creation, and that publication takes priority
-    ///   over the peer's own unknown-subscribe fall-through — so a subscribe
-    ///   arriving there answers "does not exist" even though the peer holds a
-    ///   working route. And a dialed session has no `Producer` draining
+    ///   over the peer's own unknown-subscribe fall-through. A dialed session
+    ///   also has no `Producer` draining
     ///   `subscribed()` at all, so it could not be served even if the
     ///   placeholder were gone.
     ///
@@ -235,12 +296,9 @@ impl Consumer {
 
         // Forward the namespace upstream, if configured.
         if let Some(mut forward) = self.forward {
-            // Same advertise-only container as the peer fan-out below, and the
-            // same defect: dropping the request half here means the `--announce`
-            // upstream cannot route a subscribe back down this session either.
-            // Latent rather than fixed — no deployment sets `--announce` today,
-            // and giving it a real route is the same work as making dialed
-            // sessions serve subscribes, which is deliberately out of scope.
+            // This advertise-only container cannot route a subscribe back down
+            // the dialed session. Supporting that requires the dialed side to
+            // run a Producer, which is outside this forwarding path.
             let (_, _forward_request, forward_reader) =
                 Tracks::new(published_ns.namespace.clone()).produce();
             tasks.push(
@@ -294,15 +352,10 @@ impl Consumer {
             // The forwarding API uses the moq-transport Tracks helper as an
             // adapter for the outgoing publish_namespace call; it is not the
             // relay-local registry.
-            // Advertise-only container. Its writer and request halves are
-            // dropped here, which closes the request channel at creation, so
-            // the reader can carry the namespace outward but can never answer a
-            // subscribe. That is load-bearing and fragile: on the receiving
-            // peer this publication takes priority over the unknown-subscribe
-            // fall-through, so any subscribe routed back down this session gets
-            // "does not exist" rather than the peer's real route. Nothing must
-            // route a subscribe here — see `serve_proxied`, and the guard test
-            // `fanout_adapter_accepts_a_subscribe_it_can_never_serve`.
+            // The request half is dropped before this task runs, so this reader
+            // can advertise the namespace but cannot serve a subscription. The
+            // receiving relay must keep it out of local routing; see
+            // `serve_proxied`.
             let (_, _request, reader) = Tracks::new(published_ns.namespace.clone()).produce();
             tasks.push(
                 async move {
@@ -344,6 +397,7 @@ impl Consumer {
                     let mut subscriber = self.subscriber.clone();
 
                     tasks.push(async move {
+                        let mut cleanup = CacheSubscriptionCleanup::new(lease);
                         let info = writer.info.clone();
                         let namespace = info.namespace.to_utf8_path();
                         let track_name = info.name.clone();
@@ -353,16 +407,29 @@ impl Consumer {
                             "forwarding subscribe: {:?}", info
                         );
 
-                        // Hold the subscription explicitly rather than using
-                        // `subscribe()`, so it can be dropped — sending
-                        // UNSUBSCRIBE — once downstream interest goes away.
-                        //
-                        // `subscribe_open` resolves once the upstream publisher
-                        // answers, so its outcome is exactly what downstream
-                        // subscribers are waiting on to satisfy draft-16 §8.4.
-                        let subscribe = match subscriber.subscribe_open(writer).await {
+                        // Stop opening the upstream stream when all downstream
+                        // interest disappears. Once opening succeeds, cleanup
+                        // owns the stream through ordered teardown.
+                        let lease = cleanup.lease.as_ref().ok_or_else(|| {
+                            ServeError::Internal(
+                                "cache subscription cleanup is missing its lease".to_string(),
+                            )
+                        })?;
+                        let subscribe_result = tokio::select! {
+                            biased;
+                            result = subscriber.subscribe_start(writer) => Some(result),
+                            _ = lease.abandoned() => None,
+                        };
+                        let Some(subscribe_result) = subscribe_result else {
+                            tracing::debug!(
+                                namespace = %namespace,
+                                track = %track_name,
+                                "downstream left while opening upstream subscribe"
+                            );
+                            return Ok(());
+                        };
+                        let subscribe = match subscribe_result {
                             Ok(subscribe) => {
-                                upstream.established();
                                 subscribe
                             }
                             Err(err) => {
@@ -379,6 +446,39 @@ impl Consumer {
                                 return Ok(());
                             }
                         };
+                        cleanup.attach(subscribe);
+                        let (subscribe, lease) = cleanup.handles()?;
+
+                        let accepted = tokio::select! {
+                            result = subscribe.ok() => Some(result),
+                            _ = lease.abandoned() => None,
+                        };
+                        let Some(accepted) = accepted else {
+                            tracing::debug!(
+                                namespace = %namespace,
+                                track = %track_name,
+                                "downstream left before upstream accepted subscribe"
+                            );
+                            if let Some(task) = cleanup.finish() {
+                                let _ = task.await;
+                            }
+                            return Ok(());
+                        };
+                        if let Err(err) = accepted {
+                            tracing::warn!(
+                                namespace = %namespace,
+                                track = %track_name,
+                                error = %err,
+                                "failed forwarding subscribe: {:?}", info
+                            );
+                            upstream.failed(err);
+                            if let Some(task) = cleanup.finish() {
+                                let _ = task.await;
+                            }
+                            return Ok(());
+                        }
+                        upstream.established();
+                        let (subscribe, lease) = cleanup.handles()?;
 
                         tokio::select! {
                             res = subscribe.closed() => {
@@ -392,8 +492,8 @@ impl Consumer {
                                 }
                             }
                             // The cached track went unwatched long enough to be
-                            // evicted, so stop pulling it. Dropping `subscribe`
-                            // below sends UNSUBSCRIBE upstream.
+                            // evicted, so stop pulling it and complete ordered
+                            // request-stream teardown below.
                             _ = lease.released() => {
                                 tracing::info!(
                                     namespace = %namespace,
@@ -402,8 +502,9 @@ impl Consumer {
                                 );
                             }
                         }
-
-                        drop(subscribe);
+                        if let Some(task) = cleanup.finish() {
+                            let _ = task.await;
+                        }
 
                         Ok(())
                     }.boxed());
@@ -495,52 +596,45 @@ impl Consumer {
 
 #[cfg(test)]
 mod tests {
-    use futures::FutureExt;
-    use moq_transport::serve::Tracks;
+    use moq_transport::serve::FullTrackName;
+
+    use super::CacheSubscriptionCleanup;
+    use crate::{Locals, TrackRequest};
 
     fn ns(path: &str) -> moq_transport::coding::TrackNamespace {
         moq_transport::coding::TrackNamespace::try_from(path).expect("valid namespace")
     }
 
-    /// Pins the defect in the fan-out adapter so it stays visible.
-    ///
-    /// `serve()` builds this container to carry a namespace outward and drops
-    /// its writer and request halves immediately, which closes the request
-    /// channel before anything can use it. The container is therefore incapable
-    /// of answering a subscribe — and on the receiving peer it takes priority
-    /// over the unknown-subscribe fall-through, so a subscribe routed to it is
-    /// answered "does not exist" rather than being served from the peer's real
-    /// route.
-    ///
-    /// The fix keeps subscribes away from it rather than repairing it, which
-    /// makes this a property nothing enforces at the type level. If a future
-    /// change routes a subscribe onto a fan-out session, this test is the
-    /// warning that the destination is a dead end.
-    #[test]
-    fn fanout_adapter_accepts_a_subscribe_it_can_never_serve() {
+    #[tokio::test]
+    async fn cleanup_before_subscribe_start_removes_the_cache_generation() {
         let namespace = ns("room/123");
+        let mut locals = Locals::new();
+        let (_registration, mut requests) = locals
+            .register_namespace(None, namespace.clone())
+            .await
+            .expect("register namespace source");
+        let local = locals
+            .get_or_request_track(None, namespace.clone(), "video")
+            .await
+            .expect("request missing track");
+        let TrackRequest {
+            writer,
+            lease,
+            upstream,
+        } = requests.recv().await.expect("receive track request");
+        drop(local);
+        lease.abandoned().await;
 
-        // Note what it does NOT do: refuse. It accepts the subscribe and hands
-        // back a track, having pushed the matching writer onto a queue that has
-        // no consumer. The subscribe is answered, then never served.
-        let (_, _request, mut reader) = Tracks::new(namespace.clone()).produce();
-        assert!(
-            reader.subscribe(namespace.clone(), "video").is_some(),
-            "expected the advertise-only container to accept a subscribe it \
-             cannot serve; if it now refuses outright, the hazard has changed \
-             shape and the comments at both Tracks::produce call sites need \
-             revisiting"
-        );
+        let full_name = FullTrackName {
+            namespace,
+            name: "video".into(),
+        };
+        assert!(locals.retrieve_track(None, &full_name).is_some());
 
-        // With the request half alive the same container does serve, which is
-        // what makes dropping it the whole defect rather than an incidental
-        // detail. Keeping both cases in one test stops the assertion above from
-        // being read as "this container is simply broken".
-        let (_, mut request, mut wired) = Tracks::new(namespace.clone()).produce();
-        assert!(wired.subscribe(namespace, "video").is_some());
-        assert!(
-            request.next().now_or_never().flatten().is_some(),
-            "a wired container must deliver the writer to its requester"
-        );
+        drop(CacheSubscriptionCleanup::new(lease));
+
+        assert!(locals.retrieve_track(None, &full_name).is_none());
+        drop(writer);
+        drop(upstream);
     }
 }

--- a/moq-relay-ietf/src/consumer.rs
+++ b/moq-relay-ietf/src/consumer.rs
@@ -13,7 +13,8 @@ use moq_transport::{
 use tokio::sync::Semaphore;
 
 use crate::{
-    metrics::GaugeGuard, Coordinator, Locals, Producer, RemoteManager, SessionContext, TrackRequest,
+    metrics::GaugeGuard, Coordinator, Locals, Producer, RemoteManager, SessionContext,
+    SessionInterface, TrackRequest,
 };
 
 const MAX_INBOUND_PUBLISH_TRACKS_PER_SESSION: usize = 1024;
@@ -104,6 +105,71 @@ impl Consumer {
         }
     }
 
+    /// Serve a PUBLISH_NAMESPACE forwarded by a peer relay: advertise it for
+    /// discovery, and route nothing through this session.
+    ///
+    /// The peer that forwarded this is not the origin, it is relaying on the
+    /// origin's behalf, so this relay must not present itself as a source. It
+    /// registers the namespace the same way the SUBSCRIBE_NAMESPACE pull path
+    /// does — visible to `list_namespaces_matching`, absent from
+    /// `route_namespace` — so a downstream SUBSCRIBE misses locally and resolves
+    /// through the coordinator to whoever actually owns it.
+    ///
+    /// Deliberately absent, each for its own reason:
+    ///
+    /// * **No coordinator registration.** Ownership is the origin's. Claiming it
+    ///   here races the origin for one key and loses, and the losing path
+    ///   unwinds the local registration it had already published — which
+    ///   downstream reads as the namespace being withdrawn milliseconds after
+    ///   it appeared, while the publisher is still live.
+    ///
+    /// * **No request queue.** With no local route nothing can queue against
+    ///   this session, so there is no queue to strand and no need to drain one.
+    ///
+    /// * **No subscribe reaching this session.** That matters twice over: the
+    ///   forwarding peer publishes a placeholder track container whose request
+    ///   channel is closed at creation, and that publication takes priority
+    ///   over the peer's own unknown-subscribe fall-through — so a subscribe
+    ///   arriving there answers "does not exist" even though the peer holds a
+    ///   working route. And a dialed session has no `Producer` draining
+    ///   `subscribed()` at all, so it could not be served even if the
+    ///   placeholder were gone.
+    ///
+    /// * **No onward fan-out.** The coordinator already returns no subscriber
+    ///   relays for an internal context; not asking is one fewer way to
+    ///   propagate a forwarded announce into a loop.
+    async fn serve_proxied(
+        self,
+        mut published_ns: PublishedNamespace,
+    ) -> Result<(), anyhow::Error> {
+        let ns = published_ns.namespace.to_utf8_path();
+
+        let _registration = match self
+            .locals
+            .register_remote_namespace(self.context.scope(), published_ns.namespace.clone())
+        {
+            Ok(registration) => registration,
+            Err(err) => {
+                metrics::counter!("moq_relay_announce_errors_total", "phase" => "remote_register")
+                    .increment(1);
+                return Err(err);
+            }
+        };
+        tracing::debug!(namespace = %ns, "registered proxied namespace for discovery");
+
+        if let Err(err) = published_ns.ok() {
+            metrics::counter!("moq_relay_announce_errors_total", "phase" => "send_ok").increment(1);
+            return Err(err.into());
+        }
+        metrics::counter!("moq_relay_announce_ok_total", "kind" => "proxied").increment(1);
+        tracing::info!(namespace = %ns, "serving proxied PUBLISH_NAMESPACE from peer relay");
+
+        published_ns.closed().await?;
+        tracing::info!(namespace = %ns, "proxied PUBLISH_NAMESPACE closed");
+
+        Ok(())
+    }
+
     /// Serve an inbound PUBLISH_NAMESPACE.
     async fn serve(mut self, mut published_ns: PublishedNamespace) -> Result<(), anyhow::Error> {
         // Track active publishers - decrements when this function returns.
@@ -113,6 +179,12 @@ impl Consumer {
             futures::future::BoxFuture<'static, Result<(), anyhow::Error>>,
         > = FuturesUnordered::new();
         let ns = published_ns.namespace.to_utf8_path();
+
+        // A namespace forwarded by a peer relay is proxied, not ours, so it is
+        // advertised for discovery and nothing more.
+        if self.context.interface == SessionInterface::Internal {
+            return self.serve_proxied(published_ns).await;
+        }
 
         // Register namespace routing metadata locally. This does not register
         // any media tracks; it only creates a request queue used when a
@@ -159,13 +231,16 @@ impl Consumer {
             return Err(err.into());
         }
         tracing::debug!(namespace = %ns, "sent REQUEST_OK for PUBLISH_NAMESPACE");
-        metrics::counter!("moq_relay_announce_ok_total").increment(1);
+        metrics::counter!("moq_relay_announce_ok_total", "kind" => "client").increment(1);
 
         // Forward the namespace upstream, if configured.
         if let Some(mut forward) = self.forward {
-            // The forwarding API still uses the moq-transport Tracks helper.
-            // This helper is not the relay-local registry; it is only an
-            // adapter for the outgoing publish_namespace API.
+            // Same advertise-only container as the peer fan-out below, and the
+            // same defect: dropping the request half here means the `--announce`
+            // upstream cannot route a subscribe back down this session either.
+            // Latent rather than fixed — no deployment sets `--announce` today,
+            // and giving it a real route is the same work as making dialed
+            // sessions serve subscribes, which is deliberately out of scope.
             let (_, _forward_request, forward_reader) =
                 Tracks::new(published_ns.namespace.clone()).produce();
             tasks.push(
@@ -219,6 +294,15 @@ impl Consumer {
             // The forwarding API uses the moq-transport Tracks helper as an
             // adapter for the outgoing publish_namespace call; it is not the
             // relay-local registry.
+            // Advertise-only container. Its writer and request halves are
+            // dropped here, which closes the request channel at creation, so
+            // the reader can carry the namespace outward but can never answer a
+            // subscribe. That is load-bearing and fragile: on the receiving
+            // peer this publication takes priority over the unknown-subscribe
+            // fall-through, so any subscribe routed back down this session gets
+            // "does not exist" rather than the peer's real route. Nothing must
+            // route a subscribe here — see `serve_proxied`, and the guard test
+            // `fanout_adapter_accepts_a_subscribe_it_can_never_serve`.
             let (_, _request, reader) = Tracks::new(published_ns.namespace.clone()).produce();
             tasks.push(
                 async move {
@@ -406,5 +490,57 @@ impl Consumer {
         tracing::info!(namespace = %namespace, track = %track_name, "PUBLISH closed");
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::FutureExt;
+    use moq_transport::serve::Tracks;
+
+    fn ns(path: &str) -> moq_transport::coding::TrackNamespace {
+        moq_transport::coding::TrackNamespace::try_from(path).expect("valid namespace")
+    }
+
+    /// Pins the defect in the fan-out adapter so it stays visible.
+    ///
+    /// `serve()` builds this container to carry a namespace outward and drops
+    /// its writer and request halves immediately, which closes the request
+    /// channel before anything can use it. The container is therefore incapable
+    /// of answering a subscribe — and on the receiving peer it takes priority
+    /// over the unknown-subscribe fall-through, so a subscribe routed to it is
+    /// answered "does not exist" rather than being served from the peer's real
+    /// route.
+    ///
+    /// The fix keeps subscribes away from it rather than repairing it, which
+    /// makes this a property nothing enforces at the type level. If a future
+    /// change routes a subscribe onto a fan-out session, this test is the
+    /// warning that the destination is a dead end.
+    #[test]
+    fn fanout_adapter_accepts_a_subscribe_it_can_never_serve() {
+        let namespace = ns("room/123");
+
+        // Note what it does NOT do: refuse. It accepts the subscribe and hands
+        // back a track, having pushed the matching writer onto a queue that has
+        // no consumer. The subscribe is answered, then never served.
+        let (_, _request, mut reader) = Tracks::new(namespace.clone()).produce();
+        assert!(
+            reader.subscribe(namespace.clone(), "video").is_some(),
+            "expected the advertise-only container to accept a subscribe it \
+             cannot serve; if it now refuses outright, the hazard has changed \
+             shape and the comments at both Tracks::produce call sites need \
+             revisiting"
+        );
+
+        // With the request half alive the same container does serve, which is
+        // what makes dropping it the whole defect rather than an incidental
+        // detail. Keeping both cases in one test stops the assertion above from
+        // being read as "this container is simply broken".
+        let (_, mut request, mut wired) = Tracks::new(namespace.clone()).produce();
+        assert!(wired.subscribe(namespace, "video").is_some());
+        assert!(
+            request.next().now_or_never().flatten().is_some(),
+            "a wired container must deliver the writer to its requester"
+        );
     }
 }

--- a/moq-relay-ietf/src/consumer.rs
+++ b/moq-relay-ietf/src/consumer.rs
@@ -48,6 +48,7 @@ impl CacheSubscriptionCleanup {
     fn finish(mut self) -> Option<tokio::task::JoinHandle<()>> {
         let subscribe = self.subscribe.take();
         let lease = self.lease.take()?;
+        lease.begin_release();
         Some(tokio::spawn(async move {
             if let Some(subscribe) = subscribe {
                 subscribe.unsubscribe().await;
@@ -62,6 +63,7 @@ impl Drop for CacheSubscriptionCleanup {
         let Some(lease) = self.lease.take() else {
             return;
         };
+        lease.begin_release();
         let subscribe = self.subscribe.take();
 
         if let Some(subscribe) = subscribe {
@@ -449,6 +451,8 @@ impl Consumer {
                         cleanup.attach(subscribe);
                         let (subscribe, lease) = cleanup.handles()?;
 
+                        // Opening wins a tied wake above, so recheck abandonment
+                        // before accepting the upstream subscription.
                         let accepted = tokio::select! {
                             result = subscribe.ok() => Some(result),
                             _ = lease.abandoned() => None,

--- a/moq-relay-ietf/src/interest.rs
+++ b/moq-relay-ietf/src/interest.rs
@@ -20,6 +20,7 @@
 //! name, an outstanding guard from the old entry decrements the old counter
 //! instead of making the new entry look busy.
 
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -36,7 +37,13 @@ struct InterestInner {
     /// Number of live guards. The count lives in the watch value so that
     /// mutations and change notifications cannot get out of step.
     count: watch::Sender<usize>,
+    lifecycle: AtomicU8,
+    removed: watch::Sender<bool>,
 }
+
+const ACTIVE: u8 = 0;
+const CLOSING: u8 = 1;
+const REMOVED: u8 = 2;
 
 impl Default for TrackInterest {
     fn default() -> Self {
@@ -47,8 +54,13 @@ impl Default for TrackInterest {
 impl TrackInterest {
     pub fn new() -> Self {
         let (count, _) = watch::channel(0);
+        let (removed, _) = watch::channel(false);
         Self {
-            inner: Arc::new(InterestInner { count }),
+            inner: Arc::new(InterestInner {
+                count,
+                lifecycle: AtomicU8::new(ACTIVE),
+                removed,
+            }),
         }
     }
 
@@ -78,6 +90,28 @@ impl TrackInterest {
     /// entry generation.
     pub fn same_generation(&self, other: &TrackInterest) -> bool {
         Arc::ptr_eq(&self.inner, &other.inner)
+    }
+
+    pub(crate) fn is_closing(&self) -> bool {
+        self.inner.lifecycle.load(Ordering::Acquire) != ACTIVE
+    }
+
+    pub(crate) fn mark_closing(&self) {
+        self.inner.lifecycle.store(CLOSING, Ordering::Release);
+    }
+
+    pub(crate) fn mark_removed(&self) {
+        self.inner.lifecycle.store(REMOVED, Ordering::Release);
+        self.inner.removed.send_replace(true);
+    }
+
+    pub(crate) async fn removed(&self) {
+        let mut removed = self.inner.removed.subscribe();
+        while !*removed.borrow_and_update() {
+            if removed.changed().await.is_err() {
+                return;
+            }
+        }
     }
 
     /// Resolve once the count has been continuously zero for `grace`.

--- a/moq-relay-ietf/src/local.rs
+++ b/moq-relay-ietf/src/local.rs
@@ -74,7 +74,8 @@ pub struct TrackRequest {
     /// Lease on the pull-through cache entry backing this request.
     ///
     /// The requester should hold the upstream subscription open until
-    /// [`CacheLease::released`] resolves, then drop it to send UNSUBSCRIBE.
+    /// [`CacheLease::released`] resolves, wait for upstream cancellation, then
+    /// call [`CacheLease::finish_release`].
     pub lease: CacheLease,
 
     /// Reports whether the upstream subscription was established.
@@ -103,7 +104,7 @@ enum UpstreamState {
 
 /// Readiness gate for the upstream subscription behind a cached track.
 ///
-/// Draft-16 §8.4 requires a relay to have an established upstream subscription
+/// Draft-18 Section 9.4 requires a relay to have an established upstream subscription
 /// before it sends SUBSCRIBE_OK for a downstream SUBSCRIBE. The pull-through
 /// cache reserves its entry synchronously but subscribes upstream asynchronously
 /// (the publishing session owns that side), so the entry exists before the
@@ -119,6 +120,11 @@ pub struct UpstreamReady {
 }
 
 impl UpstreamReady {
+    /// Whether the upstream publisher has not answered yet.
+    pub(crate) fn is_pending(&self) -> bool {
+        matches!(*self.state.borrow(), UpstreamState::Pending)
+    }
+
     /// Wait until the upstream subscription is established.
     ///
     /// Returns the upstream failure if it could not be established, so the caller
@@ -182,10 +188,8 @@ impl UpstreamReadyTx {
 /// Most ways this sender dies are not calls to [`UpstreamReadyTx::established`]
 /// or [`UpstreamReadyTx::failed`]: the owning session can return early, be torn
 /// down mid-handshake, or have its task dropped while parked on the upstream
-/// SUBSCRIBE. In every one of those cases the publisher really is gone, so
-/// failing the gate is the correct outcome and not merely a better log line —
-/// waiting subscribers must be released rather than left until the response
-/// timeout.
+/// SUBSCRIBE. In every one of those cases the publisher really is gone. Failing
+/// the gate releases waiting subscribers before the response timeout.
 ///
 /// Without this, the sender's disappearance was only observable as a closed
 /// channel, which surfaced downstream as an unattributable internal error with
@@ -208,7 +212,7 @@ impl Drop for UpstreamReadyTx {
         // `Uuid::new_v4` panics rather than degrading when the OS entropy
         // source is unavailable (seccomp-blocked `getrandom`, an exhausted fd
         // table with no `/dev/urandom`). A `Drop` must not make a fallible
-        // syscall — and this one especially must not, because it runs *during*
+        // syscall. This code can run during
         // unwinding: a panic here while another panic is in flight aborts the
         // process, turning one failed task into a dead relay.
         //
@@ -221,7 +225,7 @@ impl Drop for UpstreamReadyTx {
         //
         // Built out here rather than in the closure so the allocation stays off
         // the write lock, and so the closure cannot do anything but match and
-        // move — `send_if_modified` re-raises a panicking closure.
+        // move, because `send_if_modified` re-raises a panicking closure.
         let err = ServeError::Internal(
             "upstream publisher went away before the subscription was established".to_string(),
         );
@@ -248,15 +252,16 @@ pub struct CacheLease {
     scope_key: ScopeKey,
     full_name: FullTrackName,
     interest: TrackInterest,
+    finished: bool,
 }
 
 impl CacheLease {
-    /// Resolve once the cache entry has been evicted for lack of interest.
+    /// Resolve once the cache entry is ready for ordered upstream cancellation.
     ///
-    /// The caller should drop its upstream subscription when this returns, which
-    /// sends UNSUBSCRIBE. Eviction happens first so that a subscriber arriving
-    /// afterwards misses the cache and triggers a fresh upstream SUBSCRIBE,
-    /// rather than attaching to a reader that is about to stop being fed.
+    /// The entry remains as a closing generation until
+    /// [`finish_release`](Self::finish_release) is called after the peer has
+    /// ended the old request stream. Subscribers wait for that transition so a
+    /// replacement SUBSCRIBE cannot overtake the old UNSUBSCRIBE.
     ///
     /// Never resolves when the idle timeout is disabled, preserving the previous
     /// behaviour of holding the upstream subscription for the session's lifetime.
@@ -266,13 +271,40 @@ impl CacheLease {
             std::future::pending::<()>().await;
         }
 
+        self.release_after(timeout).await;
+    }
+
+    /// Release an upstream request as soon as every waiting subscriber leaves.
+    ///
+    /// A request that has not been accepted upstream has no warm state worth
+    /// retaining for the normal cache grace period.
+    pub(crate) async fn abandoned(&self) {
+        self.release_after(Duration::ZERO).await;
+    }
+
+    pub(crate) fn finish_release(mut self) {
+        self.release();
+    }
+
+    fn release(&mut self) {
+        if self.finished {
+            return;
+        }
+        self.finished = true;
+        self.locals
+            .remove_cache_generation(&self.scope_key, &self.full_name, &self.interest);
+        self.interest.mark_removed();
+    }
+
+    async fn release_after(&self, timeout: Duration) {
         loop {
             self.interest.idle_for(timeout).await;
 
-            if self
-                .locals
-                .evict_idle_cache_entry(&self.scope_key, &self.full_name, &self.interest)
-            {
+            if self.locals.mark_idle_cache_entry_closing(
+                &self.scope_key,
+                &self.full_name,
+                &self.interest,
+            ) {
                 return;
             }
 
@@ -284,6 +316,14 @@ impl CacheLease {
                 "cache eviction abandoned; downstream interest returned"
             );
         }
+    }
+}
+
+impl Drop for CacheLease {
+    fn drop(&mut self) {
+        // Requests can be abandoned while still buffered in the namespace
+        // queue, before a session takes responsibility for their teardown.
+        self.release();
     }
 }
 
@@ -330,8 +370,8 @@ pub struct LocalTrack {
     /// `None` for locally published tracks, which have no upstream subscription.
     pub interest: Option<TrackInterestGuard>,
 
-    /// Must resolve before the caller sends SUBSCRIBE_OK downstream (draft-16
-    /// §8.4).
+    /// Must resolve before the caller sends SUBSCRIBE_OK downstream (draft-18
+    /// Section 9.4).
     ///
     /// `None` for locally published tracks, which are already established.
     pub upstream: Option<UpstreamReady>,
@@ -473,6 +513,25 @@ impl Locals {
             .ok()
     }
 
+    #[cfg(test)]
+    pub(crate) fn available_rendezvous_holds(&self) -> usize {
+        self.rendezvous_hold_permits.available_permits()
+    }
+
+    #[cfg(test)]
+    fn contains_track_entry(&self, scope: Option<&str>, full_name: &FullTrackName) -> bool {
+        let scope_key = scope.unwrap_or(UNSCOPED);
+        self.tracks
+            .read()
+            .ok()
+            .and_then(|tracks| {
+                tracks
+                    .get(scope_key)
+                    .map(|bucket| bucket.contains_key(full_name))
+            })
+            .unwrap_or(false)
+    }
+
     pub(crate) fn rendezvous_overload_retry_interval(&self) -> u64 {
         let sequence = self
             .rendezvous_retry_sequence
@@ -561,10 +620,13 @@ impl Locals {
             return;
         };
         for key in keys {
-            if bucket
-                .get(key)
-                .is_some_and(|entry| entry.reader.is_closed())
-            {
+            if bucket.get(key).is_some_and(|entry| {
+                entry.reader.is_closed()
+                    && !entry
+                        .interest
+                        .as_ref()
+                        .is_some_and(TrackInterest::is_closing)
+            }) {
                 bucket.remove(key);
             }
         }
@@ -761,7 +823,7 @@ impl Locals {
         None
     }
 
-    /// Remove an unwatched pull-through cache entry.
+    /// Mark an unwatched pull-through cache entry as closing.
     ///
     /// Returns false, leaving the entry in place, if interest returned before the
     /// write lock was acquired, or if the entry has since been replaced by a
@@ -770,7 +832,7 @@ impl Locals {
     /// The idle check happens under the same lock that guards are created under,
     /// so a subscriber racing eviction either gets counted here (and eviction is
     /// abandoned) or misses the cache entirely and requests a fresh one.
-    fn evict_idle_cache_entry(
+    fn mark_idle_cache_entry_closing(
         &self,
         scope_key: &str,
         full_name: &FullTrackName,
@@ -796,6 +858,7 @@ impl Locals {
                     .is_some_and(|current| current.same_generation(interest));
 
                 if !ours {
+                    interest.mark_removed();
                     return true;
                 }
 
@@ -803,23 +866,23 @@ impl Locals {
                     return false;
                 }
 
-                bucket.remove(full_name);
+                interest.mark_closing();
+                metrics::counter!("moq_relay_cache_idle_evictions_total", "source" => "local")
+                    .increment(1);
             }
             // Already gone (e.g. pruned as closed), so the upstream subscription
             // is no longer serving anything.
-            None => return true,
-        }
-
-        if bucket.is_empty() {
-            tracks.remove(scope_key);
+            None => {
+                interest.mark_removed();
+                return true;
+            }
         }
 
         tracing::debug!(
             namespace = %full_name.namespace,
             track = %full_name.name,
-            "evicting idle cached track and releasing upstream subscription"
+            "closing idle cached track before releasing upstream subscription"
         );
-        metrics::counter!("moq_relay_cache_idle_evictions_total", "source" => "local").increment(1);
 
         true
     }
@@ -858,6 +921,14 @@ impl Locals {
         best_match
     }
 
+    pub(crate) fn has_namespace_route(
+        &self,
+        scope: Option<&str>,
+        namespace: &TrackNamespace,
+    ) -> bool {
+        self.route_namespace(scope, namespace).is_some()
+    }
+
     /// Get an existing exact track or request it from a matching namespace source.
     ///
     /// This replaces the old `TracksReader::subscribe` relay registry behavior:
@@ -880,101 +951,123 @@ impl Locals {
         };
         let scope_key = scope.unwrap_or(UNSCOPED).to_string();
 
-        if let Some(hit) = self.retrieve_track_with_interest(&scope_key, &full_name) {
-            return Some(hit);
-        }
-
-        let source = self.route_namespace(scope, &namespace)?;
-
-        // Reserve the pull-through cache slot under a single lock so concurrent
-        // misses for the same track collapse onto one produced reader. The caller
-        // that finds no live entry claims the slot with a freshly produced track and
-        // owns requesting it from the source; concurrent callers share the reserved
-        // reader instead of racing to insert and failing with a spurious `None`.
-        let (writer, reader, interest, guard, upstream_tx, upstream) = {
-            let mut tracks = self.tracks.write().ok()?;
-            let bucket = tracks.entry(scope_key.clone()).or_default();
-
-            if let Some(entry) = bucket.get(&full_name) {
-                if !entry.reader.is_closed() {
-                    return Some(LocalTrack {
-                        largest_location: entry.reader.largest_location(),
-                        reader: entry.reader.clone(),
-                        interest: entry.interest.as_ref().map(TrackInterest::guard),
-                        upstream: entry.upstream.clone(),
-                    });
-                }
+        loop {
+            if let Some(hit) = self.retrieve_track_with_interest(scope, &full_name) {
+                return Some(hit);
             }
 
-            // Vacant slot (or a stale, closed reader): claim it with a fresh track.
-            let (writer, reader) = Track::new(namespace, track_name).produce();
-            let interest = TrackInterest::new();
+            let source = self.route_namespace(scope, &namespace)?;
 
-            // Take this caller's guard before the entry is visible to anyone
-            // else, so the entry can never be seen as idle while we are still
-            // setting up the upstream subscription.
-            let guard = interest.guard();
+            // Reserve the pull-through cache slot under a single lock so concurrent
+            // misses for the same track collapse onto one produced reader. The caller
+            // that finds no live entry claims the slot with a freshly produced track and
+            // owns requesting it from the source; concurrent callers share the reserved
+            // reader instead of racing to insert and failing with a spurious `None`.
+            let mut closing_generation = None;
+            let created = {
+                let mut tracks = self.tracks.write().ok()?;
+                let bucket = tracks.entry(scope_key.clone()).or_default();
 
-            // Published alongside the entry so that a subscriber arriving while
-            // the upstream handshake is still in flight shares this gate rather
-            // than being served a reader nothing has subscribed to yet.
-            let (upstream_tx, upstream_rx) = watch::channel(UpstreamState::Pending);
-            let upstream = UpstreamReady { state: upstream_rx };
+                if let Some(entry) = bucket.get(&full_name) {
+                    if let Some(closing) = entry
+                        .interest
+                        .as_ref()
+                        .filter(|interest| interest.is_closing())
+                        .cloned()
+                    {
+                        closing_generation = Some(closing);
+                    } else if !entry.reader.is_closed() {
+                        return Some(LocalTrack {
+                            largest_location: entry.reader.largest_location(),
+                            reader: entry.reader.clone(),
+                            interest: entry.interest.as_ref().map(TrackInterest::guard),
+                            upstream: entry.upstream.clone(),
+                        });
+                    }
+                }
 
-            bucket.insert(
-                full_name.clone(),
-                TrackEntry {
-                    reader: reader.clone(),
-                    source: TrackSource::Cache,
-                    interest: Some(interest.clone()),
-                    upstream: Some(upstream.clone()),
-                },
-            );
-            (
-                writer,
+                if closing_generation.is_some() {
+                    None
+                } else {
+                    // Vacant slot (or a stale, closed reader): claim it with a fresh track.
+                    let (writer, reader) =
+                        Track::new(namespace.clone(), track_name.clone()).produce();
+                    let interest = TrackInterest::new();
+
+                    // Take this caller's guard before the entry is visible to anyone
+                    // else, so the entry can never be seen as idle while we are still
+                    // setting up the upstream subscription.
+                    let guard = interest.guard();
+
+                    // Published alongside the entry so that a subscriber arriving while
+                    // the upstream handshake is still in flight shares this gate rather
+                    // than being served a reader nothing has subscribed to yet.
+                    let (upstream_tx, upstream_rx) = watch::channel(UpstreamState::Pending);
+                    let upstream = UpstreamReady { state: upstream_rx };
+
+                    bucket.insert(
+                        full_name.clone(),
+                        TrackEntry {
+                            reader: reader.clone(),
+                            source: TrackSource::Cache,
+                            interest: Some(interest.clone()),
+                            upstream: Some(upstream.clone()),
+                        },
+                    );
+                    Some((
+                        writer,
+                        reader,
+                        interest,
+                        guard,
+                        UpstreamReadyTx { state: upstream_tx },
+                        upstream,
+                    ))
+                }
+            };
+
+            if let Some(closing) = closing_generation {
+                closing.removed().await;
+                continue;
+            }
+            let (writer, reader, interest, guard, upstream_tx, upstream) = created?;
+
+            let lease = CacheLease {
+                locals: self.clone(),
+                scope_key: scope_key.clone(),
+                full_name: full_name.clone(),
+                interest: interest.clone(),
+                finished: false,
+            };
+            let cleanup = CacheGenerationCleanup {
+                locals: self.clone(),
+                scope_key: scope_key.clone(),
+                full_name: full_name.clone(),
+                interest: interest.clone(),
+                armed: true,
+            };
+
+            if source
+                .requests
+                .send(TrackRequest {
+                    writer,
+                    lease,
+                    upstream: upstream_tx,
+                })
+                .await
+                .is_err()
+            {
+                return None;
+            }
+
+            cleanup.disarm();
+
+            return Some(LocalTrack {
                 reader,
-                interest,
-                guard,
-                UpstreamReadyTx { state: upstream_tx },
-                upstream,
-            )
-        };
-
-        let lease = CacheLease {
-            locals: self.clone(),
-            scope_key: scope_key.clone(),
-            full_name: full_name.clone(),
-            interest: interest.clone(),
-        };
-        let cleanup = CacheGenerationCleanup {
-            locals: self.clone(),
-            scope_key: scope_key.clone(),
-            full_name: full_name.clone(),
-            interest: interest.clone(),
-            armed: true,
-        };
-
-        if source
-            .requests
-            .send(TrackRequest {
-                writer,
-                lease,
-                upstream: upstream_tx,
-            })
-            .await
-            .is_err()
-        {
-            return None;
+                largest_location: None,
+                interest: Some(guard),
+                upstream: Some(upstream),
+            });
         }
-
-        cleanup.disarm();
-
-        Some(LocalTrack {
-            reader,
-            largest_location: None,
-            interest: Some(guard),
-            upstream: Some(upstream),
-        })
     }
 
     /// Remove a cache entry if it is still the given generation, regardless of
@@ -1006,6 +1099,8 @@ impl Locals {
         if bucket.is_empty() {
             tracks.remove(scope_key);
         }
+
+        interest.mark_removed();
     }
 
     /// Cache lookup that also registers interest, under a single lock.
@@ -1013,16 +1108,23 @@ impl Locals {
     /// Interest must be registered while the lock is held: taking the guard after
     /// releasing it would leave a window where eviction sees an idle entry and
     /// removes the reader this caller is about to serve.
-    fn retrieve_track_with_interest(
+    pub(crate) fn retrieve_track_with_interest(
         &self,
-        scope_key: &str,
+        scope: Option<&str>,
         full_name: &FullTrackName,
     ) -> Option<LocalTrack> {
+        let scope_key = scope.unwrap_or(UNSCOPED);
         {
             let tracks = self.tracks.read().ok()?;
             let bucket = tracks.get(scope_key)?;
             match bucket.get(full_name) {
-                Some(entry) if !entry.reader.is_closed() => {
+                Some(entry)
+                    if !entry.reader.is_closed()
+                        && !entry
+                            .interest
+                            .as_ref()
+                            .is_some_and(TrackInterest::is_closing) =>
+                {
                     return Some(LocalTrack {
                         largest_location: entry.reader.largest_location(),
                         reader: entry.reader.clone(),
@@ -2045,8 +2147,8 @@ mod tests {
     /// drains its request queue, so the request is destroyed while still
     /// buffered in the channel rather than after being received.
     ///
-    /// This is `Consumer::serve` returning early — a failed coordinator
-    /// registration, or the session being torn down — after
+    /// This is `Consumer::serve` returning early after a failed coordinator
+    /// registration or session teardown, once
     /// `register_namespace` has already published the route source. Distinct
     /// from `abandoned_request_releases_waiting_subscribers`, which drops a
     /// request that was successfully received.
@@ -2054,6 +2156,7 @@ mod tests {
     async fn requests_stranded_in_the_queue_release_waiting_subscribers() {
         let mut locals = Locals::new();
         let namespace = ns("room/123");
+        let full_name = full(&namespace, "video");
         let (_registration, requests) = locals
             .register_namespace(None, namespace.clone())
             .await
@@ -2067,9 +2170,11 @@ mod tests {
             .expect("missing track should be requested")
             .upstream
             .expect("cached track should hand back a gate");
+        assert!(locals.contains_track_entry(None, &full_name));
 
         // The session aborts without ever calling `requests.recv()`.
         drop(requests);
+        assert!(!locals.contains_track_entry(None, &full_name));
 
         let err = tokio::time::timeout(Duration::from_secs(5), upstream.established())
             .await
@@ -2149,7 +2254,7 @@ mod tests {
     ///
     /// `watch::Sender::send` refuses to update once the last receiver drops,
     /// which would leave a successfully established subscription sitting on
-    /// `Pending` — indistinguishable from abandonment, and so reported as a
+    /// `Pending`. The `Drop` fallback would treat that state as abandonment and report a
     /// spurious failure by the `Drop` fallback.
     ///
     /// Driven against the sender directly: in the registry the cache entry
@@ -2169,7 +2274,7 @@ mod tests {
         );
     }
 
-    /// With the outcome recorded, `Drop` must leave it alone — otherwise the
+    /// With the outcome recorded, `Drop` must leave it alone. Otherwise the
     /// fallback would rewrite a success into a failure.
     #[test]
     fn drop_does_not_rewrite_an_outcome_recorded_without_receivers() {
@@ -2256,27 +2361,30 @@ mod tests {
         let request = requests.recv().await.expect("source should get a request");
         let key = full(&namespace, "video");
 
-        // While a subscriber is being served the entry must stay put.
-        let released = request.lease.released();
-        tokio::pin!(released);
-        tokio::select! {
-            _ = &mut released => panic!("evicted a track that still has a subscriber"),
-            _ = tokio::time::sleep(idle * 4) => {}
-        }
-        assert!(locals.retrieve_track(None, &key).is_some());
+        {
+            // While a subscriber is being served the entry must stay put.
+            let released = request.lease.released();
+            tokio::pin!(released);
+            tokio::select! {
+                _ = &mut released => panic!("evicted a track that still has a subscriber"),
+                _ = tokio::time::sleep(idle * 4) => {}
+            }
+            assert!(locals.retrieve_track(None, &key).is_some());
 
-        // Last subscriber leaves: the entry lingers for the grace period, then goes.
-        drop(guard);
-        tokio::select! {
-            _ = &mut released => panic!("evicted before the grace period elapsed"),
-            _ = tokio::time::sleep(idle / 2) => {}
-        }
-        assert!(
-            locals.retrieve_track(None, &key).is_some(),
-            "a warm cache entry should survive a brief gap between subscribers"
-        );
+            // Last subscriber leaves: the entry lingers for the grace period, then goes.
+            drop(guard);
+            tokio::select! {
+                _ = &mut released => panic!("evicted before the grace period elapsed"),
+                _ = tokio::time::sleep(idle / 2) => {}
+            }
+            assert!(
+                locals.retrieve_track(None, &key).is_some(),
+                "a warm cache entry should survive a brief gap between subscribers"
+            );
 
-        released.await;
+            released.await;
+        }
+        request.lease.finish_release();
         assert!(
             locals.retrieve_track(None, &key).is_none(),
             "idle entry should be evicted so the next subscriber re-requests upstream"
@@ -2301,41 +2409,44 @@ mod tests {
             .expect("missing track should be requested");
         let request = requests.recv().await.expect("source should get a request");
 
-        let released = request.lease.released();
-        tokio::pin!(released);
+        {
+            let released = request.lease.released();
+            tokio::pin!(released);
 
-        drop(
-            local
+            drop(
+                local
+                    .interest
+                    .expect("cached track should hand back a guard"),
+            );
+
+            tokio::select! {
+                _ = &mut released => panic!("evicted before the grace period elapsed"),
+                _ = tokio::time::sleep(idle / 2) => {}
+            }
+
+            // New subscriber inside the grace period: served from cache, no new request.
+            let guard = locals
+                .get_or_request_track(None, namespace.clone(), "video")
+                .await
+                .expect("warm entry should still be served")
                 .interest
-                .expect("cached track should hand back a guard"),
-        );
+                .expect("cached track should hand back a guard");
 
-        tokio::select! {
-            _ = &mut released => panic!("evicted before the grace period elapsed"),
-            _ = tokio::time::sleep(idle / 2) => {}
+            tokio::select! {
+                _ = &mut released => panic!("evicted while a subscriber was present"),
+                _ = tokio::time::sleep(idle * 4) => {}
+            }
+
+            assert!(
+                requests.try_recv().is_err(),
+                "reusing the warm entry must not trigger a second upstream SUBSCRIBE"
+            );
+
+            // And it still gets evicted once that subscriber leaves too.
+            drop(guard);
+            released.await;
         }
-
-        // New subscriber inside the grace period: served from cache, no new request.
-        let guard = locals
-            .get_or_request_track(None, namespace.clone(), "video")
-            .await
-            .expect("warm entry should still be served")
-            .interest
-            .expect("cached track should hand back a guard");
-
-        tokio::select! {
-            _ = &mut released => panic!("evicted while a subscriber was present"),
-            _ = tokio::time::sleep(idle * 4) => {}
-        }
-
-        assert!(
-            requests.try_recv().is_err(),
-            "reusing the warm entry must not trigger a second upstream SUBSCRIBE"
-        );
-
-        // And it still gets evicted once that subscriber leaves too.
-        drop(guard);
-        released.await;
+        request.lease.finish_release();
         assert!(locals
             .retrieve_track(None, &full(&namespace, "video"))
             .is_none());
@@ -2364,6 +2475,7 @@ mod tests {
 
         let request = requests.recv().await.expect("source should get a request");
         request.lease.released().await;
+        request.lease.finish_release();
 
         assert!(
             locals
@@ -2371,6 +2483,32 @@ mod tests {
                 .is_none(),
             "an abandoned request must not leave a permanently leased entry"
         );
+    }
+
+    #[tokio::test]
+    async fn pending_request_is_released_without_cache_grace() {
+        let idle = Duration::from_secs(30);
+        let mut locals = Locals::with_cache_idle_timeout(idle);
+        let namespace = ns("room/123");
+        let (_registration, mut requests) = locals
+            .register_namespace(None, namespace.clone())
+            .await
+            .expect("namespace source should register");
+
+        let local = locals
+            .get_or_request_track(None, namespace.clone(), "video")
+            .await
+            .expect("missing track should be requested");
+        let request = requests.recv().await.expect("source should get a request");
+        drop(local);
+
+        tokio::time::timeout(Duration::from_secs(1), request.lease.abandoned())
+            .await
+            .expect("pending request retained the cache grace period");
+        request.lease.finish_release();
+        assert!(locals
+            .retrieve_track(None, &full(&namespace, "video"))
+            .is_none());
     }
 
     /// A zero timeout preserves the old behaviour: the upstream subscription is
@@ -2444,6 +2582,7 @@ mod tests {
         // entry look busy.
         let _ = &stale_guard;
         second_request.lease.released().await;
+        second_request.lease.finish_release();
 
         assert!(
             locals.retrieve_track(None, &key).is_none(),

--- a/moq-relay-ietf/src/local.rs
+++ b/moq-relay-ietf/src/local.rs
@@ -286,6 +286,11 @@ impl CacheLease {
         self.release();
     }
 
+    pub(crate) fn begin_release(&self) {
+        self.locals
+            .mark_cache_entry_closing(&self.scope_key, &self.full_name, &self.interest);
+    }
+
     fn release(&mut self) {
         if self.finished {
             return;
@@ -577,7 +582,7 @@ impl Locals {
 
         // Collect matching readers under a shared read lock so concurrent
         // SUBSCRIBE_NAMESPACE fan-outs don't serialize against each other. Note any
-        // closed entries and prune them afterwards under a brief write lock, keeping
+        // closed entries and handle them afterwards under a brief write lock, keeping
         // the common (no-stale) path read-only.
         let mut matches = Vec::new();
         let mut stale = Vec::new();
@@ -600,38 +605,33 @@ impl Locals {
         }
 
         if !stale.is_empty() {
-            self.prune_closed_tracks(scope_key, &stale);
+            self.mark_closed_cache_tracks(scope_key, &stale);
         }
 
         matches
     }
 
-    /// Remove the given tracks from a scope bucket if they are still closed.
+    /// Mark closed cache entries as closing without removing published generations.
     ///
     /// Invoked off the read path (e.g. by [`Locals::list_tracks_matching`]) so that
-    /// closed-entry cleanup takes the write lock only briefly and only when a closed
-    /// entry was actually observed. The re-check guards against removing an entry
-    /// that a concurrent writer replaced with a live reader.
-    fn prune_closed_tracks(&self, scope_key: &str, keys: &[FullTrackName]) {
-        let Ok(mut tracks) = self.tracks.write() else {
+    /// the transition takes the write lock only briefly. The re-check avoids marking
+    /// an entry that a concurrent writer replaced with a live reader.
+    fn mark_closed_cache_tracks(&self, scope_key: &str, keys: &[FullTrackName]) {
+        let Ok(tracks) = self.tracks.write() else {
             return;
         };
-        let Some(bucket) = tracks.get_mut(scope_key) else {
+        let Some(bucket) = tracks.get(scope_key) else {
             return;
         };
         for key in keys {
-            if bucket.get(key).is_some_and(|entry| {
-                entry.reader.is_closed()
-                    && !entry
-                        .interest
-                        .as_ref()
-                        .is_some_and(TrackInterest::is_closing)
-            }) {
-                bucket.remove(key);
+            if let Some(entry) = bucket.get(key).filter(|entry| entry.reader.is_closed()) {
+                // Cache entries remain as a closing generation until their
+                // upstream request stream is torn down. Published entries are
+                // removed only by their generation-owning registration.
+                if let Some(interest) = &entry.interest {
+                    interest.mark_closing();
+                }
             }
-        }
-        if bucket.is_empty() {
-            tracks.remove(scope_key);
         }
     }
 
@@ -787,13 +787,14 @@ impl Locals {
 
         let _ = self.track_changes.send(TrackChange::Added {
             scope: scope_key_to_option(&scope_key),
-            track,
+            track: track.clone(),
         });
 
         Ok(LocalTrackRegistration {
             locals: self.clone(),
             scope_key,
             full_name,
+            reader: track,
             _gauge_guard: GaugeGuard::new("moq_relay_active_published_tracks"),
         })
     }
@@ -817,9 +818,9 @@ impl Locals {
             }
         }
 
-        // The entry was closed; remove it under a brief write lock (re-checking in
-        // case a concurrent writer replaced it with a live reader).
-        self.prune_closed_tracks(scope_key, std::slice::from_ref(full_name));
+        // A closed cache entry must remain visible as a closing generation until
+        // its upstream request stream is torn down.
+        self.mark_closed_cache_tracks(scope_key, std::slice::from_ref(full_name));
         None
     }
 
@@ -885,6 +886,27 @@ impl Locals {
         );
 
         true
+    }
+
+    fn mark_cache_entry_closing(
+        &self,
+        scope_key: &str,
+        full_name: &FullTrackName,
+        interest: &TrackInterest,
+    ) {
+        let Ok(tracks) = self.tracks.write() else {
+            return;
+        };
+        let ours = tracks
+            .get(scope_key)
+            .and_then(|bucket| bucket.get(full_name))
+            .and_then(|entry| entry.interest.as_ref())
+            .is_some_and(|current| current.same_generation(interest));
+        if ours {
+            interest.mark_closing();
+        } else {
+            interest.mark_removed();
+        }
     }
 
     /// Return the best namespace route source for a requested namespace.
@@ -964,6 +986,7 @@ impl Locals {
             // owns requesting it from the source; concurrent callers share the reserved
             // reader instead of racing to insert and failing with a spurious `None`.
             let mut closing_generation = None;
+            let mut removed_published = false;
             let created = {
                 let mut tracks = self.tracks.write().ok()?;
                 let bucket = tracks.entry(scope_key.clone()).or_default();
@@ -983,6 +1006,11 @@ impl Locals {
                             interest: entry.interest.as_ref().map(TrackInterest::guard),
                             upstream: entry.upstream.clone(),
                         });
+                    } else if let Some(interest) = &entry.interest {
+                        interest.mark_closing();
+                        closing_generation = Some(interest.clone());
+                    } else if entry.source == TrackSource::Published {
+                        removed_published = true;
                     }
                 }
 
@@ -1024,6 +1052,13 @@ impl Locals {
                     ))
                 }
             };
+
+            if removed_published {
+                let _ = self.track_changes.send(TrackChange::Removed {
+                    scope: scope_key_to_option(&scope_key),
+                    full_name: full_name.clone(),
+                });
+            }
 
             if let Some(closing) = closing_generation {
                 closing.removed().await;
@@ -1137,7 +1172,7 @@ impl Locals {
             }
         }
 
-        self.prune_closed_tracks(scope_key, std::slice::from_ref(full_name));
+        self.mark_closed_cache_tracks(scope_key, std::slice::from_ref(full_name));
         None
     }
 }
@@ -1236,6 +1271,7 @@ pub struct LocalTrackRegistration {
     locals: Locals,
     scope_key: ScopeKey,
     full_name: FullTrackName,
+    reader: TrackReader,
     _gauge_guard: GaugeGuard,
 }
 
@@ -1250,21 +1286,24 @@ impl Drop for LocalTrackRegistration {
         };
         tracing::debug!(namespace = %namespace, track = %track, scope = %scope, "deregistering track from locals");
 
-        let mut removed = false;
         if let Ok(mut tracks) = self.locals.tracks.write() {
             if let Some(bucket) = tracks.get_mut(self.scope_key.as_str()) {
-                removed = bucket.remove(&self.full_name).is_some();
+                let ours = bucket.get(&self.full_name).is_some_and(|entry| {
+                    entry.source == TrackSource::Published
+                        && Arc::ptr_eq(&entry.reader.info, &self.reader.info)
+                });
+                if ours {
+                    if bucket.remove(&self.full_name).is_some() {
+                        let _ = self.locals.track_changes.send(TrackChange::Removed {
+                            scope: scope_key_to_option(&self.scope_key),
+                            full_name: self.full_name.clone(),
+                        });
+                    }
+                }
                 if bucket.is_empty() {
                     tracks.remove(self.scope_key.as_str());
                 }
             }
-        }
-
-        if removed {
-            let _ = self.locals.track_changes.send(TrackChange::Removed {
-                scope: scope_key_to_option(&self.scope_key),
-                full_name: self.full_name.clone(),
-            });
         }
     }
 }
@@ -1500,6 +1539,92 @@ mod tests {
         assert!(locals.retrieve_track(None, &key).is_none());
 
         drop(writer);
+    }
+
+    #[tokio::test]
+    async fn closed_published_track_remains_owned_until_registration_drops() {
+        let mut locals = Locals::new();
+        let namespace = ns("room/123");
+        let (writer, reader) = Track::new(namespace.clone(), "audio").produce();
+        let registration = locals
+            .register_track(None, reader)
+            .await
+            .expect("track registration should succeed");
+        drop(writer);
+
+        assert!(locals
+            .retrieve_track(None, &full(&namespace, "audio"))
+            .is_none());
+        let (_replacement_writer, replacement_reader) =
+            Track::new(namespace.clone(), "audio").produce();
+        assert!(locals
+            .register_track(None, replacement_reader.clone())
+            .await
+            .is_err());
+
+        drop(registration);
+        let _replacement = locals
+            .register_track(None, replacement_reader)
+            .await
+            .expect("replacement should register after the old owner drops");
+    }
+
+    #[tokio::test]
+    async fn stale_published_registration_does_not_remove_cache_replacement() {
+        let mut locals = Locals::new();
+        let mut changes = locals.subscribe_track_changes();
+        let namespace = ns("room/123");
+        let (_namespace_registration, mut requests) = locals
+            .register_namespace(None, namespace.clone())
+            .await
+            .expect("namespace source should register");
+        let (writer, reader) = Track::new(namespace.clone(), "audio").produce();
+        let published_registration = locals
+            .register_track(None, reader)
+            .await
+            .expect("published track should register");
+        assert!(matches!(
+            changes.recv().await.expect("published track added"),
+            TrackChange::Added { .. }
+        ));
+        drop(writer);
+
+        let cached = locals
+            .get_or_request_track(None, namespace.clone(), "audio")
+            .await
+            .expect("closed published track should be replaced from namespace source");
+        let request = requests.recv().await.expect("cache request");
+        assert!(matches!(
+            changes
+                .recv()
+                .await
+                .expect("closed published track removed"),
+            TrackChange::Removed { .. }
+        ));
+
+        drop(published_registration);
+        assert!(locals
+            .retrieve_track(None, &full(&namespace, "audio"))
+            .is_some());
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), changes.recv())
+                .await
+                .is_err(),
+            "stale registration emitted a duplicate removal"
+        );
+
+        drop(cached);
+        request.lease.finish_release();
+        let (_replacement_writer, replacement_reader) =
+            Track::new(namespace.clone(), "audio").produce();
+        let _replacement = locals
+            .register_track(None, replacement_reader)
+            .await
+            .expect("published replacement should register");
+        assert!(matches!(
+            changes.recv().await.expect("replacement track added"),
+            TrackChange::Added { .. }
+        ));
     }
 
     #[tokio::test]
@@ -2509,6 +2634,49 @@ mod tests {
         assert!(locals
             .retrieve_track(None, &full(&namespace, "video"))
             .is_none());
+    }
+
+    #[tokio::test]
+    async fn closed_cache_generation_blocks_replacement_until_lease_finishes() {
+        let mut locals = Locals::new();
+        let namespace = ns("room/123");
+        let (_registration, mut requests) = locals
+            .register_namespace(None, namespace.clone())
+            .await
+            .expect("namespace source should register");
+        let first = locals
+            .get_or_request_track(None, namespace.clone(), "video")
+            .await
+            .expect("first request");
+        let TrackRequest {
+            writer,
+            lease,
+            upstream,
+        } = requests.recv().await.expect("first request received");
+
+        drop(writer);
+        drop(upstream);
+
+        let replacement = locals.get_or_request_track(None, namespace.clone(), "video");
+        tokio::pin!(replacement);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), &mut replacement)
+                .await
+                .is_err(),
+            "a replacement overtook the closing cache generation"
+        );
+        assert!(requests.try_recv().is_err());
+
+        lease.finish_release();
+        let second = tokio::time::timeout(Duration::from_secs(1), &mut replacement)
+            .await
+            .expect("replacement remained blocked after teardown")
+            .expect("replacement request");
+        let second_request = requests.recv().await.expect("second request received");
+
+        drop(first);
+        drop(second);
+        second_request.lease.finish_release();
     }
 
     /// A zero timeout preserves the old behaviour: the upstream subscription is

--- a/moq-relay-ietf/src/local.rs
+++ b/moq-relay-ietf/src/local.rs
@@ -158,13 +158,84 @@ pub struct UpstreamReadyTx {
 impl UpstreamReadyTx {
     /// Report that the upstream publisher acknowledged the SUBSCRIBE.
     pub fn established(&self) {
-        // Fails only when every downstream subscriber has already gone away.
-        let _ = self.state.send(UpstreamState::Established);
+        self.resolve(UpstreamState::Established);
     }
 
     /// Report that the upstream subscription could not be established.
     pub fn failed(&self, err: ServeError) {
-        let _ = self.state.send(UpstreamState::Failed(err));
+        self.resolve(UpstreamState::Failed(err));
+    }
+
+    /// Record the outcome, whether or not anyone is currently waiting.
+    ///
+    /// `watch::Sender::send` refuses to update once the last receiver is gone,
+    /// which would leave the state on `Pending` forever and make a resolved
+    /// subscription indistinguishable from an abandoned one. The outcome is
+    /// what [`Drop`] keys off, so it has to be recorded unconditionally.
+    fn resolve(&self, outcome: UpstreamState) {
+        self.state.send_replace(outcome);
+    }
+}
+
+/// Resolve the gate on drop so abandonment is never silent.
+///
+/// Most ways this sender dies are not calls to [`UpstreamReadyTx::established`]
+/// or [`UpstreamReadyTx::failed`]: the owning session can return early, be torn
+/// down mid-handshake, or have its task dropped while parked on the upstream
+/// SUBSCRIBE. In every one of those cases the publisher really is gone, so
+/// failing the gate is the correct outcome and not merely a better log line —
+/// waiting subscribers must be released rather than left until the response
+/// timeout.
+///
+/// Without this, the sender's disappearance was only observable as a closed
+/// channel, which surfaced downstream as an unattributable internal error with
+/// no indication of which session gave up or why.
+impl Drop for UpstreamReadyTx {
+    fn drop(&mut self) {
+        // Fast path: already resolved. Checked before building the error so a
+        // successful subscription's teardown neither allocates nor takes the
+        // write lock.
+        //
+        // This must stay an `if` around `matches!`. The condition of an `if` is
+        // a temporary scope, so the read guard is released before the body
+        // runs; `if let` is not, and would hold it across the write lock below
+        // and self-deadlock every abandoned request.
+        if !matches!(&*self.state.borrow(), UpstreamState::Pending) {
+            return;
+        }
+
+        // Deliberately not `ServeError::internal_ctx`: that mints a UUID, and
+        // `Uuid::new_v4` panics rather than degrading when the OS entropy
+        // source is unavailable (seccomp-blocked `getrandom`, an exhausted fd
+        // table with no `/dev/urandom`). A `Drop` must not make a fallible
+        // syscall — and this one especially must not, because it runs *during*
+        // unwinding: a panic here while another panic is in flight aborts the
+        // process, turning one failed task into a dead relay.
+        //
+        // Nothing is logged here either. The waiting subscriber already reports
+        // this at its own site, with the namespace and track attached, so the
+        // reason only has to be carried in the error itself. Spelling it out
+        // rather than hiding it behind a correlation id makes that report
+        // self-explanatory and gives the downstream REQUEST_ERROR an honest
+        // reason phrase; there is nothing sensitive in "the publisher left".
+        //
+        // Built out here rather than in the closure so the allocation stays off
+        // the write lock, and so the closure cannot do anything but match and
+        // move — `send_if_modified` re-raises a panicking closure.
+        let err = ServeError::Internal(
+            "upstream publisher went away before the subscription was established".to_string(),
+        );
+
+        // Re-check under the lock so a concurrently recorded outcome always
+        // wins over this fallback; the sender is never cloned, so this is
+        // belt-and-braces rather than a live race.
+        self.state.send_if_modified(|state| match state {
+            UpstreamState::Pending => {
+                *state = UpstreamState::Failed(err);
+                true
+            }
+            _ => false,
+        });
     }
 }
 
@@ -1961,9 +2032,177 @@ mod tests {
             .established()
             .await
             .expect_err("an abandoned request must not leave subscribers waiting forever");
+        // The reason is spelled out rather than reported as an opaque internal
+        // error: abandonment used to be indistinguishable from any other
+        // internal fault once it reached the subscriber.
         assert!(
-            matches!(err, ServeError::InternalWithId(_, _)),
+            matches!(&err, ServeError::Internal(reason) if reason.contains("upstream publisher went away")),
             "unexpected error: {err}"
+        );
+    }
+
+    /// The production strand: the owning session gives up *before* it ever
+    /// drains its request queue, so the request is destroyed while still
+    /// buffered in the channel rather than after being received.
+    ///
+    /// This is `Consumer::serve` returning early — a failed coordinator
+    /// registration, or the session being torn down — after
+    /// `register_namespace` has already published the route source. Distinct
+    /// from `abandoned_request_releases_waiting_subscribers`, which drops a
+    /// request that was successfully received.
+    #[tokio::test]
+    async fn requests_stranded_in_the_queue_release_waiting_subscribers() {
+        let mut locals = Locals::new();
+        let namespace = ns("room/123");
+        let (_registration, requests) = locals
+            .register_namespace(None, namespace.clone())
+            .await
+            .expect("namespace source should register");
+
+        // A downstream SUBSCRIBE lands in the window between the route source
+        // being published and the owning session reaching its drain loop.
+        let upstream = locals
+            .get_or_request_track(None, namespace.clone(), "video")
+            .await
+            .expect("missing track should be requested")
+            .upstream
+            .expect("cached track should hand back a gate");
+
+        // The session aborts without ever calling `requests.recv()`.
+        drop(requests);
+
+        let err = tokio::time::timeout(Duration::from_secs(5), upstream.established())
+            .await
+            .expect("a stranded request must not leave subscribers waiting")
+            .expect_err("a stranded request is not an established subscription");
+        assert!(
+            matches!(&err, ServeError::Internal(reason) if reason.contains("upstream publisher went away")),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// A resolved gate must survive the sender's drop.
+    ///
+    /// The sender outlives `established()` by the whole lifetime of the
+    /// upstream subscription, so if its `Drop` overwrote the outcome, every
+    /// subscriber arriving after a track stopped would be told the upstream
+    /// failed when it had in fact succeeded.
+    #[tokio::test]
+    async fn dropping_a_resolved_sender_does_not_overwrite_the_outcome() {
+        let mut locals = Locals::new();
+        let namespace = ns("room/123");
+        let (_registration, mut requests) = locals
+            .register_namespace(None, namespace.clone())
+            .await
+            .expect("namespace source should register");
+
+        let upstream = locals
+            .get_or_request_track(None, namespace.clone(), "video")
+            .await
+            .expect("missing track should be requested")
+            .upstream
+            .expect("cached track should hand back a gate");
+
+        let request = requests.recv().await.expect("source should get a request");
+        request.upstream.established();
+        drop(request);
+
+        tokio::time::timeout(Duration::from_secs(5), upstream.established())
+            .await
+            .expect("a resolved gate must not block")
+            .expect("dropping the sender must not turn success into failure");
+    }
+
+    /// The same guarantee for an explicit failure: the reported reason must not
+    /// be replaced by the generic drop fallback.
+    #[tokio::test]
+    async fn dropping_a_failed_sender_preserves_the_reported_reason() {
+        let mut locals = Locals::new();
+        let namespace = ns("room/123");
+        let (_registration, mut requests) = locals
+            .register_namespace(None, namespace.clone())
+            .await
+            .expect("namespace source should register");
+
+        let upstream = locals
+            .get_or_request_track(None, namespace.clone(), "video")
+            .await
+            .expect("missing track should be requested")
+            .upstream
+            .expect("cached track should hand back a gate");
+
+        let request = requests.recv().await.expect("source should get a request");
+        request.upstream.failed(ServeError::NotFound);
+        drop(request);
+
+        let err = tokio::time::timeout(Duration::from_secs(5), upstream.established())
+            .await
+            .expect("a resolved gate must not block")
+            .expect_err("the upstream failure should surface");
+        assert!(
+            matches!(err, ServeError::NotFound),
+            "drop fallback overwrote the real reason: {err}"
+        );
+    }
+
+    /// Resolving with every receiver already gone must still be recorded.
+    ///
+    /// `watch::Sender::send` refuses to update once the last receiver drops,
+    /// which would leave a successfully established subscription sitting on
+    /// `Pending` — indistinguishable from abandonment, and so reported as a
+    /// spurious failure by the `Drop` fallback.
+    ///
+    /// Driven against the sender directly: in the registry the cache entry
+    /// holds its own receiver, so the last-receiver case cannot be staged
+    /// through `get_or_request_track`.
+    #[test]
+    fn outcome_is_recorded_after_the_last_receiver_is_gone() {
+        let (state_tx, state_rx) = watch::channel(UpstreamState::Pending);
+        let tx = UpstreamReadyTx { state: state_tx };
+
+        drop(state_rx);
+        tx.established();
+
+        assert!(
+            matches!(&*tx.state.borrow(), UpstreamState::Established),
+            "the outcome must be recorded even with no receivers left"
+        );
+    }
+
+    /// With the outcome recorded, `Drop` must leave it alone — otherwise the
+    /// fallback would rewrite a success into a failure.
+    #[test]
+    fn drop_does_not_rewrite_an_outcome_recorded_without_receivers() {
+        let (state_tx, state_rx) = watch::channel(UpstreamState::Pending);
+        let tx = UpstreamReadyTx { state: state_tx };
+
+        // Genuinely zero receivers at the moment the outcome is reported; the
+        // observer re-attaches only afterwards, standing in for a subscriber
+        // that arrives while the track is still cached.
+        drop(state_rx);
+        tx.established();
+        let observer = tx.state.subscribe();
+        drop(tx);
+
+        assert!(
+            matches!(&*observer.borrow(), UpstreamState::Established),
+            "drop must not overwrite a recorded success"
+        );
+    }
+
+    /// An unresolved sender must fail the gate on drop rather than leaving it
+    /// pending: that is what releases subscribers when a session is torn down
+    /// while parked on the upstream SUBSCRIBE.
+    #[test]
+    fn drop_resolves_an_unreported_outcome_as_failed() {
+        let (state_tx, state_rx) = watch::channel(UpstreamState::Pending);
+        let tx = UpstreamReadyTx { state: state_tx };
+
+        drop(tx);
+
+        assert!(
+            matches!(&*state_rx.borrow(), UpstreamState::Failed(_)),
+            "an unresolved sender must fail the gate on drop"
         );
     }
 

--- a/moq-relay-ietf/src/local.rs
+++ b/moq-relay-ietf/src/local.rs
@@ -1292,13 +1292,11 @@ impl Drop for LocalTrackRegistration {
                     entry.source == TrackSource::Published
                         && Arc::ptr_eq(&entry.reader.info, &self.reader.info)
                 });
-                if ours {
-                    if bucket.remove(&self.full_name).is_some() {
-                        let _ = self.locals.track_changes.send(TrackChange::Removed {
-                            scope: scope_key_to_option(&self.scope_key),
-                            full_name: self.full_name.clone(),
-                        });
-                    }
+                if ours && bucket.remove(&self.full_name).is_some() {
+                    let _ = self.locals.track_changes.send(TrackChange::Removed {
+                        scope: scope_key_to_option(&self.scope_key),
+                        full_name: self.full_name.clone(),
+                    });
                 }
                 if bucket.is_empty() {
                     tracks.remove(self.scope_key.as_str());

--- a/moq-relay-ietf/src/metrics.rs
+++ b/moq-relay-ietf/src/metrics.rs
@@ -24,8 +24,8 @@
 //! | `moq_relay_connections_closed_total` | - | Total connections that have closed (graceful or error) |
 //! | `moq_relay_connection_errors_total` | `stage` | Connection failures (stage: session_accept, session_run) |
 //! | `moq_relay_publishers_total` | - | Total publishers (PUBLISH_NAMESPACE requests) received |
-//! | `moq_relay_announce_ok_total` | - | Successful REQUEST_OK responses sent for PUBLISH_NAMESPACE |
-//! | `moq_relay_announce_errors_total` | `phase` | PUBLISH_NAMESPACE failures (phase: coordinator_register, local_register, send_ok) |
+//! | `moq_relay_announce_ok_total` | `kind` | Successful REQUEST_OK responses sent for PUBLISH_NAMESPACE (kind: client, proxied) |
+//! | `moq_relay_announce_errors_total` | `phase` | PUBLISH_NAMESPACE failures (phase: local_register, remote_register, coordinator_register, coordinator_lookup, send_ok, forward, peer_fanout) |
 //! | `moq_relay_subscribers_total` | - | Total subscribers (SUBSCRIBE requests) received |
 //! | `moq_relay_subscribe_not_found_total` | - | Track not found after checking all sources |
 //! | `moq_relay_subscribe_route_errors_total` | - | Infrastructure failure when routing to remote |
@@ -94,11 +94,14 @@ pub fn describe_metrics() {
     );
     describe_counter!(
         "moq_relay_announce_ok_total",
-        "Successful REQUEST_OK responses sent for PUBLISH_NAMESPACE"
+        "Successful REQUEST_OK responses sent for PUBLISH_NAMESPACE, by kind \
+         (client: published to this relay; proxied: forwarded by a peer relay \
+         and advertised for discovery only)"
     );
     describe_counter!(
         "moq_relay_announce_errors_total",
-        "PUBLISH_NAMESPACE failures by phase (coordinator_register, local_register, send_ok)"
+        "PUBLISH_NAMESPACE failures by phase (local_register, remote_register, \
+         coordinator_register, coordinator_lookup, send_ok, forward, peer_fanout)"
     );
     describe_counter!(
         "moq_relay_subscribers_total",

--- a/moq-relay-ietf/src/producer.rs
+++ b/moq-relay-ietf/src/producer.rs
@@ -1683,6 +1683,106 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn cancelled_remote_subscribe_tears_down_before_same_track_retry() {
+        let (upstream_server_transport, upstream_client_transport) =
+            loopback_webtransport_pair().await;
+        let (upstream_server, upstream_client) = tokio::join!(
+            TransportSession::accept(upstream_server_transport, None, Transport::WebTransport),
+            TransportSession::connect(upstream_client_transport, None, Transport::WebTransport),
+        );
+        let (upstream_server, mut upstream_publisher, _) =
+            upstream_server.expect("accept upstream MoQT session");
+        let (upstream_client, remote_publisher, remote_subscriber) =
+            upstream_client.expect("connect upstream MoQT session");
+        let remote_url = url::Url::parse("https://relay.example.com/live").unwrap();
+        let coordinator = Arc::new(RemoteCoordinator {
+            url: remote_url.clone(),
+        });
+        let remotes = RemoteManager::new(coordinator.clone(), Vec::new());
+        remotes
+            .insert_test_remote(remote_url, remote_publisher, remote_subscriber)
+            .await;
+
+        let upstream_server_task = tokio::spawn(upstream_server.run());
+        let upstream_client_task = tokio::spawn(upstream_client.run());
+        let locals = Locals::new();
+        let subscriber =
+            spawn_relay_session(locals, remotes, coordinator as Arc<dyn Coordinator>).await;
+        let namespace = TrackNamespace::from_utf8_path("admission");
+
+        let (first_writer, _first_reader) = Track::new(namespace.clone(), "retry").produce();
+        let mut first_subscriber = subscriber.clone();
+        let first = tokio::spawn(async move {
+            let mut params = KeyValuePairs::default();
+            params.set_rendezvous_timeout(30_000);
+            first_subscriber
+                .subscribe_open_with_params(first_writer, params)
+                .await
+        });
+        let first_upstream = tokio::time::timeout(
+            Duration::from_secs(2),
+            upstream_publisher
+                .as_mut()
+                .expect("upstream server publisher")
+                .subscribed(),
+        )
+        .await
+        .expect("first upstream subscribe timed out")
+        .expect("first upstream subscribe");
+
+        first.abort();
+        match first.await {
+            Err(err) => assert!(err.is_cancelled()),
+            Ok(_) => panic!("first subscribe was not cancelled"),
+        }
+
+        let mut retry_subscriber = subscriber.clone();
+        let retry_namespace = namespace.clone();
+        let retry = tokio::spawn(async move {
+            let (writer, _reader) = Track::new(retry_namespace, "retry").produce();
+            let mut params = KeyValuePairs::default();
+            params.set_rendezvous_timeout(30_000);
+            retry_subscriber
+                .subscribe_open_with_params(writer, params)
+                .await
+        });
+
+        let publisher = upstream_publisher
+            .as_mut()
+            .expect("upstream server publisher");
+        tokio::time::timeout(Duration::from_secs(2), async {
+            tokio::select! {
+                biased;
+                _ = first_upstream.closed() => {}
+                _ = publisher.subscribed() => {
+                    panic!("same-track retry overtook the first upstream teardown")
+                }
+            }
+        })
+        .await
+        .expect("first upstream teardown did not complete");
+        drop(first_upstream);
+
+        let second_upstream = tokio::time::timeout(Duration::from_secs(2), publisher.subscribed())
+            .await
+            .expect("second upstream subscribe timed out")
+            .expect("second upstream subscribe");
+        second_upstream
+            .close(ServeError::Closed(RequestErrorCode::Uninterested as u64))
+            .expect("reject second upstream subscribe");
+        assert!(matches!(
+            tokio::time::timeout(Duration::from_secs(2), retry)
+                .await
+                .expect("downstream retry timed out")
+                .expect("join downstream retry"),
+            Err(ServeError::Closed(code)) if code == RequestErrorCode::Uninterested as u64
+        ));
+
+        upstream_server_task.abort();
+        upstream_client_task.abort();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn one_session_cannot_monopolize_relay_capacity() {
         let locals = Locals::new();
         let coordinator = Arc::new(CountingCoordinator::default());

--- a/moq-relay-ietf/src/producer.rs
+++ b/moq-relay-ietf/src/producer.rs
@@ -481,19 +481,14 @@ impl Producer {
                 return self.reject_unresolved_overload(subscribed, &mut timing_guard);
             }
 
+            let remote_lookup = self.remotes.subscribe_with_lookup_status(
+                self.context.scope(),
+                &namespace,
+                &track_name,
+                &mut coordinator_lookup_succeeded,
+            );
             let remote = if let Some(deadline) = deadline {
-                match Self::await_rendezvous_work(
-                    &subscribed,
-                    deadline,
-                    self.remotes.subscribe_with_lookup_status(
-                        self.context.scope(),
-                        &namespace,
-                        &track_name,
-                        &mut coordinator_lookup_succeeded,
-                    ),
-                )
-                .await
-                {
+                match Self::await_rendezvous_work(&subscribed, deadline, remote_lookup).await {
                     RendezvousWork::Completed(result) => result,
                     RendezvousWork::TimedOut => {
                         return Self::finish_unresolved_rendezvous(
@@ -515,14 +510,18 @@ impl Producer {
                     }
                 }
             } else {
-                self.remotes
-                    .subscribe_with_lookup_status(
-                        self.context.scope(),
-                        &namespace,
-                        &track_name,
-                        &mut coordinator_lookup_succeeded,
-                    )
-                    .await
+                tokio::select! {
+                    result = remote_lookup => result,
+                    _ = subscribed.closed() => {
+                        tracing::debug!(
+                            namespace = %namespace.to_utf8_path(),
+                            track = %track_name,
+                            "subscriber left during a route lookup"
+                        );
+                        timing_guard.set_label("source", "downstream_left");
+                        return Ok(());
+                    }
+                }
             };
 
             match remote {
@@ -1682,8 +1681,7 @@ mod tests {
         upstream_client_task.abort();
     }
 
-    #[tokio::test(flavor = "multi_thread")]
-    async fn cancelled_remote_subscribe_tears_down_before_same_track_retry() {
+    async fn assert_cancelled_remote_subscribe_orders_retry(rendezvous: bool) {
         let (upstream_server_transport, upstream_client_transport) =
             loopback_webtransport_pair().await;
         let (upstream_server, upstream_client) = tokio::join!(
@@ -1713,11 +1711,15 @@ mod tests {
         let (first_writer, _first_reader) = Track::new(namespace.clone(), "retry").produce();
         let mut first_subscriber = subscriber.clone();
         let first = tokio::spawn(async move {
-            let mut params = KeyValuePairs::default();
-            params.set_rendezvous_timeout(30_000);
-            first_subscriber
-                .subscribe_open_with_params(first_writer, params)
-                .await
+            if rendezvous {
+                let mut params = KeyValuePairs::default();
+                params.set_rendezvous_timeout(30_000);
+                first_subscriber
+                    .subscribe_open_with_params(first_writer, params)
+                    .await
+            } else {
+                first_subscriber.subscribe_open(first_writer).await
+            }
         });
         let first_upstream = tokio::time::timeout(
             Duration::from_secs(2),
@@ -1740,11 +1742,15 @@ mod tests {
         let retry_namespace = namespace.clone();
         let retry = tokio::spawn(async move {
             let (writer, _reader) = Track::new(retry_namespace, "retry").produce();
-            let mut params = KeyValuePairs::default();
-            params.set_rendezvous_timeout(30_000);
-            retry_subscriber
-                .subscribe_open_with_params(writer, params)
-                .await
+            if rendezvous {
+                let mut params = KeyValuePairs::default();
+                params.set_rendezvous_timeout(30_000);
+                retry_subscriber
+                    .subscribe_open_with_params(writer, params)
+                    .await
+            } else {
+                retry_subscriber.subscribe_open(writer).await
+            }
         });
 
         let publisher = upstream_publisher
@@ -1780,6 +1786,16 @@ mod tests {
 
         upstream_server_task.abort();
         upstream_client_task.abort();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn cancelled_remote_subscribe_tears_down_before_same_track_retry() {
+        assert_cancelled_remote_subscribe_orders_retry(true).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn cancelled_remote_subscribe_without_rendezvous_releases_the_slot() {
+        assert_cancelled_remote_subscribe_orders_retry(false).await;
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/moq-relay-ietf/src/producer.rs
+++ b/moq-relay-ietf/src/producer.rs
@@ -20,6 +20,7 @@ use tokio::sync::{broadcast, OwnedSemaphorePermit, Semaphore};
 use crate::{
     local::MAX_CONCURRENT_RENDEZVOUS_HOLDS,
     metrics::{GaugeGuard, TimingGuard},
+    remote::RemoteSubscribeError,
     upstream_namespaces::UpstreamNamespaces,
     Coordinator, Locals, NamespaceChange, RemoteManager, SessionContext, TrackChange,
     UpstreamReady,
@@ -186,6 +187,36 @@ impl Producer {
         Some((session, relay))
     }
 
+    fn try_reserve_unresolved_capacity(
+        &self,
+        permit: &mut Option<(OwnedSemaphorePermit, OwnedSemaphorePermit)>,
+        gauge: &mut Option<GaugeGuard>,
+    ) -> bool {
+        if permit.is_some() {
+            return true;
+        }
+
+        let Some(acquired) = self.try_acquire_rendezvous_hold() else {
+            return false;
+        };
+        *permit = Some(acquired);
+        *gauge = Some(GaugeGuard::new("moq_relay_active_rendezvous_holds"));
+        true
+    }
+
+    fn reject_unresolved_overload(
+        &self,
+        subscribed: Subscribed,
+        timing_guard: &mut TimingGuard,
+    ) -> Result<(), anyhow::Error> {
+        metrics::counter!("moq_relay_rendezvous_rejections_total").increment(1);
+        timing_guard.set_label("source", "rendezvous_overloaded");
+        let err = ServeError::Closed(RequestErrorCode::ExcessiveLoad as u64);
+        let retry_interval = self.locals.rendezvous_overload_retry_interval();
+        let _ = subscribed.close_with_retry(err.clone(), retry_interval);
+        Err(err.into())
+    }
+
     /// Send PUBLISH_NAMESPACE for a set of tracks to the remote peer.
     pub async fn publish_namespace(&mut self, tracks: TracksReader) -> Result<(), SessionError> {
         self.publisher.publish_namespace(tracks).await
@@ -300,53 +331,72 @@ impl Producer {
         let mut coordinator_lookup_succeeded = false;
         let mut rendezvous_permit = None;
         let mut rendezvous_guard = None;
+        let full_name = FullTrackName {
+            namespace: namespace.clone(),
+            name: track_name.clone(),
+        };
 
         // Re-entered after a publisher appears. The lookup is repeated rather
         // than trusting the wake, because `Consumer::serve_track` emits
         // TrackChange::Added before the coordinator registration behind it has
         // succeeded, so an event does not guarantee a servable track.
         loop {
-            // Local lookup order inside Locals:
-            // 1. actual FullTrackName -> TrackReader media cache
-            // 2. PUBLISH_NAMESPACE route source, which triggers upstream SUBSCRIBE
             let mut locals = self.locals.clone();
-            let local = if let Some(deadline) = deadline {
-                match Self::await_rendezvous_work(
-                    &subscribed,
-                    deadline,
-                    locals.get_or_request_track(
-                        self.context.scope(),
-                        namespace.clone(),
-                        &track_name,
-                    ),
-                )
-                .await
+            let mut local = locals.retrieve_track_with_interest(self.context.scope(), &full_name);
+
+            // A namespace route creates an upstream request and cache generation,
+            // so admission must precede that work. Exact established tracks above
+            // stay on the unmetered fast path.
+            if local.is_none() && locals.has_namespace_route(self.context.scope(), &namespace) {
+                if !self
+                    .try_reserve_unresolved_capacity(&mut rendezvous_permit, &mut rendezvous_guard)
                 {
-                    RendezvousWork::Completed(result) => result,
-                    RendezvousWork::TimedOut => {
-                        return Self::finish_unresolved_rendezvous(
-                            subscribed,
-                            &mut timing_guard,
-                            coordinator_lookup_succeeded,
-                            &namespace,
-                            &track_name,
-                        );
-                    }
-                    RendezvousWork::DownstreamLeft => {
-                        tracing::debug!(
-                            namespace = %namespace.to_utf8_path(),
-                            track = %track_name,
-                            "subscriber left during a rendezvous local lookup"
-                        );
-                        timing_guard.set_label("source", "downstream_left");
-                        return Ok(());
-                    }
+                    return self.reject_unresolved_overload(subscribed, &mut timing_guard);
                 }
-            } else {
-                locals
-                    .get_or_request_track(self.context.scope(), namespace.clone(), &track_name)
+
+                local = if let Some(deadline) = deadline {
+                    match Self::await_rendezvous_work(
+                        &subscribed,
+                        deadline,
+                        locals.get_or_request_track(
+                            self.context.scope(),
+                            namespace.clone(),
+                            &track_name,
+                        ),
+                    )
                     .await
-            };
+                    {
+                        RendezvousWork::Completed(result) => result,
+                        RendezvousWork::TimedOut => {
+                            return Self::finish_unresolved_rendezvous(
+                                subscribed,
+                                &mut timing_guard,
+                                coordinator_lookup_succeeded,
+                                &namespace,
+                                &track_name,
+                            );
+                        }
+                        RendezvousWork::DownstreamLeft => {
+                            tracing::debug!(
+                                namespace = %namespace.to_utf8_path(),
+                                track = %track_name,
+                                "subscriber left during a rendezvous local lookup"
+                            );
+                            timing_guard.set_label("source", "downstream_left");
+                            return Ok(());
+                        }
+                    }
+                } else {
+                    locals
+                        .get_or_request_track(self.context.scope(), namespace.clone(), &track_name)
+                        .await
+                };
+
+                if local.is_none() {
+                    drop(rendezvous_guard.take());
+                    drop(rendezvous_permit.take());
+                }
+            }
 
             if let Some(local) = local {
                 let largest_location = local.largest_location;
@@ -363,6 +413,19 @@ impl Producer {
                 // downstream SUBSCRIBE." A pull-through cache entry exists before
                 // its upstream subscription does, so wait for it.
                 if let Some(upstream) = local.upstream {
+                    if upstream.is_pending()
+                        && !self.try_reserve_unresolved_capacity(
+                            &mut rendezvous_permit,
+                            &mut rendezvous_guard,
+                        )
+                    {
+                        // Recheck after failed admission because the upstream may
+                        // have completed while permits were inspected.
+                        if upstream.is_pending() {
+                            return self.reject_unresolved_overload(subscribed, &mut timing_guard);
+                        }
+                    }
+
                     if let Err(outcome) =
                         Self::await_upstream(&subscribed, &upstream, deadline).await
                     {
@@ -413,6 +476,11 @@ impl Producer {
             }
 
             // Check remote tracks after local exact tracks and namespace route sources.
+            if !self.try_reserve_unresolved_capacity(&mut rendezvous_permit, &mut rendezvous_guard)
+            {
+                return self.reject_unresolved_overload(subscribed, &mut timing_guard);
+            }
+
             let remote = if let Some(deadline) = deadline {
                 match Self::await_rendezvous_work(
                     &subscribed,
@@ -448,7 +516,12 @@ impl Producer {
                 }
             } else {
                 self.remotes
-                    .subscribe(self.context.scope(), &namespace, &track_name)
+                    .subscribe_with_lookup_status(
+                        self.context.scope(),
+                        &namespace,
+                        &track_name,
+                        &mut coordinator_lookup_succeeded,
+                    )
                     .await
             };
 
@@ -476,7 +549,15 @@ impl Producer {
                     .await;
                 }
                 Ok(None) => coordinator_lookup_succeeded = true,
-                Err(e) => {
+                Err(RemoteSubscribeError::Peer(err)) => {
+                    let ns = namespace.to_utf8_path();
+                    tracing::debug!(namespace = %ns, track = %track_name, error = %err, "upstream relay rejected subscribe");
+                    metrics::counter!("moq_relay_subscribe_upstream_errors_total").increment(1);
+                    timing_guard.set_label("source", "upstream_error");
+                    let _ = subscribed.close(err.clone());
+                    return Err(err.into());
+                }
+                Err(RemoteSubscribeError::Route(e)) => {
                     // Route error = infrastructure failure (couldn't reach coordinator/upstream)
                     // This is different from "not found" - we don't know if the track exists
                     let ns = namespace.to_utf8_path();
@@ -521,17 +602,11 @@ impl Producer {
             // Capacity limits held requests, not ordinary resolution work. An
             // available publisher must be served even when every hold slot is in
             // use, so only acquire a slot after the initial lookup misses.
-            if rendezvous_permit.is_none() {
-                let Some(permit) = self.try_acquire_rendezvous_hold() else {
-                    metrics::counter!("moq_relay_rendezvous_rejections_total").increment(1);
-                    timing_guard.set_label("source", "rendezvous_overloaded");
-                    let err = ServeError::Closed(RequestErrorCode::ExcessiveLoad as u64);
-                    let retry_interval = self.locals.rendezvous_overload_retry_interval();
-                    let _ = subscribed.close_with_retry(err.clone(), retry_interval);
-                    return Err(err.into());
-                };
-                rendezvous_permit = Some(permit);
-                rendezvous_guard = Some(GaugeGuard::new("moq_relay_active_rendezvous_holds"));
+            if rendezvous_permit.is_none()
+                && !self
+                    .try_reserve_unresolved_capacity(&mut rendezvous_permit, &mut rendezvous_guard)
+            {
+                return self.reject_unresolved_overload(subscribed, &mut timing_guard);
             }
 
             match Self::await_rendezvous(
@@ -1179,12 +1254,16 @@ mod tests {
     };
     use crate::{
         Coordinator, CoordinatorContext, CoordinatorError, CoordinatorResult, Locals,
-        NamespaceOrigin, NamespaceRegistration, RemoteManager, SessionContext,
+        NamespaceOrigin, NamespaceRegistration, RemoteManager, SessionContext, TrackRequest,
     };
 
     #[derive(Default)]
     struct CountingCoordinator {
         track_lookups: Mutex<Vec<String>>,
+    }
+
+    struct RemoteCoordinator {
+        url: url::Url,
     }
 
     impl CountingCoordinator {
@@ -1245,6 +1324,37 @@ mod tests {
                 .map_err(|_| anyhow::anyhow!("track lookup lock poisoned"))?
                 .push(track.to_string());
             Err(CoordinatorError::NamespaceNotFound)
+        }
+    }
+
+    #[async_trait]
+    impl Coordinator for RemoteCoordinator {
+        async fn register_namespace(
+            &self,
+            _scope: Option<&str>,
+            _namespace: &TrackNamespace,
+            _context: &CoordinatorContext,
+        ) -> CoordinatorResult<NamespaceRegistration> {
+            Ok(NamespaceRegistration::new(()))
+        }
+
+        async fn unregister_namespace(
+            &self,
+            _scope: Option<&str>,
+            _namespace: &TrackNamespace,
+        ) -> CoordinatorResult<()> {
+            Ok(())
+        }
+
+        async fn lookup(
+            &self,
+            _scope: Option<&str>,
+            namespace: &TrackNamespace,
+        ) -> CoordinatorResult<(NamespaceOrigin, Option<moq_native_ietf::quic::Client>)> {
+            Ok((
+                NamespaceOrigin::new(namespace.clone(), self.url.clone(), None),
+                None,
+            ))
         }
     }
 
@@ -1395,7 +1505,7 @@ mod tests {
             subscribe_result(&mut first_subscriber, "held", Some(10_000)).await
         });
         tokio::time::timeout(Duration::from_secs(2), async {
-            while !coordinator.looked_up("held") {
+            while !coordinator.looked_up("held") || locals.available_rendezvous_holds() != 0 {
                 tokio::time::sleep(Duration::from_millis(10)).await;
             }
         })
@@ -1416,18 +1526,18 @@ mod tests {
         drop(available);
 
         let absent = rejected_subscribe(&mut second_subscriber, "absent", None).await;
-        assert!(matches!(
+        assert_eq!(
             absent,
-            ServeError::NotFound | ServeError::NotFoundWithId(_, _)
-        ));
-        assert!(coordinator.looked_up("absent"));
+            ServeError::Closed(RequestErrorCode::ExcessiveLoad as u64)
+        );
+        assert!(!coordinator.looked_up("absent"));
 
         let zero = rejected_subscribe(&mut second_subscriber, "zero", Some(0)).await;
-        assert!(matches!(
+        assert_eq!(
             zero,
-            ServeError::NotFound | ServeError::NotFoundWithId(_, _)
-        ));
-        assert!(coordinator.looked_up("zero"));
+            ServeError::Closed(RequestErrorCode::ExcessiveLoad as u64)
+        );
+        assert!(!coordinator.looked_up("zero"));
 
         let overloaded =
             rejected_subscribe(&mut second_subscriber, "overloaded", Some(10_000)).await;
@@ -1435,7 +1545,7 @@ mod tests {
             overloaded,
             ServeError::Closed(RequestErrorCode::ExcessiveLoad as u64)
         );
-        assert!(coordinator.looked_up("overloaded"));
+        assert!(!coordinator.looked_up("overloaded"));
 
         let (_held_writer, held_reader) = Track::new(namespace.clone(), "held").produce();
         let _held_registration = registering_locals
@@ -1448,16 +1558,128 @@ mod tests {
             .expect("join held request")
             .expect("held request was rejected");
 
-        let (_next_writer, next_reader) = Track::new(namespace, "after-release").produce();
-        let _next_registration = registering_locals
-            .register_track(None, next_reader)
-            .await
-            .expect("register track after capacity release");
-        let accepted = subscribe_result(&mut second_subscriber, "after-release", Some(10_000))
-            .await
-            .expect("resolved hold should be released before the next request");
-        drop(accepted);
+        let after_release =
+            rejected_subscribe(&mut second_subscriber, "after-release", Some(25)).await;
+        assert_eq!(
+            after_release,
+            ServeError::Timeout,
+            "resolved hold should release capacity for another rendezvous"
+        );
         drop(first_subscription);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn unresolved_pull_through_obeys_capacity_and_releases_on_timeout() {
+        let locals = Locals::with_rendezvous_capacity(1);
+        let namespace = TrackNamespace::from_utf8_path("admission");
+        let (registration, mut requests) = locals
+            .clone()
+            .register_namespace(None, namespace)
+            .await
+            .expect("register namespace source");
+        let coordinator = Arc::new(CountingCoordinator::default());
+        let remotes = RemoteManager::new(coordinator.clone(), Vec::new());
+        let mut first_subscriber =
+            spawn_relay_session(locals.clone(), remotes.clone(), coordinator.clone()).await;
+        let mut second_subscriber = spawn_relay_session(locals.clone(), remotes, coordinator).await;
+
+        let requests_task = tokio::spawn(async move {
+            while let Some(TrackRequest {
+                writer,
+                lease,
+                upstream,
+            }) = requests.recv().await
+            {
+                tokio::spawn(async move {
+                    lease.abandoned().await;
+                    drop(writer);
+                    drop(upstream);
+                });
+            }
+        });
+
+        let first = tokio::spawn(async move {
+            rejected_subscribe(&mut first_subscriber, "first-pending", Some(100)).await
+        });
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while locals.available_rendezvous_holds() != 0 {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("first pull-through did not acquire rendezvous capacity");
+
+        let overloaded =
+            rejected_subscribe(&mut second_subscriber, "overloaded-pending", Some(1_000)).await;
+        assert_eq!(
+            overloaded,
+            ServeError::Closed(RequestErrorCode::ExcessiveLoad as u64)
+        );
+
+        assert_eq!(
+            first.await.expect("join first pull-through"),
+            ServeError::Timeout
+        );
+        let after_timeout =
+            rejected_subscribe(&mut second_subscriber, "after-timeout", Some(25)).await;
+        assert_eq!(after_timeout, ServeError::Timeout);
+
+        drop(registration);
+        requests_task.abort();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn remote_peer_rejection_is_forwarded_with_and_without_rendezvous() {
+        let (upstream_server_transport, upstream_client_transport) =
+            loopback_webtransport_pair().await;
+        let (upstream_server, upstream_client) = tokio::join!(
+            TransportSession::accept(upstream_server_transport, None, Transport::WebTransport),
+            TransportSession::connect(upstream_client_transport, None, Transport::WebTransport),
+        );
+        let (upstream_server, mut upstream_publisher, _) =
+            upstream_server.expect("accept upstream MoQT session");
+        let (upstream_client, remote_publisher, remote_subscriber) =
+            upstream_client.expect("connect upstream MoQT session");
+        let remote_url = url::Url::parse("https://relay.example.com/live").unwrap();
+        let coordinator = Arc::new(RemoteCoordinator {
+            url: remote_url.clone(),
+        });
+        let remotes = RemoteManager::new(coordinator.clone(), Vec::new());
+        remotes
+            .insert_test_remote(remote_url, remote_publisher, remote_subscriber)
+            .await;
+
+        let upstream_server_task = tokio::spawn(upstream_server.run());
+        let upstream_client_task = tokio::spawn(upstream_client.run());
+        let reject = tokio::spawn(async move {
+            let publisher = upstream_publisher
+                .as_mut()
+                .expect("upstream server publisher");
+            for _ in 0..2 {
+                let subscribed = publisher
+                    .subscribed()
+                    .await
+                    .expect("receive upstream subscribe");
+                subscribed
+                    .close(ServeError::Closed(RequestErrorCode::Unauthorized as u64))
+                    .expect("reject upstream subscribe");
+            }
+        });
+
+        let locals = Locals::new();
+        let mut subscriber =
+            spawn_relay_session(locals, remotes, coordinator as Arc<dyn Coordinator>).await;
+
+        for rendezvous_timeout in [None, Some(1_000)] {
+            assert_eq!(
+                rejected_subscribe(&mut subscriber, "unauthorized", rendezvous_timeout).await,
+                ServeError::Closed(RequestErrorCode::Unauthorized as u64)
+            );
+        }
+
+        reject.await.expect("join upstream rejection task");
+        upstream_server_task.abort();
+        upstream_client_task.abort();
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -1497,7 +1719,7 @@ mod tests {
             overloaded,
             ServeError::Closed(RequestErrorCode::ExcessiveLoad as u64)
         );
-        assert!(coordinator.looked_up("same-session-overloaded"));
+        assert!(!coordinator.looked_up("same-session-overloaded"));
 
         let other_hold = tokio::spawn(async move {
             subscribe_result(&mut other_session, "other-session-hold", Some(10_000)).await

--- a/moq-relay-ietf/src/relay.rs
+++ b/moq-relay-ietf/src/relay.rs
@@ -411,26 +411,11 @@ impl Relay {
                                 None => SessionContext::public(scope),
                             };
 
-                            // The resolved interface decides whether a
-                            // PUBLISH_NAMESPACE on this session is treated as
-                            // ours or as proxied for a peer, and until now
-                            // nothing recorded it. Classification depends on
-                            // `local_ip` being populated, which is a platform
-                            // property rather than a configured one: if it is
-                            // absent, every peer relay silently classifies as a
-                            // public client and the proxied path is never taken.
-                            // That failure mode is invisible without this line —
-                            // the behaviour degrades to exactly what it was
-                            // before, with no error anywhere.
-                            //
-                            // Emitted for every accepted session so the
-                            // precondition is observable in production rather
-                            // than inferred, but only peer sessions are worth
-                            // info: they are rare and they are the ones whose
-                            // classification changes behaviour. Clients are the
-                            // bulk of the traffic and would drown it out, so
-                            // they stay at debug and remain available when a
-                            // misclassification is what is being investigated.
+                            // The resolved interface controls whether an inbound
+                            // PUBLISH_NAMESPACE is owned here or advertised only
+                            // for peer discovery. Internal sessions are rare and
+                            // logged at info; public client sessions stay at
+                            // debug to avoid a per-connection info log.
                             match context.interface {
                                 SessionInterface::Internal => tracing::info!(
                                     interface = ?context.interface,

--- a/moq-relay-ietf/src/relay.rs
+++ b/moq-relay-ietf/src/relay.rs
@@ -13,7 +13,8 @@ use url::Url;
 use crate::upstream_namespaces::{UpstreamNamespaces, UpstreamNamespacesRunner};
 use crate::{
     metrics::GaugeGuard, ConnectionMeta, ConnectionTagger, Consumer, Coordinator, Locals, Producer,
-    RelayInfo, RemoteManager, Session, SessionContext, DEFAULT_CACHE_IDLE_TIMEOUT,
+    RelayInfo, RemoteManager, Session, SessionContext, SessionInterface,
+    DEFAULT_CACHE_IDLE_TIMEOUT,
 };
 
 // A type alias for boxed future
@@ -409,6 +410,43 @@ impl Relay {
                                 }
                                 None => SessionContext::public(scope),
                             };
+
+                            // The resolved interface decides whether a
+                            // PUBLISH_NAMESPACE on this session is treated as
+                            // ours or as proxied for a peer, and until now
+                            // nothing recorded it. Classification depends on
+                            // `local_ip` being populated, which is a platform
+                            // property rather than a configured one: if it is
+                            // absent, every peer relay silently classifies as a
+                            // public client and the proxied path is never taken.
+                            // That failure mode is invisible without this line —
+                            // the behaviour degrades to exactly what it was
+                            // before, with no error anywhere.
+                            //
+                            // Emitted for every accepted session so the
+                            // precondition is observable in production rather
+                            // than inferred, but only peer sessions are worth
+                            // info: they are rare and they are the ones whose
+                            // classification changes behaviour. Clients are the
+                            // bulk of the traffic and would drown it out, so
+                            // they stay at debug and remain available when a
+                            // misclassification is what is being investigated.
+                            match context.interface {
+                                SessionInterface::Internal => tracing::info!(
+                                    interface = ?context.interface,
+                                    local_ip = ?local_ip,
+                                    remote_addr = %remote_addr,
+                                    tagger = connection_tagger.is_some(),
+                                    "session accepted"
+                                ),
+                                SessionInterface::Public => tracing::debug!(
+                                    interface = ?context.interface,
+                                    local_ip = ?local_ip,
+                                    remote_addr = %remote_addr,
+                                    tagger = connection_tagger.is_some(),
+                                    "session accepted"
+                                ),
+                            }
 
                             if let Some(ref info) = scope_info {
                                 tracing::debug!(

--- a/moq-relay-ietf/src/relay.rs
+++ b/moq-relay-ietf/src/relay.rs
@@ -416,21 +416,24 @@ impl Relay {
                             // for peer discovery. Internal sessions are rare and
                             // logged at info; public client sessions stay at
                             // debug to avoid a per-connection info log.
+                            macro_rules! log_session_accepted {
+                                ($level:ident) => {
+                                    tracing::$level!(
+                                    interface = ?context.interface,
+                                    local_ip = ?local_ip,
+                                    remote_addr = %remote_addr,
+                                    tagger = connection_tagger.is_some(),
+                                    "session accepted"
+                                    )
+                                };
+                            }
                             match context.interface {
-                                SessionInterface::Internal => tracing::info!(
-                                    interface = ?context.interface,
-                                    local_ip = ?local_ip,
-                                    remote_addr = %remote_addr,
-                                    tagger = connection_tagger.is_some(),
-                                    "session accepted"
-                                ),
-                                SessionInterface::Public => tracing::debug!(
-                                    interface = ?context.interface,
-                                    local_ip = ?local_ip,
-                                    remote_addr = %remote_addr,
-                                    tagger = connection_tagger.is_some(),
-                                    "session accepted"
-                                ),
+                                SessionInterface::Internal => {
+                                    log_session_accepted!(info)
+                                }
+                                SessionInterface::Public => {
+                                    log_session_accepted!(debug)
+                                }
                             }
 
                             if let Some(ref info) = scope_info {

--- a/moq-relay-ietf/src/remote.rs
+++ b/moq-relay-ietf/src/remote.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use moq_native_ietf::quic;
 use moq_transport::coding::{KeyValuePairs, TrackName, TrackNamespace, TrackNamespacePrefix};
 use moq_transport::message::SubscribeOptions;
-use moq_transport::serve::{Track, TrackReader, TracksReader};
+use moq_transport::serve::{ServeError, Track, TrackReader, TracksReader};
 use moq_transport::session::{Publisher, SessionConfig, SubscribeNamespace};
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
@@ -70,6 +70,8 @@ impl Drop for EmptyRemoteSlotCleanup {
             std::mem::drop(runtime.spawn(async move {
                 remove_empty_remote_slot(&remotes, &key, &slot).await;
             }));
+        } else {
+            tracing::warn!(remote_url = %key.0, "could not clean up an empty remote slot outside a Tokio runtime");
         }
     }
 }
@@ -113,6 +115,8 @@ impl Drop for EmptyTrackSlotCleanup {
             std::mem::drop(runtime.spawn(async move {
                 remove_empty_track_slot(&tracks, &key, &slot).await;
             }));
+        } else {
+            tracing::warn!(namespace = %key.0, track = %key.1, "could not clean up an empty remote track slot outside a Tokio runtime");
         }
     }
 }
@@ -125,6 +129,12 @@ struct CachedTrack {
     /// Interest in this cached reader. When it goes idle for the configured
     /// grace period the upstream subscription to the peer relay is released.
     interest: TrackInterest,
+}
+
+#[derive(Debug)]
+pub(crate) enum RemoteSubscribeError {
+    Peer(ServeError),
+    Route(anyhow::Error),
 }
 
 /// Manages connections to remote relays.
@@ -251,7 +261,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn successful_coordinator_lookup_survives_later_connection_error() {
+    async fn connection_error_is_not_a_conclusive_lookup() {
         let manager = RemoteManager::new(Arc::new(FoundCoordinator), vec![]);
         let mut lookup_succeeded = false;
 
@@ -264,8 +274,8 @@ mod tests {
             )
             .await;
 
-        assert!(result.is_err());
-        assert!(lookup_succeeded);
+        assert!(matches!(result, Err(RemoteSubscribeError::Route(_))));
+        assert!(!lookup_succeeded);
     }
 
     #[test]
@@ -395,18 +405,16 @@ mod tests {
 
     const GRACE: Duration = Duration::from_secs(30);
 
-    /// The slot must be cleared before the caller drops its peer subscription, so
-    /// a later subscriber re-subscribes instead of attaching to a dying reader.
+    /// The generation remains visible but unusable until the caller finishes the
+    /// peer request stream, preventing a replacement from overtaking teardown.
     #[tokio::test(start_paused = true)]
-    async fn evict_when_idle_clears_the_slot_once_unwatched() {
+    async fn evict_when_idle_marks_the_slot_closing_once_unwatched() {
         let (slot, interest) = cached_track();
 
         evict_when_idle(&slot, &interest, GRACE).await;
 
-        assert!(
-            slot.lock().await.is_none(),
-            "slot must be cleared before the subscription is released"
-        );
+        assert!(slot.lock().await.is_some());
+        assert!(interest.is_closing());
     }
 
     #[tokio::test(start_paused = true)]
@@ -425,7 +433,8 @@ mod tests {
 
         drop(guard);
         evict.await;
-        assert!(slot.lock().await.is_none());
+        assert!(slot.lock().await.is_some());
+        assert!(interest.is_closing());
     }
 
     /// A replacement generation owns the slot now, so this subscription is stale:
@@ -490,6 +499,29 @@ impl RemoteManager {
         }
     }
 
+    #[cfg(test)]
+    pub(crate) async fn insert_test_remote(
+        &self,
+        url: Url,
+        publisher: Publisher,
+        subscriber: moq_transport::session::Subscriber,
+    ) {
+        let remote = Remote {
+            context: Remote::context_for_endpoint(url.clone(), None),
+            url: url.clone(),
+            subscriber,
+            publisher,
+            tracks: Arc::new(Mutex::new(HashMap::new())),
+            connected: Arc::new(AtomicBool::new(true)),
+            cancel: CancellationToken::new(),
+            cache_idle_timeout: self.cache_idle_timeout,
+        };
+        self.remotes
+            .lock()
+            .await
+            .insert((url, None), Arc::new(Mutex::new(Some(remote))));
+    }
+
     /// Override how long an unwatched cross-relay cache entry is retained before
     /// its upstream subscription is released.
     ///
@@ -520,6 +552,10 @@ impl RemoteManager {
             &mut coordinator_lookup_succeeded,
         )
         .await
+        .map_err(|err| match err {
+            RemoteSubscribeError::Peer(err) => anyhow::Error::new(err),
+            RemoteSubscribeError::Route(err) => err,
+        })
     }
 
     pub(crate) async fn subscribe_with_lookup_status(
@@ -528,7 +564,7 @@ impl RemoteManager {
         namespace: &TrackNamespace,
         track_name: impl Into<TrackName>,
         coordinator_lookup_succeeded: &mut bool,
-    ) -> anyhow::Result<Option<(TrackReader, TrackInterestGuard)>> {
+    ) -> Result<Option<(TrackReader, TrackInterestGuard)>, RemoteSubscribeError> {
         let track_name = track_name.into();
 
         // Coordinator::lookup_track is the ergonomic routing entry point: it
@@ -539,15 +575,12 @@ impl RemoteManager {
             .lookup_track(scope, namespace, &track_name.to_string())
             .await
         {
-            Ok(result) => {
-                *coordinator_lookup_succeeded = true;
-                result
-            }
+            Ok(result) => result,
             Err(CoordinatorError::NamespaceNotFound) => {
                 *coordinator_lookup_succeeded = true;
                 return Ok(None);
             }
-            Err(err) => return Err(err.into()),
+            Err(err) => return Err(RemoteSubscribeError::Route(err.into())),
         };
 
         let url = origin.url();
@@ -560,17 +593,25 @@ impl RemoteManager {
             Ok(remote) => remote,
             Err(err) => {
                 tracing::error!(remote_url = %url, error = %err, "failed to connect to remote relay: {}", err);
-                return Err(err);
+                return Err(RemoteSubscribeError::Route(err));
             }
         };
 
         match remote.subscribe(namespace.clone(), track_name).await {
-            Ok(reader) => Ok(reader),
-            Err(err) => {
+            Ok(reader) => {
+                *coordinator_lookup_succeeded = true;
+                Ok(reader)
+            }
+            Err(RemoteSubscribeError::Peer(err)) => {
+                *coordinator_lookup_succeeded = true;
+                tracing::debug!(remote_url = %url, error = %err, "remote relay rejected SUBSCRIBE");
+                Err(RemoteSubscribeError::Peer(err))
+            }
+            Err(RemoteSubscribeError::Route(err)) => {
                 tracing::warn!(remote_url = %url, error = %err, "remote subscribe failed, removing from cache");
                 self.remove_if_same_remote(&cache_key, &remote).await;
 
-                Err(err)
+                Err(RemoteSubscribeError::Route(err))
             }
         }
     }
@@ -645,13 +686,6 @@ impl RemoteManager {
         cache_key: RemoteCacheKey,
         client: Option<&quic::Client>,
     ) -> anyhow::Result<Remote> {
-        let client = match client {
-            Some(client) => client,
-            None => self.clients.first().ok_or_else(|| {
-                anyhow::anyhow!("no QUIC clients configured for remote connections")
-            })?,
-        };
-
         loop {
             // The manager lock only protects the map. The per-key slot lock protects
             // that key's connection state, so unrelated remotes can connect in parallel.
@@ -691,6 +725,13 @@ impl RemoteManager {
             if let Some(remote) = cached.take() {
                 remote.shutdown().await;
             }
+
+            let client = match client {
+                Some(client) => client,
+                None => self.clients.first().ok_or_else(|| {
+                    anyhow::anyhow!("no QUIC clients configured for remote connections")
+                })?,
+            };
 
             tracing::info!(remote_url = %cache_key.0, "connecting to remote relay");
             let remote = match Remote::connect(
@@ -779,10 +820,9 @@ async fn remove_empty_remote_slot(
 
 /// Clear a cached cross-relay track once it has been unwatched for `timeout`.
 ///
-/// Resolving means the caller should drop its subscription to the peer relay. The
-/// slot is cleared *before* returning, while the lock is still held, so a
-/// subscriber arriving afterwards misses the cache and re-subscribes instead of
-/// attaching to a reader whose upstream subscription is being torn down.
+/// Resolving means the caller should end its subscription to the peer relay. The
+/// slot remains in a closing state until that teardown completes, so a replacement
+/// SUBSCRIBE cannot overtake the old UNSUBSCRIBE.
 ///
 /// The idle re-check happens under the slot lock, which is also where interest
 /// guards are created, so a subscriber racing eviction is either counted here
@@ -799,7 +839,7 @@ async fn evict_when_idle(slot: &TrackSlot, interest: &TrackInterest, timeout: Du
     loop {
         interest.idle_for(timeout).await;
 
-        let mut cached = slot.lock().await;
+        let cached = slot.lock().await;
 
         // A different generation now owns the slot; it has its own idle timer, so
         // this subscription is no longer serving anything and must not clear it.
@@ -813,7 +853,7 @@ async fn evict_when_idle(slot: &TrackSlot, interest: &TrackInterest, timeout: Du
         }
 
         if interest.is_idle() {
-            cached.take();
+            interest.mark_closing();
             return;
         }
 
@@ -1016,12 +1056,15 @@ impl Remote {
         &self,
         namespace: TrackNamespace,
         track_name: TrackName,
-    ) -> anyhow::Result<Option<(TrackReader, TrackInterestGuard)>> {
+    ) -> Result<Option<(TrackReader, TrackInterestGuard)>, RemoteSubscribeError> {
         let key = (namespace.clone(), track_name.clone());
 
         loop {
             if !self.is_connected() {
-                anyhow::bail!("remote connection to {} is closed", self.url);
+                return Err(RemoteSubscribeError::Route(anyhow::anyhow!(
+                    "remote connection to {} is closed",
+                    self.url
+                )));
             }
 
             let slot = {
@@ -1044,6 +1087,16 @@ impl Remote {
 
             if !is_current_slot {
                 cleanup.disarm();
+                continue;
+            }
+
+            let closing = cached
+                .as_ref()
+                .and_then(|entry| entry.interest.is_closing().then(|| entry.interest.clone()));
+            if let Some(closing) = closing {
+                cleanup.disarm();
+                drop(cached);
+                closing.removed().await;
                 continue;
             }
 
@@ -1070,7 +1123,7 @@ impl Remote {
 
             let (writer, reader) = Track::new(namespace.clone(), track_name.clone()).produce();
             let subscribe_result = tokio::select! {
-                result = subscriber.subscribe_open(writer) => result,
+                result = subscriber.subscribe_start(writer) => result,
                 _ = cancel.cancelled() => {
                     Err(moq_transport::serve::ServeError::Cancel)
                 }
@@ -1082,15 +1135,30 @@ impl Remote {
                     drop(cached);
                     remove_empty_track_slot(&self.tracks, &key, &slot).await;
                     cleanup.disarm();
-                    return Err(err.into());
+                    return Err(RemoteSubscribeError::Route(err.into()));
                 }
             };
+
+            if let Err(err) = subscribe.ok().await {
+                let peer_rejected = subscribe.peer_rejected();
+                drop(cached);
+                remove_empty_track_slot(&self.tracks, &key, &slot).await;
+                cleanup.disarm();
+                return if peer_rejected {
+                    Err(RemoteSubscribeError::Peer(err))
+                } else {
+                    Err(RemoteSubscribeError::Route(err.into()))
+                };
+            }
 
             if !self.is_connected() {
                 drop(cached);
                 remove_empty_track_slot(&self.tracks, &key, &slot).await;
                 cleanup.disarm();
-                anyhow::bail!("remote connection to {} is closed", self.url);
+                return Err(RemoteSubscribeError::Route(anyhow::anyhow!(
+                    "remote connection to {} is closed",
+                    self.url
+                )));
             }
 
             let interest = TrackInterest::new();
@@ -1126,18 +1194,15 @@ impl Remote {
                         tracing::debug!(remote_url = %url, namespace = %cleanup_key.0, track = %cleanup_key.1, "remote track subscription cancelled");
                     }
                     // Nobody downstream is watching this cross-relay track any
-                    // more, so stop pulling it from the peer relay. The slot is
-                    // already cleared by the time this resolves, so a later
-                    // subscriber re-subscribes rather than attaching to a reader
-                    // that is about to go silent.
+                    // more, so stop pulling it from the peer relay. The slot stays
+                    // closing until the request stream has been torn down.
                     _ = evict_when_idle(&cleanup_slot, &interest, idle_timeout) => {
                         tracing::info!(remote_url = %url, namespace = %cleanup_key.0, track = %cleanup_key.1, "releasing idle remote track subscription");
                         metrics::counter!("moq_relay_cache_idle_evictions_total", "source" => "remote").increment(1);
                     }
                 }
 
-                // Sends UNSUBSCRIBE to the peer relay if it is still open.
-                drop(subscribe);
+                subscribe.unsubscribe().await;
 
                 if let Some(tracks) = tracks.upgrade() {
                     let mut cached = cleanup_slot.lock().await;
@@ -1149,6 +1214,7 @@ impl Remote {
 
                     remove_empty_track_slot(&tracks, &cleanup_key, &cleanup_slot).await;
                 }
+                interest.mark_removed();
             });
 
             return Ok(Some((reader, guard)));

--- a/moq-relay-ietf/src/remote.rs
+++ b/moq-relay-ietf/src/remote.rs
@@ -11,7 +11,7 @@ use moq_native_ietf::quic;
 use moq_transport::coding::{KeyValuePairs, TrackName, TrackNamespace, TrackNamespacePrefix};
 use moq_transport::message::SubscribeOptions;
 use moq_transport::serve::{ServeError, Track, TrackReader, TracksReader};
-use moq_transport::session::{Publisher, SessionConfig, SubscribeNamespace};
+use moq_transport::session::{Publisher, SessionConfig, Subscribe, SubscribeNamespace};
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 use url::Url;
@@ -129,6 +129,59 @@ struct CachedTrack {
     /// Interest in this cached reader. When it goes idle for the configured
     /// grace period the upstream subscription to the peer relay is released.
     interest: TrackInterest,
+}
+
+struct TrackSubscriptionCleanup {
+    subscribe: Option<Subscribe>,
+    tracks: Weak<Mutex<HashMap<TrackCacheKey, TrackSlot>>>,
+    key: TrackCacheKey,
+    slot: TrackSlot,
+    interest: TrackInterest,
+}
+
+impl TrackSubscriptionCleanup {
+    fn new(
+        subscribe: Subscribe,
+        tracks: Weak<Mutex<HashMap<TrackCacheKey, TrackSlot>>>,
+        key: TrackCacheKey,
+        slot: TrackSlot,
+        interest: TrackInterest,
+    ) -> Self {
+        Self {
+            subscribe: Some(subscribe),
+            tracks,
+            key,
+            slot,
+            interest,
+        }
+    }
+
+    fn disarm(mut self) -> Result<Subscribe, ServeError> {
+        self.subscribe
+            .take()
+            .ok_or_else(|| ServeError::internal_ctx("remote track cleanup lost its subscription"))
+    }
+}
+
+impl Drop for TrackSubscriptionCleanup {
+    fn drop(&mut self) {
+        let Some(subscribe) = self.subscribe.take() else {
+            return;
+        };
+
+        self.interest.mark_closing();
+        let tracks = self.tracks.clone();
+        let key = self.key.clone();
+        let slot = self.slot.clone();
+        let interest = self.interest.clone();
+        if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+            std::mem::drop(runtime.spawn(finish_track_subscription(
+                subscribe, tracks, key, slot, interest,
+            )));
+        } else {
+            tracing::warn!(namespace = %self.key.0, track = %self.key.1, "could not finish remote track teardown outside a Tokio runtime");
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -879,6 +932,33 @@ async fn remove_empty_track_slot(
     }
 }
 
+async fn finish_track_subscription(
+    subscribe: Subscribe,
+    tracks: Weak<Mutex<HashMap<TrackCacheKey, TrackSlot>>>,
+    key: TrackCacheKey,
+    slot: TrackSlot,
+    interest: TrackInterest,
+) {
+    let cached = slot.lock().await;
+    if matches!(cached.as_ref(), Some(current) if current.interest.same_generation(&interest)) {
+        interest.mark_closing();
+    } else {
+        interest.mark_removed();
+    }
+    drop(cached);
+    subscribe.unsubscribe().await;
+
+    if let Some(tracks) = tracks.upgrade() {
+        let mut cached = slot.lock().await;
+        if matches!(cached.as_ref(), Some(current) if current.interest.same_generation(&interest)) {
+            cached.take();
+        }
+        drop(cached);
+        remove_empty_track_slot(&tracks, &key, &slot).await;
+    }
+    interest.mark_removed();
+}
+
 /// A connection to a single remote relay with its own QUIC client.
 #[derive(Clone)]
 struct Remote {
@@ -1109,10 +1189,14 @@ impl Remote {
                     return Ok(result);
                 }
 
-                tracing::debug!(remote_url = %self.url, namespace = %key.0, track = %key.1, "removing closed remote track from cache");
+                tracing::debug!(remote_url = %self.url, namespace = %key.0, track = %key.1, "waiting for closed remote track teardown");
+                let closing = entry.interest.clone();
+                closing.mark_closing();
+                cleanup.disarm();
+                drop(cached);
+                closing.removed().await;
+                continue;
             }
-
-            cached.take();
 
             let mut subscriber = self.subscriber.clone();
             let url = self.url.clone();
@@ -1139,11 +1223,40 @@ impl Remote {
                 }
             };
 
-            if let Err(err) = subscribe.ok().await {
-                let peer_rejected = subscribe.peer_rejected();
+            let interest = TrackInterest::new();
+            let guard = interest.guard();
+            *cached = Some(CachedTrack {
+                reader: reader.clone(),
+                interest: interest.clone(),
+            });
+            let setup_cleanup = TrackSubscriptionCleanup::new(
+                subscribe,
+                Arc::downgrade(&self.tracks),
+                key.clone(),
+                slot.clone(),
+                interest.clone(),
+            );
+
+            if let Err(err) = setup_cleanup
+                .subscribe
+                .as_ref()
+                .ok_or_else(|| {
+                    RemoteSubscribeError::Route(anyhow::anyhow!(
+                        "remote track cleanup lost its subscription"
+                    ))
+                })?
+                .ok()
+                .await
+            {
+                let peer_rejected = setup_cleanup
+                    .subscribe
+                    .as_ref()
+                    .is_some_and(Subscribe::peer_rejected);
+                let removed = interest.clone();
                 drop(cached);
-                remove_empty_track_slot(&self.tracks, &key, &slot).await;
                 cleanup.disarm();
+                drop(setup_cleanup);
+                removed.removed().await;
                 return if peer_rejected {
                     Err(RemoteSubscribeError::Peer(err))
                 } else {
@@ -1152,30 +1265,24 @@ impl Remote {
             }
 
             if !self.is_connected() {
+                let removed = interest.clone();
                 drop(cached);
-                remove_empty_track_slot(&self.tracks, &key, &slot).await;
                 cleanup.disarm();
+                drop(setup_cleanup);
+                removed.removed().await;
                 return Err(RemoteSubscribeError::Route(anyhow::anyhow!(
                     "remote connection to {} is closed",
                     self.url
                 )));
             }
 
-            let interest = TrackInterest::new();
-
-            // Take this caller's guard before the entry becomes visible, so the
-            // cleanup task cannot see a brand new entry as idle.
-            let guard = interest.guard();
-
-            *cached = Some(CachedTrack {
-                reader: reader.clone(),
-                interest: interest.clone(),
-            });
+            let subscribe = setup_cleanup
+                .disarm()
+                .map_err(|err| RemoteSubscribeError::Route(anyhow::Error::new(err)))?;
             cleanup.disarm();
             drop(cached);
 
             let cleanup_key = key.clone();
-            let cleanup_reader = reader.clone();
             let cleanup_slot = slot.clone();
             let idle_timeout = self.cache_idle_timeout;
             tokio::spawn(async move {
@@ -1202,19 +1309,8 @@ impl Remote {
                     }
                 }
 
-                subscribe.unsubscribe().await;
-
-                if let Some(tracks) = tracks.upgrade() {
-                    let mut cached = cleanup_slot.lock().await;
-                    if matches!(cached.as_ref(), Some(current) if Arc::ptr_eq(&current.reader.info, &cleanup_reader.info))
-                    {
-                        cached.take();
-                    }
-                    drop(cached);
-
-                    remove_empty_track_slot(&tracks, &cleanup_key, &cleanup_slot).await;
-                }
-                interest.mark_removed();
+                finish_track_subscription(subscribe, tracks, cleanup_key, cleanup_slot, interest)
+                    .await;
             });
 
             return Ok(Some((reader, guard)));

--- a/moq-transport/src/data/mod.rs
+++ b/moq-transport/src/data/mod.rs
@@ -7,6 +7,7 @@ mod extension_headers;
 mod fetch;
 mod header;
 mod object_status;
+mod reset_code;
 mod subgroup;
 
 pub use datagram::*;
@@ -14,4 +15,5 @@ pub use extension_headers::*;
 pub use fetch::*;
 pub use header::*;
 pub use object_status::*;
+pub use reset_code::*;
 pub use subgroup::*;

--- a/moq-transport/src/data/reset_code.rs
+++ b/moq-transport/src/data/reset_code.rs
@@ -31,6 +31,7 @@ pub enum DataStreamResetCode {
     UnknownObjectStatus = 0x6,
     /// The request's authorization token expired.
     ExpiredAuthToken = 0x7,
+    // 0x8 is unassigned in the draft-18 registry.
     /// The endpoint is overloaded.
     ExcessiveLoad = 0x9,
     /// The track was detected to be malformed.

--- a/moq-transport/src/data/reset_code.rs
+++ b/moq-transport/src/data/reset_code.rs
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2024-2026 Cloudflare Inc., Luke Curley, Mike English and contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+/// Draft-18 Section 15.10.4 Stream Reset Error Codes.
+///
+/// Sent as the QUIC/WebTransport `RESET_STREAM` application error code when a
+/// data stream is terminated before all of its objects have been delivered.
+///
+/// Draft-18 Section 11.4.3 requires a FIN only after all subgroup objects
+/// required by the subscription have been written. Earlier termination must
+/// use `RESET_STREAM`.
+/// Truncating an object and then sending FIN instead tells the receiver the
+/// subgroup ended cleanly at a byte offset that lands in the middle of an
+/// object whose length it was already promised, which is a protocol violation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum DataStreamResetCode {
+    /// An implementation specific error occurred.
+    InternalError = 0x0,
+    /// The stream was cancelled by either endpoint.
+    Cancelled = 0x1,
+    /// An object in the subgroup exceeded its delivery timeout.
+    DeliveryTimeout = 0x2,
+    /// The session is going away.
+    SessionClosed = 0x3,
+    /// The endpoint is going away and is rejecting the request.
+    GoingAway = 0x4,
+    /// The subscription exceeded the publisher's resource limits.
+    TooFarBehind = 0x5,
+    /// The publisher could not determine the status of the next fetched object.
+    UnknownObjectStatus = 0x6,
+    /// The request's authorization token expired.
+    ExpiredAuthToken = 0x7,
+    /// The endpoint is overloaded.
+    ExcessiveLoad = 0x9,
+    /// The track was detected to be malformed.
+    MalformedTrack = 0x12,
+}
+
+impl From<DataStreamResetCode> for u32 {
+    fn from(value: DataStreamResetCode) -> Self {
+        value as u32
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codes_match_the_registry() {
+        // Draft-18 Section 15.10.4. These go on the wire as RESET_STREAM codes,
+        // so the values are normative rather than internal labels.
+        assert_eq!(u32::from(DataStreamResetCode::InternalError), 0x0);
+        assert_eq!(u32::from(DataStreamResetCode::Cancelled), 0x1);
+        assert_eq!(u32::from(DataStreamResetCode::DeliveryTimeout), 0x2);
+        assert_eq!(u32::from(DataStreamResetCode::SessionClosed), 0x3);
+        assert_eq!(u32::from(DataStreamResetCode::GoingAway), 0x4);
+        assert_eq!(u32::from(DataStreamResetCode::TooFarBehind), 0x5);
+        assert_eq!(u32::from(DataStreamResetCode::UnknownObjectStatus), 0x6);
+        assert_eq!(u32::from(DataStreamResetCode::ExpiredAuthToken), 0x7);
+        assert_eq!(u32::from(DataStreamResetCode::ExcessiveLoad), 0x9);
+        assert_eq!(u32::from(DataStreamResetCode::MalformedTrack), 0x12);
+    }
+}

--- a/moq-transport/src/session/mod.rs
+++ b/moq-transport/src/session/mod.rs
@@ -2112,8 +2112,8 @@ mod tests {
         assert!(matches!(
             data_reader.done().await,
             Err(SessionError::WebTransport(web_transport::Error::Read(
-                web_transport::quinn::ReadError::Reset(0)
-            )))
+                web_transport::quinn::ReadError::Reset(code)
+            ))) if code == u32::from(crate::data::DataStreamResetCode::Cancelled)
         ));
         handler.await.unwrap().unwrap();
         drop(subgroup);
@@ -2157,8 +2157,8 @@ mod tests {
         assert!(matches!(
             data_reader.done().await,
             Err(SessionError::WebTransport(web_transport::Error::Read(
-                web_transport::quinn::ReadError::Reset(0)
-            )))
+                web_transport::quinn::ReadError::Reset(code)
+            ))) if code == u32::from(crate::data::DataStreamResetCode::Cancelled)
         ));
         drop(subgroup);
         drop(subgroups);

--- a/moq-transport/src/session/mod.rs
+++ b/moq-transport/src/session/mod.rs
@@ -45,6 +45,7 @@ use bytes::Buf;
 use futures::{stream::FuturesUnordered, StreamExt};
 use std::collections::HashMap;
 use std::future::Future;
+use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 
@@ -55,7 +56,6 @@ use crate::watch::Queue;
 use crate::{message, setup};
 
 pub(super) const CANCELLED_STREAM_CODE: u32 = crate::data::DataStreamResetCode::Cancelled as u32;
-use std::path::PathBuf;
 
 pub(crate) struct BidiResponse {
     message: Message,

--- a/moq-transport/src/session/mod.rs
+++ b/moq-transport/src/session/mod.rs
@@ -52,6 +52,8 @@ use crate::message::Message;
 use crate::mlog;
 use crate::watch::Queue;
 use crate::{message, setup};
+
+pub(super) const CANCELLED_STREAM_CODE: u32 = 0x1;
 use std::path::PathBuf;
 
 pub(crate) struct BidiResponse {
@@ -1073,6 +1075,23 @@ impl Session {
                 }
             };
 
+        // PUBLISH_NAMESPACE ends when either endpoint cancels its request stream.
+        if let Message::PublishNamespace(msg) = msg {
+            if let Some(ref mlog) = mlog {
+                if let Ok(mut mlog) = mlog.lock() {
+                    let time = mlog.elapsed_ms();
+                    let _ = mlog.add_event(mlog::events::publish_namespace_parsed(time, 0, &msg));
+                }
+            }
+
+            request_id.validate_incoming(msg.id)?;
+            let recv = subscriber
+                .as_mut()
+                .ok_or(SessionError::RoleViolation)?
+                .recv_publish_namespace(&msg)?;
+            return recv.run(writer, reader, mlog).await;
+        }
+
         // SUBSCRIBE_NAMESPACE owns its stream for the whole life of the request:
         // the reply is not one terminal message but an open-ended NAMESPACE /
         // NAMESPACE_DONE feed. Hand both halves straight to the publisher-side
@@ -1372,11 +1391,7 @@ impl Session {
                 },
             };
 
-            if let Err(err) = dispatched {
-                // Session::run decides: a protocol violation closes the session,
-                // anything else only ends this request.
-                return Err(err);
-            }
+            dispatched?;
 
             if let Some(terminal) = terminal {
                 return Ok(terminal);

--- a/moq-transport/src/session/mod.rs
+++ b/moq-transport/src/session/mod.rs
@@ -41,6 +41,7 @@ pub use track_status_requested::*;
 use reader::*;
 use writer::*;
 
+use bytes::Buf;
 use futures::{stream::FuturesUnordered, StreamExt};
 use std::collections::HashMap;
 use std::future::Future;
@@ -53,7 +54,7 @@ use crate::mlog;
 use crate::watch::Queue;
 use crate::{message, setup};
 
-pub(super) const CANCELLED_STREAM_CODE: u32 = 0x1;
+pub(super) const CANCELLED_STREAM_CODE: u32 = crate::data::DataStreamResetCode::Cancelled as u32;
 use std::path::PathBuf;
 
 pub(crate) struct BidiResponse {
@@ -1595,6 +1596,10 @@ impl Session {
                 )))
             }
         }?;
+
+        if buf.has_remaining() {
+            return Err(DecodeError::InvalidLength(0, buf.remaining()).into());
+        }
 
         if !msg.parameter_scopes_valid() {
             return Err(DecodeError::InvalidParameter.into());

--- a/moq-transport/src/session/publish_namespace.rs
+++ b/moq-transport/src/session/publish_namespace.rs
@@ -8,7 +8,7 @@ use crate::coding::TrackNamespace;
 use crate::watch::State;
 use crate::{message, serve::ServeError};
 
-use super::{Publisher, Subscribed, TrackStatusRequested};
+use super::{Publisher, Subscribed, TrackStatusRequested, CANCELLED_STREAM_CODE};
 
 /// Information about an outbound PUBLISH_NAMESPACE request.
 #[derive(Debug, Clone)]
@@ -49,11 +49,12 @@ impl Drop for PublishNamespaceState {
 
 /// Represents an outbound PUBLISH_NAMESPACE sent by a publisher.
 ///
-/// Dropped with PUBLISH_NAMESPACE_DONE unless already closed with an error.
-#[must_use = "send PUBLISH_NAMESPACE_DONE on drop"]
+/// Dropping the handle cancels the request stream unless the peer already closed it.
+#[must_use = "cancels PUBLISH_NAMESPACE on drop"]
 pub struct PublishNamespace {
     publisher: Publisher,
     state: State<PublishNamespaceState>,
+    cancel: Option<tokio::sync::oneshot::Sender<u32>>,
 
     pub info: PublishNamespaceInfo,
 }
@@ -65,7 +66,11 @@ impl PublishNamespace {
         publisher: Publisher,
         request_id: u64,
         namespace: TrackNamespace,
-    ) -> (PublishNamespace, PublishNamespaceRecv) {
+    ) -> (
+        PublishNamespace,
+        PublishNamespaceRecv,
+        tokio::sync::oneshot::Receiver<u32>,
+    ) {
         let info = PublishNamespaceInfo {
             request_id,
             namespace: namespace.clone(),
@@ -86,20 +91,26 @@ impl PublishNamespace {
         publisher: Publisher,
         info: PublishNamespaceInfo,
         request_id: u64,
-    ) -> (PublishNamespace, PublishNamespaceRecv) {
+    ) -> (
+        PublishNamespace,
+        PublishNamespaceRecv,
+        tokio::sync::oneshot::Receiver<u32>,
+    ) {
         let (send, recv) = State::default().split();
+        let (cancel, recv_cancel) = tokio::sync::oneshot::channel();
 
         let send = Self {
             publisher,
             info,
             state: send,
+            cancel: Some(cancel),
         };
         let recv = PublishNamespaceRecv {
             state: recv,
             request_id,
         };
 
-        (send, recv)
+        (send, recv, recv_cancel)
     }
 
     /// Wait until the namespace publish is closed (error or peer disconnect).
@@ -186,11 +197,10 @@ impl Drop for PublishNamespace {
             return;
         }
 
-        // Draft-16 §9.22: PUBLISH_NAMESPACE_DONE carries the Request ID,
-        // not the namespace.
-        self.publisher.send_message(message::PublishNamespaceDone {
-            id: self.info.request_id,
-        });
+        self.publisher.drop_publish_namespace(self.info.request_id);
+        if let Some(cancel) = self.cancel.take() {
+            let _ = cancel.send(CANCELLED_STREAM_CODE);
+        }
     }
 }
 
@@ -250,5 +260,34 @@ impl PublishNamespaceRecv {
             .track_statuses_requested
             .push_back(track_status_requested);
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        coding::TrackNamespace,
+        session::{test_support::loopback_session, Publisher, RequestId},
+        watch::Queue,
+    };
+
+    use super::PublishNamespace;
+
+    #[tokio::test]
+    async fn drop_cancels_request_stream() {
+        let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+        let publisher = Publisher::new(
+            Queue::default(),
+            loopback_session().await,
+            None,
+            RequestId::new(0, 1),
+            bidi_task_tx,
+        );
+        let (publish, _recv, cancel) =
+            PublishNamespace::new(publisher, 6, TrackNamespace::from_utf8_path("test"));
+
+        drop(publish);
+
+        assert_eq!(cancel.await.unwrap(), super::CANCELLED_STREAM_CODE);
     }
 }

--- a/moq-transport/src/session/publish_namespace.rs
+++ b/moq-transport/src/session/publish_namespace.rs
@@ -8,7 +8,7 @@ use crate::coding::TrackNamespace;
 use crate::watch::State;
 use crate::{message, serve::ServeError};
 
-use super::{Publisher, Subscribed, TrackStatusRequested, CANCELLED_STREAM_CODE};
+use super::{Subscribed, TrackStatusRequested, CANCELLED_STREAM_CODE};
 
 /// Information about an outbound PUBLISH_NAMESPACE request.
 #[derive(Debug, Clone)]
@@ -52,7 +52,6 @@ impl Drop for PublishNamespaceState {
 /// Dropping the handle cancels the request stream unless the peer already closed it.
 #[must_use = "cancels PUBLISH_NAMESPACE on drop"]
 pub struct PublishNamespace {
-    publisher: Publisher,
     state: State<PublishNamespaceState>,
     cancel: Option<tokio::sync::oneshot::Sender<u32>>,
 
@@ -63,7 +62,6 @@ impl PublishNamespace {
     /// Create a PublishNamespace without sending on the control stream.
     /// The caller sends via a bidi request stream (draft-18).
     pub(super) fn new(
-        publisher: Publisher,
         request_id: u64,
         namespace: TrackNamespace,
     ) -> (
@@ -75,7 +73,7 @@ impl PublishNamespace {
             request_id,
             namespace: namespace.clone(),
         };
-        Self::from_parts(publisher, info, request_id)
+        Self::from_parts(info, request_id)
     }
 
     /// Return the wire message to send on the request stream.
@@ -88,7 +86,6 @@ impl PublishNamespace {
     }
 
     fn from_parts(
-        publisher: Publisher,
         info: PublishNamespaceInfo,
         request_id: u64,
     ) -> (
@@ -100,7 +97,6 @@ impl PublishNamespace {
         let (cancel, recv_cancel) = tokio::sync::oneshot::channel();
 
         let send = Self {
-            publisher,
             info,
             state: send,
             cancel: Some(cancel),
@@ -197,7 +193,6 @@ impl Drop for PublishNamespace {
             return;
         }
 
-        self.publisher.drop_publish_namespace(self.info.request_id);
         if let Some(cancel) = self.cancel.take() {
             let _ = cancel.send(CANCELLED_STREAM_CODE);
         }
@@ -234,7 +229,7 @@ impl PublishNamespaceRecv {
         Ok(())
     }
 
-    pub fn recv_error(self, err: ServeError) -> Result<(), ServeError> {
+    pub fn recv_error(&mut self, err: ServeError) -> Result<(), ServeError> {
         let state = self.state.lock();
         state.closed.clone()?;
 
@@ -265,26 +260,14 @@ impl PublishNamespaceRecv {
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        coding::TrackNamespace,
-        session::{test_support::loopback_session, Publisher, RequestId},
-        watch::Queue,
-    };
+    use crate::coding::TrackNamespace;
 
     use super::PublishNamespace;
 
     #[tokio::test]
     async fn drop_cancels_request_stream() {
-        let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
-        let publisher = Publisher::new(
-            Queue::default(),
-            loopback_session().await,
-            None,
-            RequestId::new(0, 1),
-            bidi_task_tx,
-        );
         let (publish, _recv, cancel) =
-            PublishNamespace::new(publisher, 6, TrackNamespace::from_utf8_path("test"));
+            PublishNamespace::new(6, TrackNamespace::from_utf8_path("test"));
 
         drop(publish);
 

--- a/moq-transport/src/session/published_namespace.rs
+++ b/moq-transport/src/session/published_namespace.rs
@@ -19,6 +19,7 @@ use super::{
     PublishNamespaceInfo, Reader, Session, SessionError, Subscriber, Writer, CANCELLED_STREAM_CODE,
 };
 
+// Immediate cancellation can queue after REQUEST_OK before the stream task runs.
 const RESPONSE_QUEUE_CAPACITY: usize = 2;
 
 enum StreamAction {
@@ -296,6 +297,7 @@ mod tests {
             None,
             RequestId::new(0, 1),
             bidi_task_tx,
+            Default::default(),
         );
         PublishedNamespace::new(subscriber, 6, TrackNamespace::from_utf8_path("test"))
     }
@@ -337,6 +339,7 @@ mod tests {
             None,
             RequestId::new(0, 1),
             bidi_task_tx,
+            Default::default(),
         );
         let (mut published, recv) =
             PublishedNamespace::new(subscriber, 0, TrackNamespace::from_utf8_path("test"));
@@ -385,6 +388,7 @@ mod tests {
             None,
             RequestId::new(0, 1),
             bidi_task_tx,
+            Default::default(),
         );
         let (mut published, recv) =
             PublishedNamespace::new(subscriber, 0, TrackNamespace::from_utf8_path("test"));
@@ -428,6 +432,7 @@ mod tests {
             None,
             RequestId::new(0, 1),
             bidi_task_tx,
+            Default::default(),
         );
         let (mut published, recv) =
             PublishedNamespace::new(subscriber, 0, TrackNamespace::from_utf8_path("test"));

--- a/moq-transport/src/session/published_namespace.rs
+++ b/moq-transport/src/session/published_namespace.rs
@@ -2,16 +2,36 @@
 // SPDX-FileCopyrightText: 2023-2024 Luke Curley and contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::ops;
+use std::{
+    ops,
+    sync::{Arc, Mutex},
+};
+
+use tokio::sync::mpsc;
 
 use crate::coding::{ReasonPhrase, TrackNamespace};
-use crate::message::RequestErrorCode;
+use crate::message::{Message, RequestErrorCode};
+use crate::mlog;
 use crate::watch::State;
 use crate::{message, serve::ServeError};
 
-use super::{PublishNamespaceInfo, Subscriber};
+use super::{
+    PublishNamespaceInfo, Reader, Session, SessionError, Subscriber, Writer, CANCELLED_STREAM_CODE,
+};
 
-// Tracks whether the publisher has cleanly completed this namespace publish.
+const RESPONSE_QUEUE_CAPACITY: usize = 2;
+
+enum StreamAction {
+    Response(Message),
+    Cancel(u32),
+}
+
+enum StreamEvent {
+    Action(Option<StreamAction>),
+    RequestFinished(Result<bool, SessionError>),
+    ResponseStopped(Result<Option<u8>, SessionError>),
+}
+
 #[derive(Default)]
 struct PublishedNamespaceState {
     done: bool,
@@ -19,11 +39,11 @@ struct PublishedNamespaceState {
 
 /// Represents an inbound PUBLISH_NAMESPACE received by a subscriber.
 ///
-/// On drop, revokes an accepted namespace with PUBLISH_NAMESPACE_CANCEL, or
-/// rejects an unaccepted namespace with REQUEST_ERROR.
+/// Dropping an accepted namespace cancels its request stream. Dropping an
+/// unaccepted namespace rejects it with REQUEST_ERROR.
 pub struct PublishedNamespace {
-    session: Subscriber,
     state: State<PublishedNamespaceState>,
+    outgoing: mpsc::Sender<StreamAction>,
 
     pub info: PublishNamespaceInfo,
 
@@ -33,7 +53,7 @@ pub struct PublishedNamespace {
 
 impl PublishedNamespace {
     pub(super) fn new(
-        session: Subscriber,
+        subscriber: Subscriber,
         request_id: u64,
         namespace: TrackNamespace,
     ) -> (PublishedNamespace, PublishedNamespaceRecv) {
@@ -41,45 +61,46 @@ impl PublishedNamespace {
             request_id,
             namespace,
         };
-
-        let (send, recv) = State::default().split();
+        let (send_state, recv_state) = State::default().split();
+        let (send_queue, recv_queue) = mpsc::channel(RESPONSE_QUEUE_CAPACITY);
         let send = Self {
-            session,
+            state: send_state,
+            outgoing: send_queue,
             info,
             ok: false,
             error: None,
-            state: send,
         };
         let recv = PublishedNamespaceRecv {
-            state: recv,
+            state: recv_state,
+            outgoing: recv_queue,
+            subscriber,
             request_id,
         };
 
         (send, recv)
     }
 
-    /// Accept the PUBLISH_NAMESPACE by sending REQUEST_OK (draft-16 §9.7).
+    /// Accept the PUBLISH_NAMESPACE by sending REQUEST_OK.
     pub fn ok(&mut self) -> Result<(), ServeError> {
         if self.ok {
             return Err(ServeError::Duplicate);
         }
 
-        // Draft-16 §6.2: acceptance is signalled with REQUEST_OK, not the
-        // legacy PUBLISH_NAMESPACE_OK.
-        self.session.send_request_ok(
-            "publish_namespace",
-            message::RequestOk {
-                id: self.info.request_id,
-                params: Default::default(),
-            },
-        );
-
+        self.outgoing
+            .try_send(StreamAction::Response(
+                message::RequestOk {
+                    id: self.info.request_id,
+                    params: Default::default(),
+                }
+                .into(),
+            ))
+            .map_err(|_| ServeError::Cancel)?;
         self.ok = true;
 
         Ok(())
     }
 
-    /// Wait until the peer closes the namespace publish (PUBLISH_NAMESPACE_DONE).
+    /// Wait until the peer closes the namespace request stream.
     pub async fn closed(&self) -> Result<(), ServeError> {
         loop {
             let Some(modified) = self.state.lock().modified() else {
@@ -107,71 +128,333 @@ impl ops::Deref for PublishedNamespace {
 
 impl Drop for PublishedNamespace {
     fn drop(&mut self) {
-        let err = self.error.clone().unwrap_or(ServeError::Done);
-
         if self.state.lock().done {
             return;
         }
 
         if self.ok {
-            // Accepted: send PUBLISH_NAMESPACE_CANCEL to revoke acceptance
-            // (draft-16 §9.24).  Carries Request ID, not the namespace.
-            self.session.send_message(message::PublishNamespaceCancel {
-                id: self.info.request_id,
-                error_code: err.code(),
-                reason_phrase: ReasonPhrase(err.to_string()),
-            });
-        } else {
-            // Never accepted: send REQUEST_ERROR (draft-16 §9.8).
-            self.session.send_request_error(
-                "publish_namespace",
-                message::RequestError {
-                    id: self.info.request_id,
-                    error_code: RequestErrorCode::Uninterested as u64,
-                    retry_interval: 0,
-                    reason: ReasonPhrase(err.to_string()),
-                },
-            );
+            let _ = self
+                .outgoing
+                .try_send(StreamAction::Cancel(CANCELLED_STREAM_CODE));
+            return;
         }
+
+        let err = self.error.clone().unwrap_or(ServeError::Done);
+        let _ = self.outgoing.try_send(StreamAction::Response(
+            message::RequestError {
+                id: self.info.request_id,
+                error_code: RequestErrorCode::Uninterested as u64,
+                retry_interval: 0,
+                reason: ReasonPhrase(err.to_string()),
+            }
+            .into(),
+        ));
     }
 }
 
 pub(super) struct PublishedNamespaceRecv {
     state: State<PublishedNamespaceState>,
-    /// Request ID of the corresponding PUBLISH_NAMESPACE, used for O(1) lookup
-    /// when PUBLISH_NAMESPACE_DONE or PUBLISH_NAMESPACE_CANCEL arrives.
-    pub request_id: u64,
+    outgoing: mpsc::Receiver<StreamAction>,
+    subscriber: Subscriber,
+    request_id: u64,
 }
 
 impl PublishedNamespaceRecv {
-    pub fn recv_done(self) -> Result<(), ServeError> {
+    pub(super) async fn run(
+        mut self,
+        mut writer: Writer,
+        mut reader: Reader,
+        mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
+    ) -> Result<(), SessionError> {
+        let mut reading = true;
+
+        loop {
+            let event = tokio::select! {
+                biased;
+                done = reader.done(), if reading => StreamEvent::RequestFinished(done),
+                action = self.outgoing.recv() => StreamEvent::Action(action),
+                stopped = writer.closed() => StreamEvent::ResponseStopped(stopped),
+            };
+
+            match event {
+                StreamEvent::Action(action) => {
+                    let Some(action) = action else {
+                        if reading {
+                            let _ = writer.finish();
+                        } else {
+                            writer.reset(CANCELLED_STREAM_CODE);
+                        }
+                        reader.stop(CANCELLED_STREAM_CODE);
+                        return Ok(());
+                    };
+                    let response = match action {
+                        StreamAction::Response(response) => response,
+                        StreamAction::Cancel(code) => {
+                            if reading {
+                                let _ = writer.finish();
+                            } else {
+                                writer.reset(code);
+                            }
+                            reader.stop(code);
+                            return Ok(());
+                        }
+                    };
+                    self.emit_mlog(&mlog, &response);
+                    let terminal = matches!(response, Message::RequestError(_));
+                    match Session::encode_bidi_response(&mut writer, &response).await {
+                        Ok(()) => {}
+                        Err(err) if err.is_stream_error() => return Ok(()),
+                        Err(err) => return Err(err),
+                    }
+                    if terminal {
+                        reader.stop(CANCELLED_STREAM_CODE);
+                        return match writer.finish() {
+                            Ok(()) => Ok(()),
+                            Err(err) if err.is_stream_error() => Ok(()),
+                            Err(err) => Err(err),
+                        };
+                    }
+                }
+                StreamEvent::RequestFinished(done) => match done {
+                    Ok(true) => {
+                        reading = false;
+                    }
+                    Ok(false) => {
+                        return Err(SessionError::ProtocolViolation(
+                            "unexpected data after PUBLISH_NAMESPACE request".to_string(),
+                        ));
+                    }
+                    Err(err) if err.is_stream_error() => {
+                        writer.reset(CANCELLED_STREAM_CODE);
+                        return Ok(());
+                    }
+                    Err(err) => return Err(err),
+                },
+                StreamEvent::ResponseStopped(stopped) => {
+                    let _ = stopped?;
+                    reader.stop(CANCELLED_STREAM_CODE);
+                    return Ok(());
+                }
+            }
+        }
+    }
+
+    fn emit_mlog(&self, mlog: &Option<Arc<Mutex<mlog::MlogWriter>>>, msg: &Message) {
+        if let Some(mlog) = mlog {
+            if let Ok(mut mlog) = mlog.lock() {
+                let time = mlog.elapsed_ms();
+                let event = match msg {
+                    Message::RequestOk(msg) => Some(mlog::events::request_ok_created(
+                        time,
+                        0,
+                        "publish_namespace",
+                        msg,
+                    )),
+                    Message::RequestError(msg) => Some(mlog::events::request_error_created(
+                        time,
+                        0,
+                        "publish_namespace",
+                        msg,
+                    )),
+                    _ => None,
+                };
+                if let Some(event) = event {
+                    let _ = mlog.add_event(event);
+                }
+            }
+        }
+    }
+}
+
+impl Drop for PublishedNamespaceRecv {
+    fn drop(&mut self) {
         if let Some(mut state) = self.state.lock_mut() {
             state.done = true;
         }
-
-        // Dropping the state signals the PublishedNamespace that the peer is done.
-        Ok(())
+        self.subscriber.remove_published_namespace(self.request_id);
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::{
+        session::{
+            test_support::{loopback_session, loopback_session_pair},
+            RequestId, Transport,
+        },
+        watch::Queue,
+    };
+
     use super::*;
 
-    #[test]
-    fn recv_done_marks_namespace_done_before_drop() {
-        let state = State::<PublishedNamespaceState>::default();
-        let (send_state, recv_state) = state.split();
-        let recv = PublishedNamespaceRecv {
-            state: recv_state,
-            request_id: 0,
-        };
+    async fn pair() -> (PublishedNamespace, PublishedNamespaceRecv) {
+        let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+        let subscriber = Subscriber::new(
+            Queue::default(),
+            loopback_session().await,
+            Transport::WebTransport,
+            None,
+            RequestId::new(0, 1),
+            bidi_task_tx,
+        );
+        PublishedNamespace::new(subscriber, 6, TrackNamespace::from_utf8_path("test"))
+    }
 
-        assert!(!send_state.lock().done);
+    #[tokio::test]
+    async fn dropping_accepted_namespace_cancels_request_stream() {
+        let (mut published, mut recv) = pair().await;
+        published.ok().unwrap();
+        assert!(matches!(
+            recv.outgoing.recv().await,
+            Some(StreamAction::Response(Message::RequestOk(_)))
+        ));
+        drop(published);
 
-        recv.recv_done().unwrap();
+        assert!(matches!(
+            recv.outgoing.recv().await,
+            Some(StreamAction::Cancel(CANCELLED_STREAM_CODE))
+        ));
+    }
 
-        assert!(send_state.lock().done);
-        assert!(send_state.lock().modified().is_none());
+    #[tokio::test]
+    async fn dropping_receiver_closes_namespace() {
+        let (published, recv) = pair().await;
+
+        drop(recv);
+
+        published.closed().await.unwrap();
+        assert!(published.state.lock().done);
+    }
+
+    #[tokio::test]
+    async fn accepted_namespace_survives_request_fin_until_local_cancel() {
+        let (client, server) = loopback_session_pair().await;
+        let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+        let subscriber = Subscriber::new(
+            Queue::default(),
+            server.clone(),
+            Transport::WebTransport,
+            None,
+            RequestId::new(0, 1),
+            bidi_task_tx,
+        );
+        let (mut published, recv) =
+            PublishedNamespace::new(subscriber, 0, TrackNamespace::from_utf8_path("test"));
+
+        let (mut request_send, response_recv) = client.open_bi().await.unwrap();
+        request_send.write(b"request").await.unwrap();
+        let (response_send, mut request_recv) = server.accept_bi().await.unwrap();
+        assert_eq!(
+            request_recv.read(7).await.unwrap().unwrap().as_ref(),
+            b"request"
+        );
+
+        published.ok().unwrap();
+        let run =
+            tokio::spawn(recv.run(Writer::new(response_send), Reader::new(request_recv), None));
+        request_send.finish().unwrap();
+
+        let mut response_reader = Reader::new(response_recv);
+        assert!(matches!(
+            Session::decode_bidi_response(&mut response_reader, 0)
+                .await
+                .unwrap(),
+            Message::RequestOk(_)
+        ));
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(20), published.closed())
+                .await
+                .is_err()
+        );
+
+        drop(published);
+
+        run.await.unwrap().unwrap();
+        let reset = response_reader.done().await.unwrap_err();
+        assert!(reset.is_stream_error());
+    }
+
+    #[tokio::test]
+    async fn immediate_cancel_preserves_namespace_acceptance() {
+        let (client, server) = loopback_session_pair().await;
+        let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+        let subscriber = Subscriber::new(
+            Queue::default(),
+            server.clone(),
+            Transport::WebTransport,
+            None,
+            RequestId::new(0, 1),
+            bidi_task_tx,
+        );
+        let (mut published, recv) =
+            PublishedNamespace::new(subscriber, 0, TrackNamespace::from_utf8_path("test"));
+
+        let (mut request_send, response_recv) = client.open_bi().await.unwrap();
+        request_send.write(b"request").await.unwrap();
+        let (response_send, mut request_recv) = server.accept_bi().await.unwrap();
+        assert_eq!(
+            request_recv.read(7).await.unwrap().unwrap().as_ref(),
+            b"request"
+        );
+
+        published.ok().unwrap();
+        drop(published);
+        let run =
+            tokio::spawn(recv.run(Writer::new(response_send), Reader::new(request_recv), None));
+
+        let mut response_reader = Reader::new(response_recv);
+        assert!(matches!(
+            Session::decode_bidi_response(&mut response_reader, 0)
+                .await
+                .unwrap(),
+            Message::RequestOk(_)
+        ));
+        assert!(response_reader.done().await.unwrap());
+        assert_eq!(
+            request_send.closed().await.unwrap(),
+            Some(u8::try_from(CANCELLED_STREAM_CODE).unwrap())
+        );
+        run.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn cancel_resets_response_when_request_fin_precedes_dispatch() {
+        let (client, server) = loopback_session_pair().await;
+        let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+        let subscriber = Subscriber::new(
+            Queue::default(),
+            server.clone(),
+            Transport::WebTransport,
+            None,
+            RequestId::new(0, 1),
+            bidi_task_tx,
+        );
+        let (mut published, recv) =
+            PublishedNamespace::new(subscriber, 0, TrackNamespace::from_utf8_path("test"));
+
+        let (mut request_send, response_recv) = client.open_bi().await.unwrap();
+        request_send.write(b"request").await.unwrap();
+        request_send.finish().unwrap();
+        let (response_send, mut request_recv) = server.accept_bi().await.unwrap();
+        assert_eq!(
+            request_recv.read(7).await.unwrap().unwrap().as_ref(),
+            b"request"
+        );
+
+        published.ok().unwrap();
+        drop(published);
+        let run =
+            tokio::spawn(recv.run(Writer::new(response_send), Reader::new(request_recv), None));
+
+        let mut response_reader = Reader::new(response_recv);
+        match Session::decode_bidi_response(&mut response_reader, 0).await {
+            Ok(Message::RequestOk(_)) => {
+                let reset = response_reader.done().await.unwrap_err();
+                assert!(reset.is_stream_error());
+            }
+            Err(err) => assert!(err.is_stream_error()),
+            Ok(msg) => panic!("unexpected response: {}", msg.name()),
+        }
+        run.await.unwrap().unwrap();
     }
 }

--- a/moq-transport/src/session/publisher.rs
+++ b/moq-transport/src/session/publisher.rs
@@ -21,8 +21,8 @@ use crate::watch::Queue;
 use super::{
     split_published_state, BidiResponse, BidiResponseMap, DeliveryError, NameRegistry,
     ObjectForwarderRecv, PublishNamespace, PublishNamespaceRecv, Published, PublishedInfo,
-    PublishedRecv, RequestId, Session, SessionError, Subscribed, SubscribedNamespace,
-    SubscribedNamespaceInfo, SubscribedNamespaceRecv, TrackStatusRequested,
+    PublishedRecv, Reader, RequestId, Session, SessionError, Subscribed, SubscribedNamespace,
+    SubscribedNamespaceInfo, SubscribedNamespaceRecv, TrackStatusRequested, Writer,
 };
 use crate::message::RequestErrorCode;
 
@@ -141,6 +141,39 @@ struct PublishNamespaceCleanup {
     request_id: u64,
 }
 
+/// Resets both halves when opening a request is cancelled before its response
+/// pump takes ownership of the stream.
+struct OpeningPublishNamespaceStream {
+    writer: Option<Writer>,
+    reader: Option<Reader>,
+}
+
+impl OpeningPublishNamespaceStream {
+    fn new(send: web_transport::SendStream, recv: web_transport::RecvStream) -> Self {
+        Self {
+            writer: Some(Writer::new(send)),
+            reader: Some(Reader::new(recv)),
+        }
+    }
+
+    fn into_parts(mut self) -> Result<(Writer, Reader), SessionError> {
+        let writer = self.writer.take().ok_or(SessionError::Internal)?;
+        let reader = self.reader.take().ok_or(SessionError::Internal)?;
+        Ok((writer, reader))
+    }
+}
+
+impl Drop for OpeningPublishNamespaceStream {
+    fn drop(&mut self) {
+        if let Some(writer) = &mut self.writer {
+            writer.reset(super::CANCELLED_STREAM_CODE);
+        }
+        if let Some(reader) = &mut self.reader {
+            reader.stop(super::CANCELLED_STREAM_CODE);
+        }
+    }
+}
+
 enum PublishNamespaceEvent {
     Cancel(Result<u32, tokio::sync::oneshot::error::RecvError>),
     Response(Result<Message, SessionError>),
@@ -215,8 +248,7 @@ impl Publisher {
             }
 
             let request_id = self.request_id.allocate()?;
-            let (send, recv, cancel) =
-                PublishNamespace::new(self.clone(), request_id, tracks.namespace.clone());
+            let (send, recv, cancel) = PublishNamespace::new(request_id, tracks.namespace.clone());
             namespaces.insert(tracks.namespace.clone(), recv);
             let wire_msg = send.wire_message();
             (send, wire_msg, request_id, cancel)
@@ -284,22 +316,38 @@ impl Publisher {
         msg: message::PublishNamespace,
         mut cancel: tokio::sync::oneshot::Receiver<u32>,
     ) -> Result<(), SessionError> {
-        let frame = super::encode_request_frame(&Message::PublishNamespace(msg))?;
-        let (send_stream, recv_stream) = self.webtransport.open_bi().await?;
-        let mut writer = super::Writer::new(send_stream);
-        writer.write(&frame).await?;
-
         let mut this = self.clone();
         let cleanup = PublishNamespaceCleanup {
             publisher: this.clone(),
             request_id,
         };
+        let frame = super::encode_request_frame(&Message::PublishNamespace(msg))?;
+        let (send_stream, recv_stream) = self.webtransport.open_bi().await?;
+        let mut opening = OpeningPublishNamespaceStream::new(send_stream, recv_stream);
+
+        let OpeningPublishNamespaceStream { writer, reader } = &mut opening;
+        let writer = writer.as_mut().ok_or(SessionError::Internal)?;
+        let reader = reader.as_mut().ok_or(SessionError::Internal)?;
+
+        tokio::select! {
+            reset = &mut cancel => {
+                if let Ok(code) = reset {
+                    writer.reset(code);
+                    reader.stop(code);
+                }
+                return Ok(());
+            }
+            result = writer.write(&frame) => {
+                result?;
+            }
+        }
+
+        let (mut writer, mut reader) = opening.into_parts()?;
 
         if self
             .bidi_task_tx
             .send(Box::pin(async move {
                 let _cleanup = cleanup;
-                let mut reader = super::Reader::new(recv_stream);
                 let mut reading = true;
                 let mut responded = false;
                 let mut request_stopped = false;
@@ -350,7 +398,7 @@ impl Publisher {
                                     "multiple responses to PUBLISH_NAMESPACE".to_string(),
                                 ));
                             }
-                            this.recv_request_error(msg)?;
+                            this.recv_publish_namespace_error(&msg)?;
                             let _ = writer.finish();
                             return Ok(());
                         }
@@ -997,10 +1045,37 @@ impl Publisher {
         Ok(matched)
     }
 
+    fn recv_publish_namespace_error(
+        &mut self,
+        msg: &message::RequestError,
+    ) -> Result<bool, SessionError> {
+        let matched = {
+            let mut namespaces = self
+                .publish_namespaces
+                .lock()
+                .map_err(|_| SessionError::Internal)?;
+            match namespaces
+                .iter_mut()
+                .find(|(_namespace, publish)| publish.request_id == msg.id)
+            {
+                Some((_namespace, publish)) => {
+                    publish.recv_error(ServeError::Closed(msg.error_code))?;
+                    true
+                }
+                None => false,
+            }
+        };
+
+        if matched {
+            self.log_request_error_parsed("publish_namespace", msg);
+        }
+        Ok(matched)
+    }
+
     /// Handle REQUEST_ERROR from a subscriber — rejection of an outbound
     /// PUBLISH_NAMESPACE or PUBLISH (draft-16 §9.8).
     fn recv_request_error(&mut self, msg: message::RequestError) -> Result<(), SessionError> {
-        if let Some(recv) = self.drop_publish_namespace(msg.id) {
+        if let Some(mut recv) = self.drop_publish_namespace(msg.id) {
             self.log_request_error_parsed("publish_namespace", &msg);
             recv.recv_error(ServeError::Closed(msg.error_code))?;
             return Ok(());
@@ -1249,7 +1324,7 @@ impl Publisher {
     }
 
     fn abort_publish_namespace(&mut self, id: u64) {
-        let Some(recv) = self.drop_publish_namespace(id) else {
+        let Some(mut recv) = self.drop_publish_namespace(id) else {
             return;
         };
         if let Err(err) = recv.recv_error(ServeError::Cancel) {
@@ -1278,15 +1353,15 @@ mod tests {
         coding::{KeyValuePairs, ReasonPhrase, TrackName, TrackNamespace},
         data,
         message::{self, Message},
-        serve::{self, FullTrackName, ServeError},
+        serve::{self, FullTrackName, ServeError, Tracks},
         session::{test_support::loopback_session_pair, Reader, RequestId, Session, Writer},
         watch::Queue,
     };
     use bytes::Bytes;
 
     use super::{
-        split_published_state, AbortPublishedOnDrop, NameRegistry, PublishedEntry, PublishedRecv,
-        PublishNamespace, Publisher,
+        split_published_state, AbortPublishedOnDrop, NameRegistry, PublishNamespace,
+        PublishedEntry, PublishedRecv, Publisher,
     };
 
     fn full_track_name(namespace: &str, name: &str) -> FullTrackName {
@@ -1708,13 +1783,12 @@ mod tests {
             bidi_task_tx,
         );
         let namespace = TrackNamespace::from_utf8_path("test");
-        let (publish, recv, cancel) =
-            PublishNamespace::new(publisher.clone(), 0, namespace.clone());
+        let (publish, recv, cancel) = PublishNamespace::new(0, namespace.clone());
         publisher
             .publish_namespaces
             .lock()
             .unwrap()
-            .insert(namespace, recv);
+            .insert(namespace.clone(), recv);
         publisher
             .open_publish_namespace_stream(0, publish.wire_message(), cancel)
             .await
@@ -1748,9 +1822,51 @@ mod tests {
 
         drop(publish);
 
+        let (_, _, replacement) = Tracks::new(namespace).produce();
+        assert!(matches!(
+            publisher.publish_namespace(replacement).await,
+            Err(crate::session::SessionError::Serve(ServeError::Duplicate))
+        ));
+
         pump.await.unwrap().unwrap();
         let reset = peer_reader.done().await.unwrap_err();
         assert!(reset.is_stream_error());
+    }
+
+    #[tokio::test]
+    async fn cancelling_while_namespace_stream_is_blocked_releases_namespace() {
+        let (client, _server) = loopback_session_pair().await;
+        let mut streams = Vec::new();
+        loop {
+            match tokio::time::timeout(std::time::Duration::from_millis(20), client.open_bi()).await
+            {
+                Ok(Ok(stream)) => streams.push(stream),
+                Ok(Err(err)) => panic!("failed to open saturation stream: {err}"),
+                Err(_) => break,
+            }
+            assert!(streams.len() < 1024, "bidi stream credit was not bounded");
+        }
+
+        let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut publisher = Publisher::new(
+            Queue::default(),
+            client,
+            None,
+            RequestId::new(0, 1),
+            bidi_task_tx,
+        );
+        let (_, _, tracks) = Tracks::new(TrackNamespace::from_utf8_path("blocked")).produce();
+
+        assert!(
+            tokio::time::timeout(
+                std::time::Duration::from_millis(20),
+                publisher.publish_namespace(tracks),
+            )
+            .await
+            .is_err(),
+            "PUBLISH_NAMESPACE unexpectedly opened without bidi stream credit"
+        );
+        assert!(publisher.publish_namespaces.lock().unwrap().is_empty());
     }
 
     #[tokio::test]
@@ -1765,8 +1881,7 @@ mod tests {
             bidi_task_tx,
         );
         let namespace = TrackNamespace::from_utf8_path("test");
-        let (publish, recv, cancel) =
-            PublishNamespace::new(publisher.clone(), 0, namespace.clone());
+        let (publish, recv, cancel) = PublishNamespace::new(0, namespace.clone());
         publisher
             .publish_namespaces
             .lock()
@@ -1814,8 +1929,7 @@ mod tests {
             bidi_task_tx,
         );
         let namespace = TrackNamespace::from_utf8_path("test");
-        let (publish, recv, cancel) =
-            PublishNamespace::new(publisher.clone(), 0, namespace.clone());
+        let (publish, recv, cancel) = PublishNamespace::new(0, namespace.clone());
         publisher
             .publish_namespaces
             .lock()

--- a/moq-transport/src/session/publisher.rs
+++ b/moq-transport/src/session/publisher.rs
@@ -136,6 +136,23 @@ pub struct Publisher {
     pub(super) bidi_response_map: BidiResponseMap,
 }
 
+struct PublishNamespaceCleanup {
+    publisher: Publisher,
+    request_id: u64,
+}
+
+enum PublishNamespaceEvent {
+    Cancel(Result<u32, tokio::sync::oneshot::error::RecvError>),
+    Response(Result<Message, SessionError>),
+    Stopped(Result<Option<u8>, SessionError>),
+}
+
+impl Drop for PublishNamespaceCleanup {
+    fn drop(&mut self) {
+        self.publisher.abort_publish_namespace(self.request_id);
+    }
+}
+
 impl Publisher {
     pub(crate) fn new(
         outgoing: Queue<Message>,
@@ -187,7 +204,7 @@ impl Publisher {
     /// concurrently, since `run` polls the bidi response reader.
     pub async fn publish_namespace(&mut self, tracks: TracksReader) -> Result<(), SessionError> {
         // Phase 1: allocate under lock, release before any await.
-        let (publish_ns, wire_msg, request_id) = {
+        let (publish_ns, wire_msg, request_id, cancel) = {
             let mut namespaces = self
                 .publish_namespaces
                 .lock()
@@ -198,64 +215,16 @@ impl Publisher {
             }
 
             let request_id = self.request_id.allocate()?;
-            let (send, recv) =
+            let (send, recv, cancel) =
                 PublishNamespace::new(self.clone(), request_id, tracks.namespace.clone());
             namespaces.insert(tracks.namespace.clone(), recv);
-            let wire_msg: Message = send.wire_message().into();
-            (send, wire_msg, request_id)
+            let wire_msg = send.wire_message();
+            (send, wire_msg, request_id, cancel)
         };
         // Lock released here.
 
-        // Phase 2: encode before allocating a QUIC stream, then open and send
-        // (async, no lock held). Any failure removes the entry from Phase 1.
-        let frame = match super::encode_request_frame(&wire_msg) {
-            Ok(frame) => frame,
-            Err(e) => {
-                if let Ok(mut ns) = self.publish_namespaces.lock() {
-                    ns.remove(&tracks.namespace);
-                }
-                return Err(e);
-            }
-        };
-        let (send_stream, recv_stream) = match self.webtransport.open_bi().await {
-            Ok(streams) => streams,
-            Err(e) => {
-                if let Ok(mut ns) = self.publish_namespaces.lock() {
-                    ns.remove(&tracks.namespace);
-                }
-                return Err(e.into());
-            }
-        };
-        let mut writer = super::Writer::new(send_stream);
-        if let Err(e) = writer.write(&frame).await {
-            if let Ok(mut ns) = self.publish_namespaces.lock() {
-                ns.remove(&tracks.namespace);
-            }
-            return Err(e);
-        }
-
-        // Hand a reader future for responses on this bidi stream to
-        // Session::run, which polls it cooperatively (structured concurrency).
-        // Draft-18: responses omit Request ID (the stream identity provides it).
-        // No task is spawned; the future is dropped/cancelled on session exit.
-        let mut this = self.clone();
-        let bidi_request_id = request_id;
-        let _ = self.bidi_task_tx.send(Box::pin(async move {
-            let mut reader = super::Reader::new(recv_stream);
-            loop {
-                match Session::decode_bidi_response(&mut reader, bidi_request_id).await {
-                    Ok(msg) => {
-                        if let Ok(sub_msg) = TryInto::<message::Subscriber>::try_into(msg) {
-                            // Propagate instead of logging: Session::run closes the
-                            // session for protocol violations and ignores the rest.
-                            this.recv_message(sub_msg)?;
-                        }
-                    }
-                    Err(err) if err.is_stream_ended() => return Ok(()),
-                    Err(err) => return Err(err),
-                }
-            }
-        }));
+        self.open_publish_namespace_stream(request_id, wire_msg, cancel)
+            .await?;
 
         let mut subscribe_tasks = FuturesUnordered::new();
         let mut status_tasks = FuturesUnordered::new();
@@ -305,6 +274,118 @@ impl Publisher {
                 else => return Ok(()),
             }
         }
+    }
+
+    /// Open a PUBLISH_NAMESPACE request stream and cancel both halves when the
+    /// application drops the publish.
+    async fn open_publish_namespace_stream(
+        &mut self,
+        request_id: u64,
+        msg: message::PublishNamespace,
+        mut cancel: tokio::sync::oneshot::Receiver<u32>,
+    ) -> Result<(), SessionError> {
+        let frame = super::encode_request_frame(&Message::PublishNamespace(msg))?;
+        let (send_stream, recv_stream) = self.webtransport.open_bi().await?;
+        let mut writer = super::Writer::new(send_stream);
+        writer.write(&frame).await?;
+
+        let mut this = self.clone();
+        let cleanup = PublishNamespaceCleanup {
+            publisher: this.clone(),
+            request_id,
+        };
+
+        if self
+            .bidi_task_tx
+            .send(Box::pin(async move {
+                let _cleanup = cleanup;
+                let mut reader = super::Reader::new(recv_stream);
+                let mut reading = true;
+                let mut responded = false;
+                let mut request_stopped = false;
+
+                loop {
+                    let event = tokio::select! {
+                        reset = &mut cancel => PublishNamespaceEvent::Cancel(reset),
+                        response = Session::decode_bidi_response(&mut reader, request_id), if reading => {
+                            PublishNamespaceEvent::Response(response)
+                        }
+                        stopped = writer.closed(), if !request_stopped => {
+                            PublishNamespaceEvent::Stopped(stopped)
+                        }
+                    };
+
+                    match event {
+                        PublishNamespaceEvent::Cancel(reset) => {
+                            if let Ok(code) = reset {
+                                writer.reset(code);
+                                reader.stop(code);
+                            }
+                            return Ok(());
+                        }
+                        PublishNamespaceEvent::Stopped(stopped) => {
+                            let _ = stopped?;
+                            if responded {
+                                reader.stop(super::CANCELLED_STREAM_CODE);
+                                return Ok(());
+                            }
+                            request_stopped = true;
+                        }
+                        PublishNamespaceEvent::Response(Ok(Message::RequestOk(msg))) => {
+                            if responded {
+                                return Err(SessionError::ProtocolViolation(
+                                    "multiple responses to PUBLISH_NAMESPACE".to_string(),
+                                ));
+                            }
+                            responded = true;
+                            this.recv_publish_namespace_ok(&msg)?;
+                            if request_stopped {
+                                reader.stop(super::CANCELLED_STREAM_CODE);
+                                return Ok(());
+                            }
+                        }
+                        PublishNamespaceEvent::Response(Ok(Message::RequestError(msg))) => {
+                            if responded {
+                                return Err(SessionError::ProtocolViolation(
+                                    "multiple responses to PUBLISH_NAMESPACE".to_string(),
+                                ));
+                            }
+                            this.recv_request_error(msg)?;
+                            let _ = writer.finish();
+                            return Ok(());
+                        }
+                        PublishNamespaceEvent::Response(Ok(msg)) => {
+                            return Err(SessionError::ProtocolViolation(format!(
+                                "unexpected {} on PUBLISH_NAMESPACE request stream",
+                                msg.name()
+                            )));
+                        }
+                        PublishNamespaceEvent::Response(Err(err)) if err.is_stream_error() => {
+                            writer.reset(super::CANCELLED_STREAM_CODE);
+                            return Ok(());
+                        }
+                        PublishNamespaceEvent::Response(Err(err)) if err.is_stream_ended() => {
+                            if !responded {
+                                return Ok(());
+                            }
+                            tracing::debug!(
+                                request_id,
+                                "PUBLISH_NAMESPACE response stream finished after acceptance"
+                            );
+                            reading = false;
+                        }
+                        PublishNamespaceEvent::Response(Err(err)) => {
+                            return Err(err);
+                        }
+                    }
+                }
+            }))
+            .is_err()
+        {
+            return Err(SessionError::Internal);
+        }
+
+        Ok(())
     }
 
     /// Offer a single track to the peer with PUBLISH (draft-18 §10.13).
@@ -815,8 +896,10 @@ impl Publisher {
             message::Subscriber::SubscribeNamespace(msg) => {
                 self.send_not_supported(msg.id, "subscribe_namespace");
             }
-            message::Subscriber::PublishNamespaceCancel(msg) => {
-                self.recv_publish_namespace_cancel(msg)?;
+            message::Subscriber::PublishNamespaceCancel(_) => {
+                return Err(SessionError::ProtocolViolation(
+                    "PUBLISH_NAMESPACE_CANCEL is not part of draft-18".to_string(),
+                ));
             }
             // Draft-18 removed the dedicated PUBLISH_OK type in favour of
             // REQUEST_OK, so we never send it. Accepting it on receive keeps
@@ -953,17 +1036,6 @@ impl Publisher {
             self.log_request_ok_parsed("publish", msg);
         }
         Ok(matched)
-    }
-
-    fn recv_publish_namespace_cancel(
-        &mut self,
-        msg: message::PublishNamespaceCancel,
-    ) -> Result<(), SessionError> {
-        // Draft-16 §9.24: PUBLISH_NAMESPACE_CANCEL now carries Request ID.
-        if let Some(recv) = self.drop_publish_namespace(msg.id) {
-            recv.recv_error(ServeError::Cancel)?;
-        }
-        Ok(())
     }
 
     fn recv_subscribe(&mut self, msg: message::Subscribe) -> Result<(), SessionError> {
@@ -1116,10 +1188,10 @@ impl Publisher {
         msg: T,
     ) -> message::Publisher {
         let msg = msg.into();
-        // Draft-16: PUBLISH_NAMESPACE_DONE carries Request ID, not namespace.
-        // Dropping the recv state signals that the namespace is done.
         if let message::Publisher::PublishNamespaceDone(m) = &msg {
             let _ = self.drop_publish_namespace(m.id);
+        } else if let message::Publisher::PublishDone(m) = &msg {
+            self.drop_subscribe(m.id);
         }
         msg
     }
@@ -1163,7 +1235,7 @@ impl Publisher {
         Ok(())
     }
 
-    fn drop_publish_namespace(&mut self, id: u64) -> Option<PublishNamespaceRecv> {
+    pub(super) fn drop_publish_namespace(&mut self, id: u64) -> Option<PublishNamespaceRecv> {
         if let Ok(mut ns) = self.publish_namespaces.lock() {
             let key = ns
                 .iter()
@@ -1174,6 +1246,19 @@ impl Publisher {
             }
         }
         None
+    }
+
+    fn abort_publish_namespace(&mut self, id: u64) {
+        let Some(recv) = self.drop_publish_namespace(id) else {
+            return;
+        };
+        if let Err(err) = recv.recv_error(ServeError::Cancel) {
+            tracing::debug!(
+                request_id = id,
+                error = %err,
+                "failed to fail aborted PUBLISH_NAMESPACE"
+            );
+        }
     }
 
     pub(super) async fn open_uni(&mut self) -> Result<web_transport::SendStream, SessionError> {
@@ -1190,17 +1275,18 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use crate::{
-        coding::{KeyValuePairs, TrackName, TrackNamespace},
+        coding::{KeyValuePairs, ReasonPhrase, TrackName, TrackNamespace},
         data,
         message::{self, Message},
-        serve::{self, FullTrackName},
+        serve::{self, FullTrackName, ServeError},
         session::{test_support::loopback_session_pair, Reader, RequestId, Session, Writer},
+        watch::Queue,
     };
     use bytes::Bytes;
 
     use super::{
         split_published_state, AbortPublishedOnDrop, NameRegistry, PublishedEntry, PublishedRecv,
-        Publisher,
+        PublishNamespace, Publisher,
     };
 
     fn full_track_name(namespace: &str, name: &str) -> FullTrackName {
@@ -1579,5 +1665,196 @@ mod tests {
             .contains_name(&full_track_name("test", "track")));
         drop(subgroup);
         drop(subgroups);
+    }
+
+    #[tokio::test]
+    async fn legacy_namespace_cancel_is_a_protocol_violation() {
+        let (client, _server) = loopback_session_pair().await;
+        let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut publisher = Publisher::new(
+            Queue::default(),
+            client,
+            None,
+            RequestId::new(0, 1),
+            bidi_task_tx,
+        );
+
+        let err = publisher
+            .recv_message(message::Subscriber::PublishNamespaceCancel(
+                message::PublishNamespaceCancel {
+                    id: 0,
+                    error_code: 1,
+                    reason_phrase: ReasonPhrase("cancelled".to_string()),
+                },
+            ))
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            crate::session::SessionError::ProtocolViolation(reason)
+                if reason == "PUBLISH_NAMESPACE_CANCEL is not part of draft-18"
+        ));
+    }
+
+    #[tokio::test]
+    async fn accepted_namespace_survives_response_fin_until_local_cancel() {
+        let (client, server) = loopback_session_pair().await;
+        let (bidi_task_tx, mut bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut publisher = Publisher::new(
+            Queue::default(),
+            client,
+            None,
+            RequestId::new(0, 1),
+            bidi_task_tx,
+        );
+        let namespace = TrackNamespace::from_utf8_path("test");
+        let (publish, recv, cancel) =
+            PublishNamespace::new(publisher.clone(), 0, namespace.clone());
+        publisher
+            .publish_namespaces
+            .lock()
+            .unwrap()
+            .insert(namespace, recv);
+        publisher
+            .open_publish_namespace_stream(0, publish.wire_message(), cancel)
+            .await
+            .unwrap();
+
+        let pump = tokio::spawn(bidi_task_rx.recv().await.unwrap());
+        let (peer_send, peer_recv) = server.accept_bi().await.unwrap();
+        let mut peer_writer = Writer::new(peer_send);
+        let mut peer_reader = Reader::new(peer_recv);
+        assert!(matches!(
+            peer_reader.decode::<Message>().await.unwrap(),
+            Message::PublishNamespace(_)
+        ));
+        Session::encode_bidi_response(
+            &mut peer_writer,
+            &Message::RequestOk(message::RequestOk {
+                id: 0,
+                params: Default::default(),
+            }),
+        )
+        .await
+        .unwrap();
+        peer_writer.finish().unwrap();
+
+        publish.ok().await.unwrap();
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(20), publish.closed())
+                .await
+                .is_err()
+        );
+
+        drop(publish);
+
+        pump.await.unwrap().unwrap();
+        let reset = peer_reader.done().await.unwrap_err();
+        assert!(reset.is_stream_error());
+    }
+
+    #[tokio::test]
+    async fn response_reset_closes_accepted_namespace() {
+        let (client, server) = loopback_session_pair().await;
+        let (bidi_task_tx, mut bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut publisher = Publisher::new(
+            Queue::default(),
+            client,
+            None,
+            RequestId::new(0, 1),
+            bidi_task_tx,
+        );
+        let namespace = TrackNamespace::from_utf8_path("test");
+        let (publish, recv, cancel) =
+            PublishNamespace::new(publisher.clone(), 0, namespace.clone());
+        publisher
+            .publish_namespaces
+            .lock()
+            .unwrap()
+            .insert(namespace, recv);
+        publisher
+            .open_publish_namespace_stream(0, publish.wire_message(), cancel)
+            .await
+            .unwrap();
+
+        let pump = tokio::spawn(bidi_task_rx.recv().await.unwrap());
+        let (peer_send, peer_recv) = server.accept_bi().await.unwrap();
+        let mut peer_writer = Writer::new(peer_send);
+        let mut peer_reader = Reader::new(peer_recv);
+        assert!(matches!(
+            peer_reader.decode::<Message>().await.unwrap(),
+            Message::PublishNamespace(_)
+        ));
+        Session::encode_bidi_response(
+            &mut peer_writer,
+            &Message::RequestOk(message::RequestOk {
+                id: 0,
+                params: Default::default(),
+            }),
+        )
+        .await
+        .unwrap();
+        publish.ok().await.unwrap();
+
+        peer_writer.reset(super::super::CANCELLED_STREAM_CODE);
+
+        assert!(matches!(publish.closed().await, Err(ServeError::Cancel)));
+        pump.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn request_stop_does_not_discard_namespace_rejection() {
+        let (client, server) = loopback_session_pair().await;
+        let (bidi_task_tx, mut bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut publisher = Publisher::new(
+            Queue::default(),
+            client,
+            None,
+            RequestId::new(0, 1),
+            bidi_task_tx,
+        );
+        let namespace = TrackNamespace::from_utf8_path("test");
+        let (publish, recv, cancel) =
+            PublishNamespace::new(publisher.clone(), 0, namespace.clone());
+        publisher
+            .publish_namespaces
+            .lock()
+            .unwrap()
+            .insert(namespace, recv);
+        publisher
+            .open_publish_namespace_stream(0, publish.wire_message(), cancel)
+            .await
+            .unwrap();
+
+        let pump = tokio::spawn(bidi_task_rx.recv().await.unwrap());
+        let (peer_send, peer_recv) = server.accept_bi().await.unwrap();
+        let mut peer_writer = Writer::new(peer_send);
+        let mut peer_reader = Reader::new(peer_recv);
+        assert!(matches!(
+            peer_reader.decode::<Message>().await.unwrap(),
+            Message::PublishNamespace(_)
+        ));
+
+        peer_reader.stop(super::super::CANCELLED_STREAM_CODE);
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        Session::encode_bidi_response(
+            &mut peer_writer,
+            &Message::RequestError(message::RequestError {
+                id: 0,
+                error_code: message::RequestErrorCode::Uninterested as u64,
+                retry_interval: 0,
+                reason: crate::coding::ReasonPhrase("not interested".to_string()),
+            }),
+        )
+        .await
+        .unwrap();
+        peer_writer.finish().unwrap();
+
+        assert!(matches!(
+            publish.ok().await,
+            Err(ServeError::Closed(code))
+                if code == message::RequestErrorCode::Uninterested as u64
+        ));
+        pump.await.unwrap().unwrap();
     }
 }

--- a/moq-transport/src/session/publisher.rs
+++ b/moq-transport/src/session/publisher.rs
@@ -144,13 +144,19 @@ struct PublishNamespaceCleanup {
 /// Resets both halves when opening a request is cancelled before its response
 /// pump takes ownership of the stream.
 struct OpeningPublishNamespaceStream {
+    session: web_transport::Session,
     writer: Option<Writer>,
     reader: Option<Reader>,
 }
 
 impl OpeningPublishNamespaceStream {
-    fn new(send: web_transport::SendStream, recv: web_transport::RecvStream) -> Self {
+    fn new(
+        session: web_transport::Session,
+        send: web_transport::SendStream,
+        recv: web_transport::RecvStream,
+    ) -> Self {
         Self {
+            session,
             writer: Some(Writer::new(send)),
             reader: Some(Reader::new(recv)),
         }
@@ -165,11 +171,18 @@ impl OpeningPublishNamespaceStream {
 
 impl Drop for OpeningPublishNamespaceStream {
     fn drop(&mut self) {
+        let cancelled = self.writer.is_some() || self.reader.is_some();
         if let Some(writer) = &mut self.writer {
             writer.reset(super::CANCELLED_STREAM_CODE);
         }
         if let Some(reader) = &mut self.reader {
             reader.stop(super::CANCELLED_STREAM_CODE);
+        }
+        if cancelled {
+            self.session.close(
+                super::CANCELLED_STREAM_CODE,
+                "PUBLISH_NAMESPACE stream opening cancelled",
+            );
         }
     }
 }
@@ -323,9 +336,10 @@ impl Publisher {
         };
         let frame = super::encode_request_frame(&Message::PublishNamespace(msg))?;
         let (send_stream, recv_stream) = self.webtransport.open_bi().await?;
-        let mut opening = OpeningPublishNamespaceStream::new(send_stream, recv_stream);
+        let mut opening =
+            OpeningPublishNamespaceStream::new(self.webtransport.clone(), send_stream, recv_stream);
 
-        let OpeningPublishNamespaceStream { writer, reader } = &mut opening;
+        let OpeningPublishNamespaceStream { writer, reader, .. } = &mut opening;
         let writer = writer.as_mut().ok_or(SessionError::Internal)?;
         let reader = reader.as_mut().ok_or(SessionError::Internal)?;
 
@@ -1727,8 +1741,8 @@ mod tests {
         assert!(matches!(
             data_reader.done().await,
             Err(crate::session::SessionError::WebTransport(
-                web_transport::Error::Read(web_transport::quinn::ReadError::Reset(0))
-            ))
+                web_transport::Error::Read(web_transport::quinn::ReadError::Reset(code))
+            )) if code == u32::from(data::DataStreamResetCode::Cancelled)
         ));
         let mut request_reader = request.await.unwrap();
         assert!(request_reader.done().await.unwrap());

--- a/moq-transport/src/session/subscribe.rs
+++ b/moq-transport/src/session/subscribe.rs
@@ -274,7 +274,13 @@ impl Subscribe {
                 }
                 // RESET_STREAM is not ordered against a new QUIC stream. Retire
                 // this session before releasing a cache generation so a retry
-                // cannot overtake teardown on the same connection.
+                // cannot overtake teardown on the same connection. This also
+                // interrupts every other subscription multiplexed on the peer;
+                // they reconnect through normal upstream routing.
+                tracing::warn!(
+                    request_id = self.info.id,
+                    "retiring upstream session after stuck SUBSCRIBE teardown; all multiplexed subscriptions will reconnect"
+                );
                 self.subscriber.close_session(
                     super::CANCELLED_STREAM_CODE,
                     "SUBSCRIBE request stream teardown timed out",

--- a/moq-transport/src/session/subscribe.rs
+++ b/moq-transport/src/session/subscribe.rs
@@ -18,7 +18,7 @@ use super::Subscriber;
 use super::{DoneOutcome, StreamDrain};
 
 const SUBSCRIBE_TEARDOWN_TIMEOUT: Duration = Duration::from_secs(5);
-type SubscribeRequestSink = tokio::sync::mpsc::UnboundedSender<message::Message>;
+type SubscribeRequestSink = tokio::sync::mpsc::Sender<message::Message>;
 
 #[derive(Debug, Clone, Copy)]
 pub struct DeliveryFilter {
@@ -272,6 +272,13 @@ impl Subscribe {
                 if let Some(cancel) = self.request_cancel.take() {
                     let _ = cancel.send(super::CANCELLED_STREAM_CODE);
                 }
+                // RESET_STREAM is not ordered against a new QUIC stream. Retire
+                // this session before releasing a cache generation so a retry
+                // cannot overtake teardown on the same connection.
+                self.subscriber.close_session(
+                    super::CANCELLED_STREAM_CODE,
+                    "SUBSCRIBE request stream teardown timed out",
+                );
                 if tokio::time::timeout(timeout, &mut request_done)
                     .await
                     .is_err()
@@ -290,7 +297,7 @@ impl Subscribe {
         let stream = self.stream.take();
         if self.state.lock().closed.is_ok() {
             if let Some(stream) = &stream {
-                let _ = stream.send(message::Unsubscribe { id: self.info.id }.into());
+                let _ = stream.try_send(message::Unsubscribe { id: self.info.id }.into());
             }
         }
     }

--- a/moq-transport/src/session/subscribe.rs
+++ b/moq-transport/src/session/subscribe.rs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2023-2024 Luke Curley and contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::ops;
+use std::{ops, time::Duration};
 
 use crate::{
     coding::{KeyValuePairs, Location, TrackName, TrackNamespace},
@@ -16,6 +16,9 @@ use crate::watch::State;
 use super::SessionError;
 use super::Subscriber;
 use super::{DoneOutcome, StreamDrain};
+
+const SUBSCRIBE_TEARDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+type SubscribeRequestSink = tokio::sync::mpsc::UnboundedSender<message::Message>;
 
 #[derive(Debug, Clone, Copy)]
 pub struct DeliveryFilter {
@@ -70,7 +73,7 @@ pub struct SubscribeInfo {
     pub end_group_id: Option<u64>,
 
     /// None means the SUBSCRIPTION_FILTER parameter was omitted and the
-    /// subscription is unfiltered per draft-16 §9.2.2.5.
+    /// subscription is unfiltered.
     pub filter: Option<SubscriptionFilter>,
 
     /// Optional parameters
@@ -152,6 +155,7 @@ fn next_group_location(largest_location: Option<Location>) -> Location {
 
 struct SubscribeState {
     ok: bool,
+    peer_rejected: bool,
     track_alias: Option<u64>,
     closed: Result<(), ServeError>,
 }
@@ -160,6 +164,7 @@ impl Default for SubscribeState {
     fn default() -> Self {
         Self {
             ok: Default::default(),
+            peer_rejected: false,
             track_alias: None,
             closed: Ok(()),
         }
@@ -171,6 +176,9 @@ impl Default for SubscribeState {
 pub struct Subscribe {
     state: State<SubscribeState>,
     subscriber: Subscriber,
+    stream: Option<SubscribeRequestSink>,
+    request_done: Option<tokio::sync::oneshot::Receiver<()>>,
+    request_cancel: Option<tokio::sync::oneshot::Sender<u32>>,
 
     pub info: SubscribeInfo,
 }
@@ -216,6 +224,9 @@ impl Subscribe {
         let send = Subscribe {
             state: send,
             subscriber,
+            stream: None,
+            request_done: None,
+            request_cancel: None,
             info,
         };
 
@@ -227,6 +238,61 @@ impl Subscribe {
         };
 
         (send, recv)
+    }
+
+    pub(super) fn set_stream(
+        &mut self,
+        stream: SubscribeRequestSink,
+        request_done: tokio::sync::oneshot::Receiver<()>,
+        request_cancel: tokio::sync::oneshot::Sender<u32>,
+    ) {
+        self.stream = Some(stream);
+        self.request_done = Some(request_done);
+        self.request_cancel = Some(request_cancel);
+    }
+
+    /// End the subscription and wait until the peer terminates its request
+    /// stream. This provides an ordering barrier before opening another
+    /// SUBSCRIBE for the same track.
+    pub async fn unsubscribe(mut self) {
+        self.unsubscribe_before(SUBSCRIBE_TEARDOWN_TIMEOUT).await;
+    }
+
+    pub(super) async fn unsubscribe_before(&mut self, timeout: Duration) {
+        self.send_unsubscribe();
+        if let Some(mut request_done) = self.request_done.take() {
+            if tokio::time::timeout(timeout, &mut request_done)
+                .await
+                .is_err()
+            {
+                tracing::warn!(
+                    request_id = self.info.id,
+                    "peer did not finish SUBSCRIBE request stream after UNSUBSCRIBE; resetting it"
+                );
+                if let Some(cancel) = self.request_cancel.take() {
+                    let _ = cancel.send(super::CANCELLED_STREAM_CODE);
+                }
+                if tokio::time::timeout(timeout, &mut request_done)
+                    .await
+                    .is_err()
+                {
+                    tracing::warn!(
+                        request_id = self.info.id,
+                        "SUBSCRIBE request stream did not stop after reset"
+                    );
+                }
+            }
+        }
+        self.subscriber.remove_subscribe(self.info.id);
+    }
+
+    fn send_unsubscribe(&mut self) {
+        let stream = self.stream.take();
+        if self.state.lock().closed.is_ok() {
+            if let Some(stream) = &stream {
+                let _ = stream.send(message::Unsubscribe { id: self.info.id }.into());
+            }
+        }
     }
 
     pub async fn closed(&self) -> Result<(), ServeError> {
@@ -262,12 +328,16 @@ impl Subscribe {
             .await;
         }
     }
+
+    /// Whether the request ended with REQUEST_ERROR from the peer.
+    pub fn peer_rejected(&self) -> bool {
+        self.state.lock().peer_rejected
+    }
 }
 
 impl Drop for Subscribe {
     fn drop(&mut self) {
-        self.subscriber
-            .send_message(message::Unsubscribe { id: self.info.id });
+        self.send_unsubscribe();
         self.subscriber.remove_subscribe(self.info.id);
     }
 }
@@ -379,7 +449,7 @@ impl SubscribeRecv {
 
     /// Apply the terminal state, closing the writer so the reader sees the end
     /// of the track.
-    fn finish(&mut self, err: ServeError) {
+    pub(super) fn finish(&mut self, err: ServeError) {
         self.drain.mark_finished();
         if let Some(writer) = self.writer.take() {
             if let Err(err) = writer.close(err.clone()) {
@@ -408,6 +478,13 @@ impl SubscribeRecv {
         state.closed = Err(err);
 
         Ok(())
+    }
+
+    pub fn reject(self, err: ServeError) -> Result<(), ServeError> {
+        if let Some(mut state) = self.state.lock().into_mut() {
+            state.peer_rejected = true;
+        }
+        self.error(err)
     }
 
     pub fn subgroup(

--- a/moq-transport/src/session/subscribed.rs
+++ b/moq-transport/src/session/subscribed.rs
@@ -10,16 +10,14 @@ use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 
 use crate::coding::{Encode, EncodeError, KeyValuePairs, Location, ReasonPhrase};
+use crate::data::DataStreamResetCode;
 use crate::message::RequestErrorCode;
 use crate::mlog;
 use crate::serve::{ServeError, TrackReaderMode};
 use crate::watch::State;
 use crate::{data, message, serve};
 
-use super::{
-    DeliveryError, DeliveryFilter, Publisher, ResetOnDropWriter, SessionError, SubscribeInfo,
-    Writer,
-};
+use super::{DeliveryError, DeliveryFilter, Publisher, SessionError, SubscribeInfo, Writer};
 
 // This file defines Publisher handling of inbound Subscriptions
 
@@ -236,6 +234,161 @@ impl ObjectForwarder {
     }
 }
 
+/// A subgroup data stream that is reset unless it is explicitly finished.
+///
+/// Draft-18 Section 11.4.3 allows FIN only after all subgroup objects required
+/// by the subscription have been delivered. Dropping a QUIC send stream
+/// implicitly finishes it, so this wrapper resets unfinished streams by default.
+struct SubgroupStream {
+    writer: Writer,
+    terminated: bool,
+}
+
+impl SubgroupStream {
+    fn new(writer: Writer) -> Self {
+        Self {
+            writer,
+            terminated: false,
+        }
+    }
+
+    fn finish(&mut self) -> Result<(), SessionError> {
+        if self.terminated {
+            return Ok(());
+        }
+        self.terminated = true;
+        self.writer.finish()
+    }
+
+    fn reset(&mut self, code: DataStreamResetCode) {
+        if self.terminated {
+            return;
+        }
+        self.terminated = true;
+        self.writer.reset(code.into());
+    }
+}
+
+impl Drop for SubgroupStream {
+    fn drop(&mut self) {
+        // Async cancellation can drop the forwarding future without reaching an
+        // error path. The subgroup is incomplete in that case.
+        self.reset(DataStreamResetCode::Cancelled);
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SubgroupTermination {
+    Fin,
+    Reset(DataStreamResetCode),
+}
+
+enum SubgroupSink {
+    Stream(SubgroupStream),
+    #[cfg(test)]
+    Buffer {
+        buffer: bytes::BytesMut,
+        termination: Option<SubgroupTermination>,
+    },
+}
+
+/// Tracks whether an encoded object still has payload bytes outstanding.
+struct SubgroupOutput {
+    sink: SubgroupSink,
+    owed: usize,
+}
+
+impl SubgroupOutput {
+    fn stream(writer: Writer) -> Self {
+        Self {
+            sink: SubgroupSink::Stream(SubgroupStream::new(writer)),
+            owed: 0,
+        }
+    }
+
+    #[cfg(test)]
+    fn buffer() -> Self {
+        Self {
+            sink: SubgroupSink::Buffer {
+                buffer: bytes::BytesMut::new(),
+                termination: None,
+            },
+            owed: 0,
+        }
+    }
+
+    async fn encode<T: Encode>(&mut self, msg: &T) -> Result<(), SessionError> {
+        match &mut self.sink {
+            SubgroupSink::Stream(stream) => stream.writer.encode(msg).await,
+            #[cfg(test)]
+            SubgroupSink::Buffer { buffer, .. } => {
+                msg.encode(buffer)?;
+                Ok(())
+            }
+        }
+    }
+
+    async fn write(&mut self, buf: &[u8]) -> Result<(), SessionError> {
+        match &mut self.sink {
+            SubgroupSink::Stream(stream) => stream.writer.write(buf).await?,
+            #[cfg(test)]
+            SubgroupSink::Buffer { buffer, .. } => buffer.extend_from_slice(buf),
+        }
+
+        self.owed = self.owed.saturating_sub(buf.len());
+        Ok(())
+    }
+
+    fn begin_object(&mut self, len: usize) {
+        self.owed = len;
+    }
+
+    fn at_object_boundary(&self) -> bool {
+        self.owed == 0
+    }
+
+    fn finish(&mut self) -> Result<(), SessionError> {
+        if !self.at_object_boundary() {
+            tracing::warn!(
+                owed = self.owed,
+                "refusing to FIN a subgroup stream mid-object; resetting instead"
+            );
+            self.reset(DataStreamResetCode::InternalError);
+            return Err(ServeError::Size.into());
+        }
+
+        match &mut self.sink {
+            SubgroupSink::Stream(stream) => stream.finish(),
+            #[cfg(test)]
+            SubgroupSink::Buffer { termination, .. } => {
+                termination.get_or_insert(SubgroupTermination::Fin);
+                Ok(())
+            }
+        }
+    }
+
+    fn reset(&mut self, code: DataStreamResetCode) {
+        match &mut self.sink {
+            SubgroupSink::Stream(stream) => stream.reset(code),
+            #[cfg(test)]
+            SubgroupSink::Buffer { termination, .. } => {
+                termination.get_or_insert(SubgroupTermination::Reset(code));
+            }
+        }
+    }
+
+    #[cfg(test)]
+    fn into_parts(self) -> (bytes::BytesMut, Option<SubgroupTermination>) {
+        match self.sink {
+            SubgroupSink::Buffer {
+                buffer,
+                termination,
+            } => (buffer, termination),
+            SubgroupSink::Stream(_) => unreachable!("test output should use a buffer"),
+        }
+    }
+}
 impl Subscribed {
     pub(super) fn new(
         publisher: Publisher,
@@ -298,7 +451,7 @@ impl Subscribed {
             !self.ok && matches!(result, Err(SessionError::Serve(ServeError::Timeout)));
 
         if deadline_expired {
-            // A simultaneous UNSUBSCRIBE may have closed the shared state first,
+            // Simultaneous request cancellation may have closed the shared state first,
             // but the relay still needs the deadline result for its response and metric.
             if let Err(err) = &result {
                 let _ = self.forwarder.close(err.clone().into(), 0);
@@ -436,7 +589,7 @@ impl Drop for Subscribed {
                 reason: ReasonPhrase(err.to_string()),
             });
         } else {
-            // Draft-16 §9.8: subscription rejection uses REQUEST_ERROR, not the
+            // Draft-18 Section 10.6 uses REQUEST_ERROR for subscription rejection, not the
             // legacy SUBSCRIBE_ERROR.
             self.forwarder.publisher.send_request_error(
                 "subscribe",
@@ -467,7 +620,7 @@ impl Subscribed {
             ServeError::NotFound | ServeError::NotFoundWithId(_, _) => {
                 RequestErrorCode::DoesNotExist as u64
             }
-            // draft-18 §10.2.6 distinguishes the two: DOES_NOT_EXIST when the relay
+            // Draft-18 Section 10.2.6 distinguishes the two: DOES_NOT_EXIST when the relay
             // did not wait, TIMEOUT when it held the subscription and no publisher
             // arrived before the subscriber's RENDEZVOUS_TIMEOUT elapsed.
             ServeError::Timeout => RequestErrorCode::Timeout as u64,
@@ -587,21 +740,11 @@ impl ObjectForwarder {
             subgroup_reader.priority
         );
 
-        let mut writer: Option<ResetOnDropWriter> = None;
-        let mut object_count = 0;
-        let mut previous_object_id = None;
-        let mut filtered_prefix = false;
         let metadata = subgroup_reader.metadata();
-        loop {
-            let mut subgroup_object_reader = match subgroup_reader.next().await {
-                Ok(Some(object)) => object,
-                Ok(None) => break,
-                Err(err) => {
-                    if let Some(writer) = writer.as_mut() {
-                        writer.reset(0);
-                    }
-                    return Err(err.into());
-                }
+        let mut filtered_prefix = false;
+        let first_object = loop {
+            let Some(subgroup_object_reader) = subgroup_reader.next().await? else {
+                return Ok(());
             };
             if !delivery_filter.allows(subgroup_reader.group_id, subgroup_object_reader.object_id) {
                 tracing::trace!(
@@ -613,59 +756,132 @@ impl ObjectForwarder {
                 continue;
             }
 
-            if writer.is_none() {
-                let header = data::SubgroupHeader {
-                    header_type: data::StreamHeaderType::subgroup(
-                        data::SubgroupIdMode::Explicit,
-                        metadata.has_properties,
-                        metadata.end_of_group,
-                        false,
-                        metadata.first_object && !filtered_prefix,
-                    ),
-                    track_alias,
-                    group_id: subgroup_reader.group_id,
-                    subgroup_id: Some(subgroup_reader.subgroup_id),
-                    publisher_priority: subgroup_reader.priority,
-                };
-                let mut send_stream = publisher.open_uni().await?;
-                tracing::trace!("[PUBLISHER] serve_subgroup: opened unidirectional stream");
+            break subgroup_object_reader;
+        };
 
-                // TODO figure out u32 vs u64 priority
-                send_stream.set_priority(subgroup_reader.priority as i32);
-                let mut new_writer = ResetOnDropWriter::new(Writer::new(send_stream));
-                stream_count.opened();
+        let header = data::SubgroupHeader {
+            header_type: data::StreamHeaderType::subgroup(
+                data::SubgroupIdMode::Explicit,
+                metadata.has_properties,
+                metadata.end_of_group,
+                false,
+                metadata.first_object && !filtered_prefix,
+            ),
+            track_alias,
+            group_id: subgroup_reader.group_id,
+            subgroup_id: Some(subgroup_reader.subgroup_id),
+            publisher_priority: subgroup_reader.priority,
+        };
+        let mut send_stream = publisher.open_uni().await?;
+        tracing::trace!("[PUBLISHER] serve_subgroup: opened unidirectional stream");
 
-                {
-                    let locked = state.lock();
-                    let closed = locked.closed.clone();
-                    closed?;
-                }
+        // TODO figure out u32 vs u64 priority
+        send_stream.set_priority(subgroup_reader.priority as i32);
 
-                tracing::trace!(
-                    "[PUBLISHER] serve_subgroup: sending header - track_alias={}, group_id={}, subgroup_id={:?}, priority={}, header_type={:?}",
-                    header.track_alias,
-                    header.group_id,
-                    header.subgroup_id,
-                    header.publisher_priority,
-                    header.header_type
-                );
+        let mut output = SubgroupOutput::stream(Writer::new(send_stream));
+        stream_count.opened();
+        let state_status = state.lock().closed.clone();
+        let res = if let Err(err) = state_status {
+            Err(err.into())
+        } else {
+            Self::serve_subgroup_objects(
+                header,
+                subgroup_reader,
+                first_object,
+                &mut output,
+                state,
+                mlog,
+                delivery_filter,
+            )
+            .await
+        };
 
-                new_writer.encode(&header).await?;
+        // Draft-18 Section 11.4.3 requires a reset when forwarding stops before
+        // all subgroup objects required by the subscription have been delivered.
+        match res {
+            Ok(()) => output.finish(),
+            Err(err) => {
+                output.reset(Self::reset_code_for(&err));
+                Err(err)
+            }
+        }
+    }
 
-                // Log subgroup header created/sent
-                if let Some(ref mlog) = mlog {
-                    if let Ok(mut mlog_guard) = mlog.lock() {
-                        let time = mlog_guard.elapsed_ms();
-                        let stream_id = 0; // TODO: Placeholder, need actual QUIC stream ID
-                        let event = mlog::subgroup_header_created(time, stream_id, &header);
-                        let _ = mlog_guard.add_event(event);
-                    }
-                }
+    /// Map a forwarding failure onto a draft-18 stream reset code.
+    fn reset_code_for(err: &SessionError) -> DataStreamResetCode {
+        match err {
+            SessionError::Serve(ServeError::Done | ServeError::Cancel) => {
+                DataStreamResetCode::Cancelled
+            }
+            SessionError::Serve(ServeError::Size) => DataStreamResetCode::MalformedTrack,
+            SessionError::Serve(ServeError::Closed(_)) => DataStreamResetCode::SessionClosed,
+            _ => DataStreamResetCode::InternalError,
+        }
+    }
 
-                writer = Some(new_writer);
+    async fn next_allowed_object(
+        subgroup_reader: &mut serve::SubgroupReader,
+        delivery_filter: DeliveryFilter,
+    ) -> Result<Option<serve::SubgroupObjectReader>, ServeError> {
+        while let Some(subgroup_object_reader) = subgroup_reader.next().await? {
+            if delivery_filter.allows(subgroup_reader.group_id, subgroup_object_reader.object_id) {
+                return Ok(Some(subgroup_object_reader));
             }
 
-            let writer = writer.as_mut().ok_or(SessionError::Internal)?;
+            tracing::trace!(
+                "[PUBLISHER] serve_subgroup: filtered object group_id={}, object_id={}",
+                subgroup_reader.group_id,
+                subgroup_object_reader.object_id
+            );
+        }
+
+        Ok(None)
+    }
+
+    async fn serve_subgroup_objects(
+        header: data::SubgroupHeader,
+        mut subgroup_reader: serve::SubgroupReader,
+        first_object: serve::SubgroupObjectReader,
+        output: &mut SubgroupOutput,
+        state: State<ObjectForwarderState>,
+        mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
+        delivery_filter: DeliveryFilter,
+    ) -> Result<(), SessionError> {
+        tracing::trace!(
+            "[PUBLISHER] serve_subgroup: sending header - track_alias={}, group_id={}, subgroup_id={:?}, priority={}, header_type={:?}",
+            header.track_alias,
+            header.group_id,
+            header.subgroup_id,
+            header.publisher_priority,
+            header.header_type
+        );
+
+        output.encode(&header).await?;
+
+        // Log subgroup header created/sent
+        if let Some(ref mlog) = mlog {
+            if let Ok(mut mlog_guard) = mlog.lock() {
+                let time = mlog_guard.elapsed_ms();
+                let stream_id = 0; // TODO: Placeholder, need actual QUIC stream ID
+                let event = mlog::subgroup_header_created(time, stream_id, &header);
+                let _ = mlog_guard.add_event(event);
+            }
+        }
+
+        let mut object_count = 0;
+        let mut previous_object_id = None;
+        let mut next_object = Some(first_object);
+        loop {
+            let mut subgroup_object_reader = match next_object.take() {
+                Some(reader) => reader,
+                None => {
+                    match Self::next_allowed_object(&mut subgroup_reader, delivery_filter).await? {
+                        Some(reader) => reader,
+                        None => break,
+                    }
+                }
+            };
+
             let object_id_delta = data::encode_object_id_delta(
                 &mut previous_object_id,
                 subgroup_object_reader.object_id,
@@ -687,14 +903,24 @@ impl ObjectForwarder {
                 subgroup_object_reader.extension_headers
             );
 
-            if metadata.has_properties {
+            // Check cancellation before the object header commits us to its
+            // payload length.
+            state
+                .lock_mut()
+                .ok_or(ServeError::Done)?
+                .update_largest_location(
+                    subgroup_reader.group_id,
+                    subgroup_object_reader.object_id,
+                )?;
+
+            if header.header_type.has_properties() {
                 let subgroup_object = data::SubgroupObjectExt {
                     object_id_delta,
                     extension_headers: subgroup_object_reader.extension_headers.clone(),
                     payload_length: subgroup_object_reader.size,
                     status,
                 };
-                writer.encode(&subgroup_object).await?;
+                output.encode(&subgroup_object).await?;
 
                 if let Some(ref mlog) = mlog {
                     if let Ok(mut mlog_guard) = mlog.lock() {
@@ -713,7 +939,6 @@ impl ObjectForwarder {
                 }
             } else {
                 if !subgroup_object_reader.extension_headers.is_empty() {
-                    writer.reset(0);
                     return Err(ServeError::internal_ctx(
                         "subgroup Object has properties without the PROPERTIES header bit",
                     )
@@ -724,7 +949,7 @@ impl ObjectForwarder {
                     payload_length: subgroup_object_reader.size,
                     status,
                 };
-                writer.encode(&subgroup_object).await?;
+                output.encode(&subgroup_object).await?;
 
                 if let Some(ref mlog) = mlog {
                     if let Ok(mut mlog_guard) = mlog.lock() {
@@ -742,14 +967,7 @@ impl ObjectForwarder {
                     }
                 }
             }
-
-            state
-                .lock_mut()
-                .ok_or(ServeError::Done)?
-                .update_largest_location(
-                    subgroup_reader.group_id,
-                    subgroup_object_reader.object_id,
-                )?;
+            output.begin_object(subgroup_object_reader.size);
 
             let mut chunks_sent = 0;
             let mut bytes_sent = 0;
@@ -757,10 +975,7 @@ impl ObjectForwarder {
                 let chunk = match subgroup_object_reader.read().await {
                     Ok(Some(chunk)) => chunk,
                     Ok(None) => break,
-                    Err(err) => {
-                        writer.reset(0);
-                        return Err(err.into());
-                    }
+                    Err(err) => return Err(err.into()),
                 };
                 tracing::trace!(
                     "[PUBLISHER] serve_subgroup: sending payload chunk #{} for object #{} ({} bytes)",
@@ -769,7 +984,7 @@ impl ObjectForwarder {
                     chunk.len()
                 );
                 bytes_sent += chunk.len();
-                writer.write(&chunk).await?;
+                output.write(&chunk).await?;
                 chunks_sent += 1;
             }
 
@@ -779,6 +994,18 @@ impl ObjectForwarder {
                 chunks_sent,
                 bytes_sent
             );
+
+            if !output.at_object_boundary() {
+                tracing::warn!(
+                    group_id = subgroup_reader.group_id,
+                    object_id = subgroup_object_reader.object_id,
+                    promised = subgroup_object_reader.size,
+                    sent = bytes_sent,
+                    "upstream object ended short of its declared payload length"
+                );
+                return Err(ServeError::Size.into());
+            }
+
             object_count += 1;
         }
 
@@ -789,11 +1016,54 @@ impl ObjectForwarder {
             object_count
         );
 
-        if let Some(writer) = writer.as_mut() {
-            writer.finish()?;
-        }
-
         Ok(())
+    }
+
+    #[cfg(test)]
+    async fn serve_subgroup_to_parts(
+        header: data::SubgroupHeader,
+        mut subgroup_reader: serve::SubgroupReader,
+        state: State<ObjectForwarderState>,
+        delivery_filter: DeliveryFilter,
+    ) -> (
+        bytes::BytesMut,
+        Result<(), SessionError>,
+        Option<SubgroupTermination>,
+    ) {
+        let first_object =
+            match Self::next_allowed_object(&mut subgroup_reader, delivery_filter).await {
+                Ok(Some(first_object)) => first_object,
+                Ok(None) => return (bytes::BytesMut::new(), Ok(()), None),
+                Err(err) => return (bytes::BytesMut::new(), Err(err.into()), None),
+            };
+
+        let mut output = SubgroupOutput::buffer();
+        let state_status = state.lock().closed.clone();
+        let res = if state_status.is_ok() {
+            Self::serve_subgroup_objects(
+                header,
+                subgroup_reader,
+                first_object,
+                &mut output,
+                state,
+                None,
+                delivery_filter,
+            )
+            .await
+        } else {
+            Err(ServeError::Done.into())
+        };
+
+        let res = match res {
+            Ok(()) => output.finish(),
+            Err(err) => {
+                output.reset(Self::reset_code_for(&err));
+                Err(err)
+            }
+        };
+
+        let (buffer, termination) = output.into_parts();
+        (buffer, res, termination)
     }
 
     async fn serve_datagrams(
@@ -1611,8 +1881,9 @@ mod tests {
             assert!(matches!(
                 reader.done().await,
                 Err(SessionError::WebTransport(web_transport::Error::Read(
-                    web_transport::quinn::ReadError::Reset(0)
+                    web_transport::quinn::ReadError::Reset(code)
                 )))
+                    if code == u32::from(DataStreamResetCode::Cancelled)
             ));
         };
         let cancel = async move {
@@ -1775,8 +2046,9 @@ mod tests {
             assert!(matches!(
                 reader.done().await,
                 Err(SessionError::WebTransport(web_transport::Error::Read(
-                    web_transport::quinn::ReadError::Reset(0)
+                    web_transport::quinn::ReadError::Reset(code)
                 )))
+                    if code == u32::from(DataStreamResetCode::Cancelled)
             ));
         };
         let cancel = async move {
@@ -2076,6 +2348,303 @@ mod tests {
         let locked = recv.state.lock();
         assert!(locked.unsubscribed);
         assert!(matches!(locked.closed, Err(ServeError::Cancel)));
+    }
+
+    #[cfg(test)]
+    async fn subgroup_with_one_object() -> (serve::SubgroupReader, data::SubgroupHeader) {
+        use bytes::Bytes;
+
+        use crate::coding::TrackNamespace;
+
+        let (track_writer, track_reader) =
+            serve::Track::new(TrackNamespace::from_utf8_path("test"), "video").produce();
+        let mut subgroups_writer = track_writer.subgroups().unwrap();
+        let mut subgroup_writer = subgroups_writer
+            .create(serve::Subgroup {
+                group_id: 1,
+                subgroup_id: 0,
+                priority: 0,
+            })
+            .unwrap();
+        subgroup_writer.write(Bytes::from_static(b"hello")).unwrap();
+        drop(subgroup_writer);
+        drop(subgroups_writer);
+
+        let mut subgroups = match track_reader.mode().await.unwrap() {
+            TrackReaderMode::Subgroups(subgroups) => subgroups,
+            _ => panic!("expected subgroups mode"),
+        };
+        let subgroup = subgroups.next().await.unwrap().expect("subgroup available");
+        let header = data::SubgroupHeader {
+            header_type: data::StreamHeaderType::SubgroupIdExt,
+            track_alias: 1,
+            group_id: subgroup.group_id,
+            subgroup_id: Some(subgroup.subgroup_id),
+            publisher_priority: subgroup.priority,
+        };
+
+        (subgroup, header)
+    }
+
+    #[cfg(test)]
+    fn all_objects() -> DeliveryFilter {
+        DeliveryFilter {
+            forward: true,
+            start_location: None,
+            end_group_id: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn complete_subgroup_writes_object_and_fin() {
+        use bytes::Buf;
+
+        use crate::coding::Decode;
+
+        let (subgroup, header) = subgroup_with_one_object().await;
+        let state = State::<ObjectForwarderState>::default();
+
+        let (buffer, res, termination) = ObjectForwarder::serve_subgroup_to_parts(
+            header.clone(),
+            subgroup,
+            state.clone(),
+            all_objects(),
+        )
+        .await;
+
+        res.expect("serving a complete subgroup should succeed");
+        assert_eq!(termination, Some(SubgroupTermination::Fin));
+        assert_eq!(state.lock().stream_count, 1);
+
+        let mut buffer = buffer.freeze();
+        let header_type = data::StreamHeaderType::decode(&mut buffer).unwrap();
+        assert_eq!(
+            data::SubgroupHeader::decode(header_type, &mut buffer).unwrap(),
+            header
+        );
+
+        let object = data::SubgroupObjectExt::decode(&mut buffer).unwrap();
+        assert_eq!(object.payload_length, 5);
+        assert_eq!(&buffer.copy_to_bytes(object.payload_length)[..], b"hello");
+        assert!(!buffer.has_remaining());
+    }
+
+    #[tokio::test]
+    async fn filtered_subgroup_does_not_open_stream() {
+        let (subgroup, header) = subgroup_with_one_object().await;
+        let state = State::<ObjectForwarderState>::default();
+
+        let (buffer, res, termination) = ObjectForwarder::serve_subgroup_to_parts(
+            header,
+            subgroup,
+            state.clone(),
+            DeliveryFilter {
+                forward: false,
+                start_location: None,
+                end_group_id: None,
+            },
+        )
+        .await;
+
+        res.expect("filtering a subgroup should succeed");
+        assert!(buffer.is_empty());
+        assert_eq!(termination, None);
+        assert_eq!(state.lock().stream_count, 0);
+    }
+
+    #[tokio::test]
+    async fn request_cancellation_resets_at_an_object_boundary() {
+        use bytes::{Buf, Bytes};
+
+        use crate::coding::{Decode, TrackNamespace};
+
+        let (track_writer, track_reader) =
+            serve::Track::new(TrackNamespace::from_utf8_path("test"), "video").produce();
+        let mut subgroups_writer = track_writer.subgroups().unwrap();
+        let mut subgroup_writer = subgroups_writer
+            .create(serve::Subgroup {
+                group_id: 1,
+                subgroup_id: 0,
+                priority: 0,
+            })
+            .unwrap();
+
+        subgroup_writer.write(Bytes::from_static(b"hello")).unwrap();
+
+        let mut subgroups = match track_reader.mode().await.unwrap() {
+            TrackReaderMode::Subgroups(subgroups) => subgroups,
+            _ => panic!("expected subgroups mode"),
+        };
+        let subgroup = subgroups.next().await.unwrap().expect("subgroup available");
+        let header = data::SubgroupHeader {
+            header_type: data::StreamHeaderType::SubgroupIdExt,
+            track_alias: 1,
+            group_id: subgroup.group_id,
+            subgroup_id: Some(subgroup.subgroup_id),
+            publisher_priority: subgroup.priority,
+        };
+
+        let (cancel_handle, state) = State::new(ObjectForwarderState {
+            largest_location: Some(Location::new(0, 0)),
+            ..Default::default()
+        })
+        .split();
+        let observer = state.clone();
+
+        let fut = ObjectForwarder::serve_subgroup_to_parts(
+            header.clone(),
+            subgroup,
+            state,
+            all_objects(),
+        );
+        tokio::pin!(fut);
+
+        loop {
+            let changed = {
+                let current = observer.lock();
+                if current.largest_location == Some(Location::new(1, 0)) {
+                    break;
+                }
+                current
+                    .modified()
+                    .expect("forwarder state should remain open")
+            };
+
+            tokio::select! {
+                _ = changed => {},
+                _ = &mut fut => panic!("forwarder should await the next object"),
+            }
+        }
+
+        drop(cancel_handle);
+        subgroup_writer.write(Bytes::from_static(b"world")).unwrap();
+
+        let (buffer, res, termination) = fut.await;
+
+        assert!(matches!(res, Err(SessionError::Serve(ServeError::Done))));
+        assert_eq!(
+            termination,
+            Some(SubgroupTermination::Reset(DataStreamResetCode::Cancelled)),
+            "an incomplete subgroup must be reset"
+        );
+
+        let mut buffer = buffer.freeze();
+        let header_type = data::StreamHeaderType::decode(&mut buffer).unwrap();
+        assert_eq!(
+            data::SubgroupHeader::decode(header_type, &mut buffer).unwrap(),
+            header
+        );
+
+        let object = data::SubgroupObjectExt::decode(&mut buffer).unwrap();
+        assert_eq!(object.payload_length, 5);
+        assert_eq!(&buffer.copy_to_bytes(object.payload_length)[..], b"hello");
+        assert!(
+            !buffer.has_remaining(),
+            "no partial object should follow the last complete one"
+        );
+    }
+
+    #[tokio::test]
+    async fn short_object_resets_subgroup_as_malformed() {
+        use bytes::Bytes;
+
+        use crate::coding::{Decode, TrackNamespace};
+
+        let (track_writer, track_reader) =
+            serve::Track::new(TrackNamespace::from_utf8_path("test"), "video").produce();
+        let mut subgroups_writer = track_writer.subgroups().unwrap();
+        let mut subgroup_writer = subgroups_writer
+            .create(serve::Subgroup {
+                group_id: 1,
+                subgroup_id: 0,
+                priority: 0,
+            })
+            .unwrap();
+        let mut object_writer = subgroup_writer.create(5, None).unwrap();
+        object_writer.write(Bytes::from_static(b"hel")).unwrap();
+        drop(object_writer);
+        drop(subgroup_writer);
+        drop(subgroups_writer);
+
+        let mut subgroups = match track_reader.mode().await.unwrap() {
+            TrackReaderMode::Subgroups(subgroups) => subgroups,
+            _ => panic!("expected subgroups mode"),
+        };
+        let subgroup = subgroups.next().await.unwrap().expect("subgroup available");
+        let header = data::SubgroupHeader {
+            header_type: data::StreamHeaderType::SubgroupIdExt,
+            track_alias: 1,
+            group_id: subgroup.group_id,
+            subgroup_id: Some(subgroup.subgroup_id),
+            publisher_priority: subgroup.priority,
+        };
+
+        let (buffer, res, termination) = ObjectForwarder::serve_subgroup_to_parts(
+            header,
+            subgroup,
+            State::default(),
+            all_objects(),
+        )
+        .await;
+
+        assert!(matches!(res, Err(SessionError::Serve(ServeError::Size))));
+        assert_eq!(
+            termination,
+            Some(SubgroupTermination::Reset(
+                DataStreamResetCode::MalformedTrack
+            ))
+        );
+
+        let mut buffer = buffer.freeze();
+        let header_type = data::StreamHeaderType::decode(&mut buffer).unwrap();
+        data::SubgroupHeader::decode(header_type, &mut buffer).unwrap();
+        let object = data::SubgroupObjectExt::decode(&mut buffer).unwrap();
+        assert_eq!(object.payload_length, 5);
+        assert_eq!(&buffer[..], b"hel");
+    }
+
+    #[tokio::test]
+    async fn finish_mid_object_resets_instead_of_truncating() {
+        let mut output = SubgroupOutput::buffer();
+
+        output.begin_object(10);
+        output.write(b"abc").await.unwrap();
+        assert!(!output.at_object_boundary());
+
+        let err = output.finish().expect_err("FIN mid-object must be refused");
+        assert!(matches!(err, SessionError::Serve(ServeError::Size)));
+
+        let (_buffer, termination) = output.into_parts();
+        assert_eq!(
+            termination,
+            Some(SubgroupTermination::Reset(
+                DataStreamResetCode::InternalError
+            ))
+        );
+    }
+
+    #[test]
+    fn forwarding_failures_use_matching_reset_codes() {
+        assert_eq!(
+            ObjectForwarder::reset_code_for(&ServeError::Done.into()),
+            DataStreamResetCode::Cancelled
+        );
+        assert_eq!(
+            ObjectForwarder::reset_code_for(&ServeError::Cancel.into()),
+            DataStreamResetCode::Cancelled
+        );
+        assert_eq!(
+            ObjectForwarder::reset_code_for(&ServeError::Size.into()),
+            DataStreamResetCode::MalformedTrack
+        );
+        assert_eq!(
+            ObjectForwarder::reset_code_for(&ServeError::Closed(0x2).into()),
+            DataStreamResetCode::SessionClosed
+        );
+        assert_eq!(
+            ObjectForwarder::reset_code_for(&ServeError::internal_ctx("boom").into()),
+            DataStreamResetCode::InternalError
+        );
     }
 
     #[test]

--- a/moq-transport/src/session/subscribed.rs
+++ b/moq-transport/src/session/subscribed.rs
@@ -460,6 +460,8 @@ impl Subscribed {
         }
 
         if let Err(err) = &result {
+            // The forwarding error remains authoritative if a concurrent
+            // request cancellation already closed the shared state.
             let _ = self.forwarder.close(err.clone().into(), 0);
         }
         let terminal = self.finish().await;
@@ -477,6 +479,8 @@ impl Subscribed {
     ) -> Result<(), SessionError> {
         let res = self.serve_inner(track, deadline, largest_location).await;
         if let Err(err) = &res {
+            // The forwarding error remains authoritative if a concurrent
+            // request cancellation already closed the shared state.
             let _ = self.forwarder.close(err.clone().into(), 0);
         }
         let terminal = self.finish().await;
@@ -697,7 +701,12 @@ impl ObjectForwarder {
                     Ok(None) => done = Some(Ok(())),
                     Err(err) => done = Some(Err(err)),
                 },
-                res = self.closed(), if done.is_none() || !tasks.is_empty() => return res.map_err(Into::into),
+                res = self.closed(), if done.is_none() || !tasks.is_empty() => {
+                    // Returning drops active subgroup futures. Their
+                    // SubgroupStream guards reset any stream that has not
+                    // reached FIN, including one blocked on a partial object.
+                    return res.map_err(SessionError::from);
+                },
                 res = tasks.next(), if !tasks.is_empty() => {
                     // Remaining subgroups still get their chance to send; the
                     // first local failure is reported once they settle.
@@ -707,8 +716,8 @@ impl ObjectForwarder {
                         }
                     }
                 },
-                // Reached only once both the subgroup source and `closed()` are
-                // disabled, which requires `done` to be set.
+                // Reached once the subgroup source has ended and every active
+                // subgroup task has settled.
                 else => {
                     // The track's own outcome is the authoritative one; a
                     // per-subgroup fault is only reported when the track itself
@@ -814,7 +823,21 @@ impl ObjectForwarder {
                 DataStreamResetCode::Cancelled
             }
             SessionError::Serve(ServeError::Size) => DataStreamResetCode::MalformedTrack,
-            SessionError::Serve(ServeError::Closed(_)) => DataStreamResetCode::SessionClosed,
+            SessionError::Serve(ServeError::Closed(code)) => match *code {
+                code if code == message::PublishDoneCode::GoingAway as u64 => {
+                    DataStreamResetCode::GoingAway
+                }
+                code if code == message::PublishDoneCode::TooFarBehind as u64 => {
+                    DataStreamResetCode::TooFarBehind
+                }
+                code if code == message::PublishDoneCode::ExcessiveLoad as u64 => {
+                    DataStreamResetCode::ExcessiveLoad
+                }
+                code if code == message::PublishDoneCode::MalformedTrack as u64 => {
+                    DataStreamResetCode::MalformedTrack
+                }
+                _ => DataStreamResetCode::InternalError,
+            },
             _ => DataStreamResetCode::InternalError,
         }
     }
@@ -1024,6 +1047,7 @@ impl ObjectForwarder {
         header: data::SubgroupHeader,
         mut subgroup_reader: serve::SubgroupReader,
         state: State<ObjectForwarderState>,
+        stream_count: StreamCount,
         delivery_filter: DeliveryFilter,
     ) -> (
         bytes::BytesMut,
@@ -1038,6 +1062,7 @@ impl ObjectForwarder {
             };
 
         let mut output = SubgroupOutput::buffer();
+        stream_count.opened();
         let state_status = state.lock().closed.clone();
         let res = if state_status.is_ok() {
             Self::serve_subgroup_objects(
@@ -2068,6 +2093,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn dropping_subgroup_stream_resets_the_peer() {
+        let (client, server) = crate::session::test_support::loopback_session_pair().await;
+        let (accepted_tx, accepted_rx) = tokio::sync::oneshot::channel();
+        let received = tokio::spawn(async move {
+            let mut stream = server.accept_uni().await.expect("accept subgroup stream");
+            let _ = accepted_tx.send(());
+            loop {
+                match stream.read(1024).await {
+                    Ok(Some(_)) => {}
+                    Ok(None) => panic!("unfinished subgroup ended with FIN"),
+                    Err(error) => return error,
+                }
+            }
+        });
+
+        let send = client.open_uni().await.expect("open subgroup stream");
+        let mut stream = SubgroupStream::new(Writer::new(send));
+        stream.writer.write(b"partial").await.unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(2), accepted_rx)
+            .await
+            .expect("peer did not accept subgroup stream")
+            .expect("subgroup accept task ended");
+        drop(stream);
+
+        let error = tokio::time::timeout(std::time::Duration::from_secs(2), received)
+            .await
+            .expect("peer did not receive subgroup reset")
+            .expect("join subgroup receiver");
+        assert!(matches!(
+            error,
+            web_transport::Error::Read(web_transport::quinn::ReadError::Reset(code))
+                if code == DataStreamResetCode::Cancelled as u32
+        ));
+    }
+
+    #[tokio::test]
     async fn deadline_prevents_subscribe_ok() {
         let (subscribed, _recv, _outgoing, _responses) = test_subscribed().await;
         let (_writer, reader) = serve::Track::new(
@@ -2403,18 +2464,20 @@ mod tests {
 
         let (subgroup, header) = subgroup_with_one_object().await;
         let state = State::<ObjectForwarderState>::default();
+        let stream_count = StreamCount::default();
 
         let (buffer, res, termination) = ObjectForwarder::serve_subgroup_to_parts(
             header.clone(),
             subgroup,
             state.clone(),
+            stream_count.clone(),
             all_objects(),
         )
         .await;
 
         res.expect("serving a complete subgroup should succeed");
         assert_eq!(termination, Some(SubgroupTermination::Fin));
-        assert_eq!(state.lock().stream_count, 1);
+        assert_eq!(stream_count.get(), 1);
 
         let mut buffer = buffer.freeze();
         let header_type = data::StreamHeaderType::decode(&mut buffer).unwrap();
@@ -2433,11 +2496,13 @@ mod tests {
     async fn filtered_subgroup_does_not_open_stream() {
         let (subgroup, header) = subgroup_with_one_object().await;
         let state = State::<ObjectForwarderState>::default();
+        let stream_count = StreamCount::default();
 
         let (buffer, res, termination) = ObjectForwarder::serve_subgroup_to_parts(
             header,
             subgroup,
             state.clone(),
+            stream_count.clone(),
             DeliveryFilter {
                 forward: false,
                 start_location: None,
@@ -2449,7 +2514,7 @@ mod tests {
         res.expect("filtering a subgroup should succeed");
         assert!(buffer.is_empty());
         assert_eq!(termination, None);
-        assert_eq!(state.lock().stream_count, 0);
+        assert_eq!(stream_count.get(), 0);
     }
 
     #[tokio::test]
@@ -2495,6 +2560,7 @@ mod tests {
             header.clone(),
             subgroup,
             state,
+            StreamCount::default(),
             all_objects(),
         );
         tokio::pin!(fut);
@@ -2545,6 +2611,60 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn request_cancellation_stops_a_partial_object_after_source_closes() {
+        use bytes::Bytes;
+
+        use crate::coding::TrackNamespace;
+
+        let (mut subscribed, mut recv, _outgoing, _responses) = test_subscribed().await;
+        let (track_writer, track_reader) =
+            serve::Track::new(TrackNamespace::from_utf8_path("test"), "track").produce();
+        let mut subgroups_writer = track_writer.subgroups().unwrap();
+        let mut subgroup_writer = subgroups_writer
+            .create(serve::Subgroup {
+                group_id: 1,
+                subgroup_id: 0,
+                priority: 0,
+            })
+            .unwrap();
+        let mut object_writer = subgroup_writer.create(5, None).unwrap();
+        object_writer.write(Bytes::from_static(b"hel")).unwrap();
+
+        let stream_count = subscribed.forwarder.stream_count_handle();
+        let serve = subscribed.forwarder.serve(track_reader, all_objects());
+        tokio::pin!(serve);
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                if stream_count.get() == 1 {
+                    break;
+                }
+                tokio::select! {
+                    result = &mut serve => panic!("serve ended before opening a stream: {result:?}"),
+                    _ = tokio::task::yield_now() => {}
+                }
+            }
+        })
+        .await
+        .expect("subgroup stream did not open");
+
+        // The source can end while its latest subgroup still has an incomplete
+        // object. Cancellation must continue to interrupt that subgroup.
+        drop(subgroups_writer);
+        recv.recv_unsubscribe().unwrap();
+        let result = tokio::time::timeout(std::time::Duration::from_secs(2), &mut serve)
+            .await
+            .expect("UNSUBSCRIBE did not stop the partial object");
+        assert!(matches!(
+            result,
+            Err(SessionError::Serve(ServeError::Cancel))
+        ));
+
+        drop(object_writer);
+        drop(subgroup_writer);
+    }
+
+    #[tokio::test]
     async fn short_object_resets_subgroup_as_malformed() {
         use bytes::Bytes;
 
@@ -2583,6 +2703,7 @@ mod tests {
             header,
             subgroup,
             State::default(),
+            StreamCount::default(),
             all_objects(),
         )
         .await;
@@ -2638,8 +2759,16 @@ mod tests {
             DataStreamResetCode::MalformedTrack
         );
         assert_eq!(
-            ObjectForwarder::reset_code_for(&ServeError::Closed(0x2).into()),
-            DataStreamResetCode::SessionClosed
+            ObjectForwarder::reset_code_for(
+                &ServeError::Closed(message::PublishDoneCode::TooFarBehind as u64).into()
+            ),
+            DataStreamResetCode::TooFarBehind
+        );
+        assert_eq!(
+            ObjectForwarder::reset_code_for(
+                &ServeError::Closed(message::PublishDoneCode::TrackEnded as u64).into()
+            ),
+            DataStreamResetCode::InternalError
         );
         assert_eq!(
             ObjectForwarder::reset_code_for(&ServeError::internal_ctx("boom").into()),

--- a/moq-transport/src/session/subscriber.rs
+++ b/moq-transport/src/session/subscriber.rs
@@ -84,6 +84,7 @@ struct SubscribeStreamCleanup {
 /// Resets both halves when opening a request is cancelled before its response
 /// pump takes ownership of the stream.
 struct OpeningRequestStream {
+    session: web_transport::Session,
     writer: Option<Writer>,
     reader: Option<Reader>,
 }
@@ -131,8 +132,13 @@ impl SubscribeStreamCleanup {
 }
 
 impl OpeningRequestStream {
-    fn new(send: web_transport::SendStream, recv: web_transport::RecvStream) -> Self {
+    fn new(
+        session: web_transport::Session,
+        send: web_transport::SendStream,
+        recv: web_transport::RecvStream,
+    ) -> Self {
         Self {
+            session,
             writer: Some(Writer::new(send)),
             reader: Some(Reader::new(recv)),
         }
@@ -147,11 +153,18 @@ impl OpeningRequestStream {
 
 impl Drop for OpeningRequestStream {
     fn drop(&mut self) {
+        let cancelled = self.writer.is_some() || self.reader.is_some();
         if let Some(writer) = &mut self.writer {
             writer.reset(super::CANCELLED_STREAM_CODE);
         }
         if let Some(reader) = &mut self.reader {
             reader.stop(super::CANCELLED_STREAM_CODE);
+        }
+        if cancelled {
+            self.session.close(
+                super::CANCELLED_STREAM_CODE,
+                "request stream opening cancelled",
+            );
         }
     }
 }
@@ -416,6 +429,10 @@ impl Subscriber {
         Ok((session, subscriber))
     }
 
+    pub(super) fn close_session(&self, code: u32, reason: &str) {
+        self.webtransport.close(code, reason);
+    }
+
     /// Wait for the next inbound PUBLISH_NAMESPACE from the peer, if any.
     pub async fn published_namespace(&mut self) -> Option<PublishedNamespace> {
         self.published_namespace_queue.pop().await
@@ -501,7 +518,8 @@ impl Subscriber {
         let frame = super::encode_request_frame(msg)?;
 
         let (send_stream, recv_stream) = self.webtransport.open_bi().await?;
-        let mut opening = OpeningRequestStream::new(send_stream, recv_stream);
+        let mut opening =
+            OpeningRequestStream::new(self.webtransport.clone(), send_stream, recv_stream);
         let writer = opening.writer.as_mut().ok_or(SessionError::Internal)?;
         writer.write(&frame).await?;
         opening.into_parts()
@@ -655,7 +673,7 @@ impl Subscriber {
             }
         }
 
-        let (stream_tx, mut stream_rx) = tokio::sync::mpsc::unbounded_channel::<Message>();
+        let (stream_tx, mut stream_rx) = tokio::sync::mpsc::channel::<Message>(2);
         let (done_tx, done_rx) = tokio::sync::oneshot::channel();
         let (cancel_tx, mut cancel_rx) = tokio::sync::oneshot::channel();
 
@@ -2738,7 +2756,7 @@ mod tests {
     async fn dropping_an_opening_request_resets_a_partial_frame() {
         let (client, server) = loopback_session_pair().await;
         let (send, recv) = client.open_bi().await.unwrap();
-        let mut opening = OpeningRequestStream::new(send, recv);
+        let mut opening = OpeningRequestStream::new(client.clone(), send, recv);
         opening
             .writer
             .as_mut()

--- a/moq-transport/src/session/subscriber.rs
+++ b/moq-transport/src/session/subscriber.rs
@@ -149,7 +149,7 @@ impl TrackAliasRegistry {
 #[derive(Clone)]
 pub struct Subscriber {
     /// Active inbound PUBLISH_NAMESPACE messages, keyed by namespace.
-    published_namespaces: Arc<Mutex<HashMap<TrackNamespace, PublishedNamespaceRecv>>>,
+    published_namespaces: Arc<Mutex<HashMap<TrackNamespace, u64>>>,
 
     /// Queue of inbound PUBLISH_NAMESPACE events waiting to be consumed by the application.
     published_namespace_queue: Queue<PublishedNamespace>,
@@ -316,11 +316,6 @@ impl Subscriber {
 
     fn log_request_error_created(&self, request_kind: &str, msg: &message::RequestError) {
         self.add_mlog_event(|time| mlog::events::request_error_created(time, 0, request_kind, msg));
-    }
-
-    pub(super) fn send_request_ok(&mut self, request_kind: &str, msg: message::RequestOk) {
-        self.add_mlog_event(|time| mlog::events::request_ok_created(time, 0, request_kind, &msg));
-        self.send_message(msg);
     }
 
     pub(super) fn send_request_error(&mut self, request_kind: &str, msg: message::RequestError) {
@@ -641,13 +636,6 @@ impl Subscriber {
     pub(super) fn send_message<M: Into<message::Subscriber>>(&mut self, msg: M) {
         let msg = msg.into();
 
-        // Remove our entry on terminal state.
-        // Draft-16: PUBLISH_NAMESPACE_CANCEL carries Request ID, so look up
-        // the namespace by iterating the map.
-        if let message::Subscriber::PublishNamespaceCancel(msg) = &msg {
-            let _ = self.drop_publish_namespace(msg.id);
-        }
-
         // TODO report dropped messages?
         let _ = self.outgoing.push(msg.into());
     }
@@ -655,9 +643,15 @@ impl Subscriber {
     /// Receive a message from the publisher via the control stream.
     pub(super) fn recv_message(&mut self, msg: message::Publisher) -> Result<(), SessionError> {
         match &msg {
-            message::Publisher::PublishNamespace(msg) => self.recv_publish_namespace(msg)?,
-            message::Publisher::PublishNamespaceDone(msg) => {
-                self.recv_publish_namespace_done(msg)?;
+            message::Publisher::PublishNamespace(_) => {
+                return Err(SessionError::ProtocolViolation(
+                    "PUBLISH_NAMESPACE must start a request stream".to_string(),
+                ));
+            }
+            message::Publisher::PublishNamespaceDone(_) => {
+                return Err(SessionError::ProtocolViolation(
+                    "PUBLISH_NAMESPACE_DONE is not part of draft-18".to_string(),
+                ));
             }
             message::Publisher::Publish(msg) => self.recv_publish(msg)?,
             message::Publisher::PublishDone(msg) => self.recv_publish_done(msg)?,
@@ -679,42 +673,28 @@ impl Subscriber {
     }
 
     /// Handle reception of an inbound PUBLISH_NAMESPACE from the publisher.
-    fn recv_publish_namespace(
+    pub(super) fn recv_publish_namespace(
         &mut self,
         msg: &message::PublishNamespace,
-    ) -> Result<(), SessionError> {
+    ) -> Result<PublishedNamespaceRecv, SessionError> {
         let mut published_namespaces = self
             .published_namespaces
             .lock()
             .map_err(|_| SessionError::Internal)?;
 
         // Duplicate PUBLISH_NAMESPACE for the same namespace within a session is invalid.
-        let entry = match published_namespaces.entry(msg.track_namespace.clone()) {
+        match published_namespaces.entry(msg.track_namespace.clone()) {
             hash_map::Entry::Occupied(_) => return Err(SessionError::Duplicate),
-            hash_map::Entry::Vacant(entry) => entry,
+            hash_map::Entry::Vacant(entry) => entry.insert(msg.id),
         };
+        drop(published_namespaces);
 
         let (published_ns, recv) =
             PublishedNamespace::new(self.clone(), msg.id, msg.track_namespace.clone());
         if let Err(published_ns) = self.published_namespace_queue.push(published_ns) {
             published_ns.close(ServeError::Cancel)?;
-            return Ok(());
         }
-        entry.insert(recv);
-
-        Ok(())
-    }
-
-    /// Handle reception of PUBLISH_NAMESPACE_DONE from the publisher.
-    fn recv_publish_namespace_done(
-        &mut self,
-        msg: &message::PublishNamespaceDone,
-    ) -> Result<(), SessionError> {
-        // Draft-16 §9.22: PUBLISH_NAMESPACE_DONE carries Request ID, not namespace.
-        if let Some(recv) = self.drop_publish_namespace(msg.id) {
-            recv.recv_done()?;
-        }
-        Ok(())
+        Ok(recv)
     }
 
     /// Handle the reception of a SubscribeOk message from the publisher.
@@ -1420,17 +1400,16 @@ impl Subscriber {
         }
     }
 
-    fn drop_publish_namespace(&mut self, id: u64) -> Option<PublishedNamespaceRecv> {
+    pub(super) fn remove_published_namespace(&self, id: u64) {
         if let Ok(mut ns) = self.published_namespaces.lock() {
             let key = ns
                 .iter()
-                .find(|(_k, v)| v.request_id == id)
+                .find(|(_k, request_id)| **request_id == id)
                 .map(|(k, _)| k.clone());
             if let Some(key) = key {
-                return ns.remove(&key);
+                ns.remove(&key);
             }
         }
-        None
     }
 
     /// Resolve a Track Alias to its owning subscription, waiting up to the

--- a/moq-transport/src/session/subscriber.rs
+++ b/moq-transport/src/session/subscriber.rs
@@ -64,6 +64,133 @@ struct SubscribeNamespaceCleanup {
     active: bool,
 }
 
+/// Releases an outbound SUBSCRIBE's track-name reservation until its receive
+/// state is registered and takes ownership of cleanup.
+struct SubscribeCleanup {
+    subscriber: Subscriber,
+    request_id: u64,
+    active: bool,
+}
+
+/// Cleans session state whether a SUBSCRIBE stream pump returns or is dropped
+/// by structured-concurrency shutdown.
+struct SubscribeStreamCleanup {
+    subscriber: Subscriber,
+    request_id: u64,
+    done: Option<tokio::sync::oneshot::Sender<()>>,
+    active: bool,
+}
+
+/// Resets both halves when opening a request is cancelled before its response
+/// pump takes ownership of the stream.
+struct OpeningRequestStream {
+    writer: Option<Writer>,
+    reader: Option<Reader>,
+}
+
+enum SubscribeStreamEvent {
+    Cancel(Result<u32, tokio::sync::oneshot::error::RecvError>),
+    Outgoing(Option<Message>),
+    Response(Result<Message, SessionError>),
+}
+
+struct DrainFinalizer {
+    subscriber: Subscriber,
+    request_id: u64,
+    expire: fn(&Subscriber, u64),
+}
+
+impl Drop for DrainFinalizer {
+    fn drop(&mut self) {
+        (self.expire)(&self.subscriber, self.request_id);
+    }
+}
+
+impl SubscribeStreamCleanup {
+    fn new(
+        subscriber: Subscriber,
+        request_id: u64,
+        done: tokio::sync::oneshot::Sender<()>,
+    ) -> Self {
+        Self {
+            subscriber,
+            request_id,
+            done: Some(done),
+            active: true,
+        }
+    }
+
+    fn complete(mut self, result: &Result<(), SessionError>) {
+        if result.as_ref().is_err_and(|err| err.is_session_fatal()) {
+            return;
+        }
+
+        self.active = false;
+        self.subscriber.abort_subscribe(self.request_id);
+    }
+}
+
+impl OpeningRequestStream {
+    fn new(send: web_transport::SendStream, recv: web_transport::RecvStream) -> Self {
+        Self {
+            writer: Some(Writer::new(send)),
+            reader: Some(Reader::new(recv)),
+        }
+    }
+
+    fn into_parts(mut self) -> Result<(Writer, Reader), SessionError> {
+        let writer = self.writer.take().ok_or(SessionError::Internal)?;
+        let reader = self.reader.take().ok_or(SessionError::Internal)?;
+        Ok((writer, reader))
+    }
+}
+
+impl Drop for OpeningRequestStream {
+    fn drop(&mut self) {
+        if let Some(writer) = &mut self.writer {
+            writer.reset(super::CANCELLED_STREAM_CODE);
+        }
+        if let Some(reader) = &mut self.reader {
+            reader.stop(super::CANCELLED_STREAM_CODE);
+        }
+    }
+}
+
+impl Drop for SubscribeStreamCleanup {
+    fn drop(&mut self) {
+        if self.active {
+            if let Some(mut subscribe) = self.subscriber.remove_subscribe(self.request_id) {
+                subscribe.finish(ServeError::Cancel);
+            }
+        }
+        if let Some(done) = self.done.take() {
+            let _ = done.send(());
+        }
+    }
+}
+
+impl SubscribeCleanup {
+    fn new(subscriber: Subscriber, request_id: u64) -> Self {
+        Self {
+            subscriber,
+            request_id,
+            active: true,
+        }
+    }
+
+    fn disarm(mut self) {
+        self.active = false;
+    }
+}
+
+impl Drop for SubscribeCleanup {
+    fn drop(&mut self) {
+        if self.active {
+            self.subscriber.drop_subscribe_name(self.request_id);
+        }
+    }
+}
+
 impl SubscribeNamespaceCleanup {
     fn new(subscriber: Subscriber, request_id: u64) -> Self {
         Self {
@@ -374,9 +501,10 @@ impl Subscriber {
         let frame = super::encode_request_frame(msg)?;
 
         let (send_stream, recv_stream) = self.webtransport.open_bi().await?;
-        let mut writer = Writer::new(send_stream);
+        let mut opening = OpeningRequestStream::new(send_stream, recv_stream);
+        let writer = opening.writer.as_mut().ok_or(SessionError::Internal)?;
         writer.write(&frame).await?;
-        Ok((writer, Reader::new(recv_stream)))
+        opening.into_parts()
     }
 
     /// Send a TRACK_STATUS request for a track.
@@ -436,6 +564,28 @@ impl Subscriber {
         track: serve::TrackWriter,
         params: KeyValuePairs,
     ) -> Result<Subscribe, ServeError> {
+        let send = self.subscribe_start_with_params(track, params).await?;
+        send.ok().await?;
+        Ok(send)
+    }
+
+    /// Start a SUBSCRIBE request without waiting for acknowledgement.
+    ///
+    /// This is useful when cancellation must race the peer's response and then
+    /// wait for request-stream teardown through [`Subscribe::unsubscribe`].
+    pub async fn subscribe_start(
+        &mut self,
+        track: serve::TrackWriter,
+    ) -> Result<Subscribe, ServeError> {
+        self.subscribe_start_with_params(track, KeyValuePairs::default())
+            .await
+    }
+
+    async fn subscribe_start_with_params(
+        &mut self,
+        track: serve::TrackWriter,
+        params: KeyValuePairs,
+    ) -> Result<Subscribe, ServeError> {
         let request_id = self
             .get_next_request_id()
             .map_err(|e| ServeError::internal_ctx(format!("request ID limit: {}", e)))?;
@@ -443,7 +593,7 @@ impl Subscriber {
         // §5.1: at most one subscriber-role subscription per track. Outbound
         // SUBSCRIBE and inbound PUBLISH both make this endpoint the subscriber,
         // so they share one registry. Reserved before the stream is opened;
-        // `remove_subscribe` releases it.
+        // `SubscribeCleanup` releases it until the receive state is registered.
         let full_name = FullTrackName {
             namespace: track.namespace.clone(),
             name: track.name.clone(),
@@ -458,19 +608,17 @@ impl Subscriber {
             }
             names.insert(full_name, request_id);
         }
+        let cleanup = SubscribeCleanup::new(self.clone(), request_id);
 
-        let (send, recv, subscribe) = match Subscribe::new(self.clone(), request_id, track, params)
-        {
-            Ok(subscribe) => subscribe,
-            Err(err) => {
-                if let Ok(mut names) = self.subscriber_names.lock() {
-                    names.remove_by_request_id(request_id);
+        let (mut send, recv, subscribe) =
+            match Subscribe::new(self.clone(), request_id, track, params) {
+                Ok(subscribe) => subscribe,
+                Err(err) => {
+                    return Err(ServeError::internal_ctx(format!(
+                        "invalid subscribe parameters: {err}"
+                    )));
                 }
-                return Err(ServeError::internal_ctx(format!(
-                    "invalid subscribe parameters: {err}"
-                )));
-            }
-        };
+            };
 
         // Open a bidi stream and send the SUBSCRIBE message BEFORE
         // registering in the subscribes map — avoids a leaked entry if
@@ -482,9 +630,6 @@ impl Subscriber {
             match self.open_request_stream(&subscribe_msg).await {
                 Ok(streams) => streams,
                 Err(e) => {
-                    if let Ok(mut names) = self.subscriber_names.lock() {
-                        names.remove_by_request_id(request_id);
-                    }
                     return Err(ServeError::internal_ctx(format!(
                         "failed to open request stream: {}",
                         e
@@ -498,58 +643,137 @@ impl Subscriber {
         match self.subscribes.lock() {
             Ok(mut subscribes) => {
                 subscribes.insert(request_id, recv);
+                cleanup.disarm();
             }
             Err(_) => {
                 tracing::warn!(
                     request_id,
                     "subscribes lock poisoned after bidi stream open; finishing stream"
                 );
-                if let Ok(mut names) = self.subscriber_names.lock() {
-                    names.remove_by_request_id(request_id);
-                }
                 let _ = request_writer.finish();
                 return Err(ServeError::internal_ctx("subscribe lock poisoned"));
             }
         }
 
+        let (stream_tx, mut stream_rx) = tokio::sync::mpsc::unbounded_channel::<Message>();
+        let (done_tx, done_rx) = tokio::sync::oneshot::channel();
+        let (cancel_tx, mut cancel_rx) = tokio::sync::oneshot::channel();
+
         // Hand a reader future for bidi stream responses (draft-18) to
         // Session::run, which polls it cooperatively (structured concurrency).
         // No task is spawned; the future is dropped/cancelled on session exit.
         let mut subscriber_clone = self.clone();
-        let _ = self.bidi_task_tx.send(Box::pin(async move {
-            let result = loop {
-                match Session::decode_bidi_response(&mut response_reader, request_id).await {
-                    Ok(msg) => {
-                        if let Ok(pub_msg) = TryInto::<message::Publisher>::try_into(msg) {
-                            // Returning rather than breaking lets Session::run decide:
-                            // a protocol violation closes the session, anything else is
-                            // logged there and only this stream ends.
-                            if let Err(err) = subscriber_clone.recv_message(pub_msg) {
-                                break Err(err);
+        let stream_cleanup =
+            SubscribeStreamCleanup::new(subscriber_clone.clone(), request_id, done_tx);
+        if self
+            .bidi_task_tx
+            .send(Box::pin(async move {
+                let mut writing = true;
+                let mut cancellation_open = true;
+                let result = 'response: loop {
+                    let event = tokio::select! {
+                        biased;
+                        cancel = &mut cancel_rx, if cancellation_open => {
+                            SubscribeStreamEvent::Cancel(cancel)
+                        }
+                        outgoing = stream_rx.recv(), if writing => {
+                            SubscribeStreamEvent::Outgoing(outgoing)
+                        }
+                        response = Session::decode_bidi_response(&mut response_reader, request_id) => {
+                            SubscribeStreamEvent::Response(response)
+                        }
+                    };
+
+                    match event {
+                        SubscribeStreamEvent::Cancel(cancel) => {
+                            match cancel {
+                                Ok(code) => {
+                                    request_writer.reset(code);
+                                    response_reader.stop(code);
+                                    writing = false;
+                                    break Ok(());
+                                }
+                                Err(_) => cancellation_open = false,
+                            }
+                        }
+                        SubscribeStreamEvent::Outgoing(outgoing) => {
+                            let Some(outgoing) = outgoing else {
+                                let _ = request_writer.finish();
+                                writing = false;
+                                continue;
+                            };
+                            let mut write = Box::pin(Session::encode_bidi_response(
+                                &mut request_writer,
+                                &outgoing,
+                            ));
+                            let write_result: Result<Result<(), SessionError>, u32> = loop {
+                                tokio::select! {
+                                    biased;
+                                    cancel = &mut cancel_rx, if cancellation_open => {
+                                        match cancel {
+                                            Ok(code) => break Err(code),
+                                            Err(_) => cancellation_open = false,
+                                        }
+                                    }
+                                    result = &mut write => break Ok(result),
+                                }
+                            };
+                            drop(write);
+
+                            match write_result {
+                                Err(code) => {
+                                    request_writer.reset(code);
+                                    response_reader.stop(code);
+                                    writing = false;
+                                    break 'response Ok(());
+                                }
+                                Ok(Err(err)) => {
+                                    tracing::debug!(request_id, error = %err, "failed writing on SUBSCRIBE request stream");
+                                    request_writer.reset(super::CANCELLED_STREAM_CODE);
+                                    response_reader.stop(super::CANCELLED_STREAM_CODE);
+                                    writing = false;
+                                    break 'response Ok(());
+                                }
+                                Ok(Ok(())) => {}
+                            }
+                            let _ = request_writer.finish();
+                            writing = false;
+                        }
+                        SubscribeStreamEvent::Response(response) => {
+                            match response {
+                                Ok(msg) => {
+                                    let terminal = matches!(msg, Message::PublishDone(_) | Message::RequestError(_));
+                                    if let Ok(pub_msg) = TryInto::<message::Publisher>::try_into(msg) {
+                                        if let Err(err) = subscriber_clone.recv_message(pub_msg) {
+                                            break Err(err);
+                                        }
+                                    }
+                                    if terminal {
+                                        break Ok(());
+                                    }
+                                }
+                                Err(err) if err.is_stream_ended() => break Ok(()),
+                                Err(err) => break Err(err),
                             }
                         }
                     }
-                    Err(err) if err.is_stream_ended() => break Ok(()),
-                    Err(err) => break Err(err),
+                };
+
+                if writing {
+                    let _ = request_writer.finish();
                 }
-            };
-
-            // Runs on every exit path. Harmless once the subscription is
-            // established, since the entry is gone by then.
-            subscriber_clone.abort_subscribe(request_id);
-            result
-        }));
-
-        // Cleanly finish (FIN) the request stream's send side now that the
-        // SUBSCRIBE has been flushed; we never write again on this stream.
-        // Placed before `send.ok().await?` so the FIN is sent on every exit
-        // path that holds the writer — both the happy path and a failed ack —
-        // rather than letting the drop emit RESET_STREAM(0).
-        if let Err(err) = request_writer.finish() {
-            tracing::debug!(request_id, error = %err, "failed to FIN SUBSCRIBE request stream");
+                stream_cleanup.complete(&result);
+                result
+            }))
+            .is_err()
+        {
+            self.abort_subscribe(request_id);
+            return Err(ServeError::internal_ctx(
+                "session request task queue closed",
+            ));
         }
 
-        send.ok().await?;
+        send.set_stream(stream_tx, done_rx, cancel_tx);
         Ok(send)
     }
 
@@ -750,10 +974,14 @@ impl Subscriber {
         if let Ok(mut aliases) = self.track_alias_map.lock() {
             aliases.remove_by_request_id(id);
         }
+        self.drop_subscribe_name(id);
+        Some(subscribe)
+    }
+
+    fn drop_subscribe_name(&self, id: u64) {
         if let Ok(mut names) = self.subscriber_names.lock() {
             names.remove_by_request_id(id);
         }
-        Some(subscribe)
     }
 
     /// Handle an outbound SUBSCRIBE whose request stream ended.
@@ -1010,10 +1238,14 @@ impl Subscriber {
     }
 
     fn arm_drain(&self, request_id: u64, expire: fn(&Subscriber, u64)) {
-        let session = self.clone();
+        let finalizer = DrainFinalizer {
+            subscriber: self.clone(),
+            request_id,
+            expire,
+        };
         let drain = async move {
             tokio::time::sleep(PUBLISH_DONE_DRAIN_TIMEOUT).await;
-            expire(&session, request_id);
+            drop(finalizer);
             Ok(())
         };
 
@@ -1024,7 +1256,6 @@ impl Subscriber {
                 request_id,
                 "session is shutting down; ending draining subscription now"
             );
-            expire(self, request_id);
         }
     }
 
@@ -1129,7 +1360,7 @@ impl Subscriber {
         if let Some(subscribe) = self.remove_subscribe(msg.id) {
             self.log_request_error_parsed("subscribe", msg);
             let err = Self::request_error_to_serve_error(msg);
-            subscribe.error(err)?;
+            subscribe.reject(err)?;
         } else {
             self.log_request_error_parsed("unknown", msg);
         }
@@ -2501,6 +2732,416 @@ mod tests {
                 crate::coding::EncodeError::InvalidValue
             ))
         ));
+    }
+
+    #[tokio::test]
+    async fn dropping_an_opening_request_resets_a_partial_frame() {
+        let (client, server) = loopback_session_pair().await;
+        let (send, recv) = client.open_bi().await.unwrap();
+        let mut opening = OpeningRequestStream::new(send, recv);
+        opening
+            .writer
+            .as_mut()
+            .unwrap()
+            .write(&[0x4])
+            .await
+            .unwrap();
+
+        let (_peer_send, peer_recv) = server.accept_bi().await.unwrap();
+        let mut peer_reader = Reader::new(peer_recv);
+        assert!(peer_reader.read_chunk(1).await.unwrap().is_some());
+        drop(opening);
+
+        let err = tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                match peer_reader.read_chunk(64 * 1024).await {
+                    Ok(Some(_)) => continue,
+                    Ok(None) => panic!("partially written request finished with FIN"),
+                    Err(err) => break err,
+                }
+            }
+        })
+        .await
+        .expect("peer did not receive the request reset");
+        assert!(err.is_stream_error());
+    }
+
+    #[tokio::test]
+    async fn subscribe_fails_when_the_session_task_queue_is_closed() {
+        let mut subscriber = test_subscriber(loopback_session().await);
+        let (writer, _reader) =
+            serve::Track::new(TrackNamespace::from_utf8_path("test/ns"), "video").produce();
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            subscriber.subscribe_open(writer),
+        )
+        .await
+        .expect("subscribe did not notice the closed task queue");
+        let _error = match result {
+            Ok(_) => panic!("subscribe should fail when its response task cannot run"),
+            Err(error) => error,
+        };
+
+        assert!(subscriber.subscribes.lock().unwrap().is_empty());
+        assert!(subscriber.subscriber_names.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn cancelling_while_request_stream_is_blocked_releases_track_name() {
+        let (client, _server) = loopback_session_pair().await;
+        let mut streams = Vec::new();
+
+        // Exhaust the peer's bidi stream credit so subscribe_open reaches its
+        // first cancellable await after reserving the track name.
+        loop {
+            match tokio::time::timeout(Duration::from_millis(20), client.open_bi()).await {
+                Ok(Ok(stream)) => streams.push(stream),
+                Ok(Err(err)) => panic!("failed to open saturation stream: {err}"),
+                Err(_) => break,
+            }
+            assert!(streams.len() < 1024, "bidi stream credit was not bounded");
+        }
+
+        let (mut subscriber, _bidi_task_rx) = test_subscriber_with_tasks(client);
+        assert!(
+            tokio::time::timeout(
+                Duration::from_millis(20),
+                subscriber.subscribe_open(test_track("blocked")),
+            )
+            .await
+            .is_err(),
+            "SUBSCRIBE unexpectedly opened without bidi stream credit"
+        );
+        assert!(subscriber.subscriber_names.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn dropping_accepted_subscribe_sends_unsubscribe_on_request_stream() {
+        let (client, server) = loopback_session_pair().await;
+        let (mut subscriber, mut bidi_task_rx) = test_subscriber_with_tasks(client);
+
+        let peer = tokio::spawn(async move {
+            let (peer_send, peer_recv) = server.accept_bi().await.unwrap();
+            let mut peer_writer = Writer::new(peer_send);
+            let mut peer_reader = Reader::new(peer_recv);
+            let request_id = match peer_reader.decode::<Message>().await.unwrap() {
+                Message::Subscribe(msg) => msg.id,
+                msg => panic!("unexpected request: {}", msg.name()),
+            };
+
+            Session::encode_bidi_response(
+                &mut peer_writer,
+                &Message::SubscribeOk(message::SubscribeOk {
+                    id: request_id,
+                    track_alias: 42,
+                    params: Default::default(),
+                    track_extensions: Default::default(),
+                }),
+            )
+            .await
+            .unwrap();
+
+            let message = Session::decode_bidi_response(&mut peer_reader, request_id)
+                .await
+                .unwrap();
+            peer_writer.finish().unwrap();
+            message
+        });
+
+        let opening = tokio::spawn(async move {
+            let result = subscriber.subscribe_open(test_track("video")).await;
+            (subscriber, result)
+        });
+        let pump = tokio::time::timeout(Duration::from_secs(2), bidi_task_rx.recv())
+            .await
+            .expect("SUBSCRIBE response pump was not registered")
+            .expect("SUBSCRIBE response pump queue closed");
+        let pump = tokio::spawn(pump);
+
+        let (subscriber, subscribe) = opening.await.unwrap();
+        drop(subscribe.unwrap());
+
+        assert!(matches!(
+            tokio::time::timeout(Duration::from_secs(2), peer)
+                .await
+                .expect("peer did not receive UNSUBSCRIBE")
+                .unwrap(),
+            Message::Unsubscribe(message::Unsubscribe { id: 0 })
+        ));
+        tokio::time::timeout(Duration::from_secs(2), pump)
+            .await
+            .expect("SUBSCRIBE response pump did not stop")
+            .unwrap()
+            .unwrap();
+        assert!(subscriber.subscribes.lock().unwrap().is_empty());
+        assert!(subscriber.subscriber_names.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn unsubscribe_resets_a_request_stream_the_peer_does_not_finish() {
+        let (client, server) = loopback_session_pair().await;
+        let (mut subscriber, mut bidi_task_rx) = test_subscriber_with_tasks(client);
+
+        let peer = tokio::spawn(async move {
+            let (peer_send, peer_recv) = server.accept_bi().await.unwrap();
+            let mut peer_writer = Writer::new(peer_send);
+            let mut peer_reader = Reader::new(peer_recv);
+            let request_id = match peer_reader.decode::<Message>().await.unwrap() {
+                Message::Subscribe(msg) => msg.id,
+                msg => panic!("unexpected request: {}", msg.name()),
+            };
+
+            Session::encode_bidi_response(
+                &mut peer_writer,
+                &Message::SubscribeOk(message::SubscribeOk {
+                    id: request_id,
+                    track_alias: 42,
+                    params: Default::default(),
+                    track_extensions: Default::default(),
+                }),
+            )
+            .await
+            .unwrap();
+
+            let message = Session::decode_bidi_response(&mut peer_reader, request_id)
+                .await
+                .unwrap();
+            let _ = peer_reader.done().await;
+            let response_stopped = peer_writer.closed().await.unwrap();
+            (message, response_stopped)
+        });
+
+        let mut subscribe = subscriber
+            .subscribe_start(test_track("video"))
+            .await
+            .unwrap();
+        let pump = tokio::spawn(bidi_task_rx.recv().await.unwrap());
+        subscribe.ok().await.unwrap();
+
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            subscribe.unsubscribe_before(Duration::from_millis(20)),
+        )
+        .await
+        .expect("bounded unsubscribe did not reset the request stream");
+
+        let (message, response_stopped) = peer.await.unwrap();
+        assert!(matches!(
+            message,
+            Message::Unsubscribe(message::Unsubscribe { id: 0 })
+        ));
+        assert_eq!(
+            response_stopped,
+            Some(u8::try_from(super::super::CANCELLED_STREAM_CODE).unwrap())
+        );
+        tokio::time::timeout(Duration::from_secs(2), pump)
+            .await
+            .expect("reset SUBSCRIBE response pump did not stop")
+            .unwrap()
+            .unwrap();
+        assert!(subscriber.subscribes.lock().unwrap().is_empty());
+        assert!(subscriber.subscriber_names.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn publish_done_drains_an_active_stream_after_the_pump_stops() {
+        let (client, server) = loopback_session_pair().await;
+        let (mut subscriber, mut bidi_task_rx) = test_subscriber_with_tasks(client);
+
+        let peer = tokio::spawn(async move {
+            let (peer_send, peer_recv) = server.accept_bi().await.unwrap();
+            let mut peer_writer = Writer::new(peer_send);
+            let mut peer_reader = Reader::new(peer_recv);
+            let request_id = match peer_reader.decode::<Message>().await.unwrap() {
+                Message::Subscribe(msg) => msg.id,
+                msg => panic!("unexpected request: {}", msg.name()),
+            };
+
+            Session::encode_bidi_response(
+                &mut peer_writer,
+                &Message::SubscribeOk(message::SubscribeOk {
+                    id: request_id,
+                    track_alias: 42,
+                    params: Default::default(),
+                    track_extensions: Default::default(),
+                }),
+            )
+            .await
+            .unwrap();
+            Session::encode_bidi_response(
+                &mut peer_writer,
+                &Message::PublishDone(message::PublishDone {
+                    id: request_id,
+                    status_code: message::PublishDoneCode::TrackEnded as u64,
+                    stream_count: 1,
+                    reason: Default::default(),
+                }),
+            )
+            .await
+            .unwrap();
+
+            peer_reader.done().await.unwrap()
+        });
+
+        let subscribe = subscriber
+            .subscribe_start(test_track("video"))
+            .await
+            .unwrap();
+        assert!(subscriber.note_subscribe_stream_received(0));
+        let pump = tokio::spawn(bidi_task_rx.recv().await.unwrap());
+
+        tokio::time::timeout(Duration::from_secs(2), pump)
+            .await
+            .expect("PUBLISH_DONE did not stop the SUBSCRIBE pump")
+            .unwrap()
+            .unwrap();
+        assert!(tokio::time::timeout(Duration::from_secs(2), peer)
+            .await
+            .expect("SUBSCRIBE writer did not finish after PUBLISH_DONE")
+            .unwrap());
+        assert!(
+            subscriber.subscribes.lock().unwrap().contains_key(&0),
+            "normal PUBLISH_DONE must keep state while a data stream is active"
+        );
+
+        subscriber.note_subscribe_stream_finished(0);
+        assert!(matches!(
+            subscribe.closed().await,
+            Err(ServeError::Closed(code))
+                if code == message::PublishDoneCode::TrackEnded as u64
+        ));
+        assert!(subscriber.subscribes.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn session_shutdown_does_not_leave_a_subscribe_drain_queued() {
+        let (client, server) = loopback_session_pair().await;
+        let (mut subscriber, mut bidi_task_rx) = test_subscriber_with_tasks(client);
+
+        let peer = tokio::spawn(async move {
+            let (peer_send, peer_recv) = server.accept_bi().await.unwrap();
+            let mut peer_writer = Writer::new(peer_send);
+            let mut peer_reader = Reader::new(peer_recv);
+            let request_id = match peer_reader.decode::<Message>().await.unwrap() {
+                Message::Subscribe(msg) => msg.id,
+                msg => panic!("unexpected request: {}", msg.name()),
+            };
+
+            Session::encode_bidi_response(
+                &mut peer_writer,
+                &Message::SubscribeOk(message::SubscribeOk {
+                    id: request_id,
+                    track_alias: 42,
+                    params: Default::default(),
+                    track_extensions: Default::default(),
+                }),
+            )
+            .await
+            .unwrap();
+            Session::encode_bidi_response(
+                &mut peer_writer,
+                &Message::PublishDone(message::PublishDone {
+                    id: request_id,
+                    status_code: message::PublishDoneCode::TrackEnded as u64,
+                    stream_count: 1,
+                    reason: Default::default(),
+                }),
+            )
+            .await
+            .unwrap();
+
+            peer_reader.done().await.unwrap()
+        });
+
+        let subscribe = subscriber
+            .subscribe_start(test_track("video"))
+            .await
+            .unwrap();
+        let pump = tokio::spawn(bidi_task_rx.recv().await.unwrap());
+        tokio::time::timeout(Duration::from_secs(2), pump)
+            .await
+            .expect("PUBLISH_DONE did not stop the SUBSCRIBE pump")
+            .unwrap()
+            .unwrap();
+        assert!(tokio::time::timeout(Duration::from_secs(2), peer)
+            .await
+            .expect("SUBSCRIBE writer did not finish after PUBLISH_DONE")
+            .unwrap());
+
+        let drain = bidi_task_rx
+            .recv()
+            .await
+            .expect("PUBLISH_DONE should arm a drain timer");
+        assert!(!subscriber.subscribes.lock().unwrap().is_empty());
+        assert!(!subscriber.track_alias_map.lock().unwrap().is_empty());
+        assert!(!subscriber.subscriber_names.lock().unwrap().is_empty());
+
+        // Session::run drops its collected futures when any session branch ends.
+        drop(drain);
+
+        assert!(matches!(
+            subscribe.closed().await,
+            Err(ServeError::Closed(code))
+                if code == message::PublishDoneCode::TrackEnded as u64
+        ));
+        assert!(subscriber.subscribes.lock().unwrap().is_empty());
+        assert!(subscriber.track_alias_map.lock().unwrap().is_empty());
+        assert!(subscriber.subscriber_names.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn request_error_terminates_the_subscribe_pump() {
+        let (client, server) = loopback_session_pair().await;
+        let (mut subscriber, mut bidi_task_rx) = test_subscriber_with_tasks(client);
+
+        let peer = tokio::spawn(async move {
+            let (peer_send, peer_recv) = server.accept_bi().await.unwrap();
+            let mut peer_writer = Writer::new(peer_send);
+            let mut peer_reader = Reader::new(peer_recv);
+            let request_id = match peer_reader.decode::<Message>().await.unwrap() {
+                Message::Subscribe(msg) => msg.id,
+                msg => panic!("unexpected request: {}", msg.name()),
+            };
+
+            Session::encode_bidi_response(
+                &mut peer_writer,
+                &Message::RequestError(message::RequestError {
+                    id: request_id,
+                    error_code: message::RequestErrorCode::DoesNotExist as u64,
+                    retry_interval: 0,
+                    reason: Default::default(),
+                }),
+            )
+            .await
+            .unwrap();
+
+            peer_reader.done().await.unwrap()
+        });
+
+        let (track, _reader) =
+            serve::Track::new(TrackNamespace::from_utf8_path("test/ns"), "missing").produce();
+        let subscribe = subscriber.subscribe_start(track).await.unwrap();
+        let pump = tokio::spawn(bidi_task_rx.recv().await.unwrap());
+
+        let _pump_result = tokio::time::timeout(Duration::from_secs(2), pump)
+            .await
+            .expect("REQUEST_ERROR did not stop the SUBSCRIBE pump")
+            .unwrap();
+        assert!(tokio::time::timeout(Duration::from_secs(2), peer)
+            .await
+            .expect("SUBSCRIBE writer did not finish after REQUEST_ERROR")
+            .unwrap());
+        let result = subscribe.ok().await;
+        assert!(
+            matches!(
+                result,
+                Err(ServeError::NotFound | ServeError::NotFoundWithId(_, _))
+            ),
+            "unexpected rejection: {result:?}"
+        );
+        assert!(subscribe.peer_rejected());
+        assert!(subscriber.subscribes.lock().unwrap().is_empty());
     }
 
     /// `Subscribe::drop` must remove the request's entry from the subscribes map


### PR DESCRIPTION
Rendezvous subscriptions could release cached routes before upstream request streams stopped, allowing replacement work to overtake cleanup. The relay now bounds unresolved work, preserves peer rejection details, and keeps each cache generation reserved until ordered teardown completes.