### PR TITLE
fix(moq-transport): preserve subgroup fanout

### DIFF
--- a/moq-transport/src/serve/subgroup.rs
+++ b/moq-transport/src/serve/subgroup.rs
@@ -14,14 +14,16 @@ use std::{
     collections::VecDeque,
     ops::Deref,
     sync::{
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc, Weak,
     },
 };
 
 use bytes::Bytes;
+use tokio::sync::Notify;
 
 use crate::data::ObjectStatus;
+use crate::message::PublishDoneCode;
 use crate::watch::State;
 
 use super::{ServeError, Track};
@@ -51,23 +53,62 @@ impl Deref for Subgroups {
 
 // State shared between the writer and reader.
 struct SubgroupsState {
-    latest_subgroup_reader: Option<SubgroupReader>,
+    latest_subgroup: Option<(u64, u64)>,
+    largest_location: Option<(u64, u64)>,
+    live_subgroups: Vec<LiveSubgroup>,
+    logical_subgroups: VecDeque<LogicalSubgroup>,
     pending_subgroups: VecDeque<(usize, SubgroupReader)>,
-    reader_cursors: Vec<Weak<AtomicUsize>>,
-    active_subgroups: Vec<((u64, u64), Weak<SubgroupInfo>)>,
+    reader_cursors: Vec<Weak<SubgroupsCursor>>,
+    template_cursor: Option<Weak<SubgroupsCursor>>,
+    template_claimed: bool,
     next_sequence: usize,
     closed: Result<(), ServeError>,
 }
 
-const MAX_PENDING_SUBGROUPS: usize = 1024;
+pub(crate) const MAX_PENDING_SUBGROUPS: usize = 1024;
+const MAX_LIVE_SUBGROUPS: usize = 1024;
+const MAX_LOGICAL_SUBGROUPS: usize = 1024;
+
+struct LiveSubgroup {
+    instance: usize,
+    reader: SubgroupReader,
+}
+
+struct LogicalSubgroup {
+    key: (u64, u64),
+    priority: u8,
+    live_streams: usize,
+}
+
+struct SubgroupsCursor {
+    sequence: Arc<AtomicUsize>,
+    lagged: AtomicBool,
+    active: AtomicBool,
+    notify: Notify,
+}
+
+impl SubgroupsCursor {
+    fn new(sequence: usize) -> Self {
+        Self {
+            sequence: Arc::new(AtomicUsize::new(sequence)),
+            lagged: AtomicBool::new(false),
+            active: AtomicBool::new(true),
+            notify: Notify::new(),
+        }
+    }
+}
 
 impl Default for SubgroupsState {
     fn default() -> Self {
         Self {
-            latest_subgroup_reader: None,
+            latest_subgroup: None,
+            largest_location: None,
+            live_subgroups: Vec::new(),
+            logical_subgroups: VecDeque::new(),
             pending_subgroups: VecDeque::new(),
             reader_cursors: Vec::new(),
-            active_subgroups: Vec::new(),
+            template_cursor: None,
+            template_claimed: false,
             next_sequence: 0,
             closed: Ok(()),
         }
@@ -75,6 +116,47 @@ impl Default for SubgroupsState {
 }
 
 impl SubgroupsState {
+    fn open_logical_subgroup(
+        &mut self,
+        key: (u64, u64),
+        priority: u8,
+        allow_continuation: bool,
+    ) -> Result<(), ServeError> {
+        if let Some(logical) = self
+            .logical_subgroups
+            .iter_mut()
+            .find(|logical| logical.key == key)
+        {
+            if !allow_continuation {
+                return Err(ServeError::Duplicate);
+            }
+            if logical.priority != priority {
+                let err = ServeError::Closed(PublishDoneCode::MalformedTrack as u64);
+                self.closed = Err(err.clone());
+                return Err(err);
+            }
+            logical.live_streams = logical.live_streams.saturating_add(1);
+            return Ok(());
+        }
+
+        if self.logical_subgroups.len() >= MAX_LOGICAL_SUBGROUPS {
+            let Some(completed) = self
+                .logical_subgroups
+                .iter()
+                .position(|logical| logical.live_streams == 0)
+            else {
+                return Err(ServeError::Closed(PublishDoneCode::ExcessiveLoad as u64));
+            };
+            self.logical_subgroups.remove(completed);
+        }
+        self.logical_subgroups.push_back(LogicalSubgroup {
+            key,
+            priority,
+            live_streams: 1,
+        });
+        Ok(())
+    }
+
     fn prune_consumed(&mut self) {
         self.reader_cursors
             .retain(|reader| reader.strong_count() > 0);
@@ -82,13 +164,14 @@ impl SubgroupsState {
             .reader_cursors
             .iter()
             .filter_map(Weak::upgrade)
-            .map(|cursor| cursor.load(Ordering::Relaxed))
+            .filter(|cursor| {
+                cursor.active.load(Ordering::Relaxed) && !cursor.lagged.load(Ordering::Relaxed)
+            })
+            .map(|cursor| cursor.sequence.load(Ordering::Relaxed))
             .min()
             .unwrap_or(self.next_sequence);
 
-        // Preserve the current latest subgroup for a reader activated after an
-        // idle period, even when every active reader has advanced past it.
-        while self.pending_subgroups.len() > 1
+        while !self.pending_subgroups.is_empty()
             && self
                 .pending_subgroups
                 .front()
@@ -96,6 +179,22 @@ impl SubgroupsState {
         {
             self.pending_subgroups.pop_front();
         }
+    }
+
+    fn isolate_lagging_readers(&mut self) {
+        for cursor in self.reader_cursors.iter().filter_map(Weak::upgrade) {
+            if !cursor.active.load(Ordering::Relaxed) {
+                continue;
+            }
+            let pending = self
+                .next_sequence
+                .saturating_sub(cursor.sequence.load(Ordering::Relaxed));
+            if pending >= MAX_PENDING_SUBGROUPS {
+                cursor.lagged.store(true, Ordering::Relaxed);
+                cursor.notify.notify_waiters();
+            }
+        }
+        self.prune_consumed();
     }
 }
 
@@ -143,7 +242,7 @@ impl SubgroupsWriter {
 
     /// Create a new subgroup with the given parameters, inserting it into the track.
     pub fn create(&mut self, subgroup: Subgroup) -> Result<SubgroupWriter, ServeError> {
-        self.create_with_metadata(subgroup, SubgroupStreamMetadata::default())
+        self.create_inner(subgroup, SubgroupStreamMetadata::default(), false)
     }
 
     pub(crate) fn create_with_metadata(
@@ -151,61 +250,62 @@ impl SubgroupsWriter {
         subgroup: Subgroup,
         metadata: SubgroupStreamMetadata,
     ) -> Result<SubgroupWriter, ServeError> {
+        self.create_inner(subgroup, metadata, true)
+    }
+
+    fn create_inner(
+        &mut self,
+        subgroup: Subgroup,
+        metadata: SubgroupStreamMetadata,
+        allow_continuation: bool,
+    ) -> Result<SubgroupWriter, ServeError> {
         let subgroup = SubgroupInfo {
             track: self.info.clone(),
             group_id: subgroup.group_id,
             subgroup_id: subgroup.subgroup_id,
             priority: subgroup.priority,
         };
-        let (writer, reader) = subgroup.produce_with_metadata(metadata);
+        let (mut writer, reader) = subgroup.produce_with_metadata(metadata);
 
         let mut state = self.state.lock_mut().ok_or(ServeError::Cancel)?;
         state.closed.clone()?;
 
-        state
-            .active_subgroups
-            .retain(|(_, subgroup)| subgroup.strong_count() > 0);
         let key = (writer.group_id, writer.subgroup_id);
-        if state
-            .active_subgroups
-            .iter()
-            .any(|(active, _)| *active == key)
-        {
-            return Err(ServeError::Duplicate);
-        }
-
-        state.prune_consumed();
-        if state.pending_subgroups.len() >= MAX_PENDING_SUBGROUPS {
-            let err =
-                ServeError::Internal("subgroup reader exceeded its pending stream limit".into());
+        if state.live_subgroups.len() >= MAX_LIVE_SUBGROUPS {
+            let err = ServeError::Closed(PublishDoneCode::ExcessiveLoad as u64);
             state.closed = Err(err.clone());
             return Err(err);
         }
-
         let sequence = state.next_sequence;
         let Some(next_sequence) = state.next_sequence.checked_add(1) else {
             let err = ServeError::Internal("subgroup delivery sequence exhausted".into());
             state.closed = Err(err.clone());
             return Err(err);
         };
+        state.open_logical_subgroup(key, writer.priority, allow_continuation)?;
+        state.isolate_lagging_readers();
         state.next_sequence = next_sequence;
+        writer.parent = Some(SubgroupParent {
+            state: self.state.clone(),
+            key,
+            instance: sequence,
+        });
+        state.live_subgroups.push(LiveSubgroup {
+            instance: sequence,
+            reader: reader.clone(),
+        });
         state
             .pending_subgroups
             .push_back((sequence, reader.clone()));
-        state
-            .active_subgroups
-            .push((key, Arc::downgrade(&reader.info)));
 
-        let advances_latest = state
-            .latest_subgroup_reader
-            .as_ref()
-            .is_none_or(|latest| key > (latest.group_id, latest.subgroup_id));
+        let advances_latest = state.latest_subgroup.is_none_or(|latest| key > latest);
         if advances_latest {
             self.next_subgroup_id = writer.subgroup_id.saturating_add(1);
             self.next_group_id = writer.group_id.saturating_add(1);
             self.last_group_id = writer.group_id;
-            state.latest_subgroup_reader = Some(reader);
+            state.latest_subgroup = Some(key);
         }
+        state.prune_consumed();
 
         Ok(writer)
     }
@@ -233,35 +333,79 @@ impl Deref for SubgroupsWriter {
 pub struct SubgroupsReader {
     pub info: Arc<Track>,
     state: State<SubgroupsState>,
-    cursor: Option<Arc<AtomicUsize>>,
+    cursor: Option<Arc<SubgroupsCursor>>,
+    initial: VecDeque<SubgroupReader>,
+    claim_template: bool,
+    template_source: bool,
+}
+
+pub(crate) struct SubgroupsLagWatcher {
+    cursor: Arc<SubgroupsCursor>,
 }
 
 impl SubgroupsReader {
     fn new(state: State<SubgroupsState>, track_info: Arc<Track>) -> Self {
+        let cursor = Arc::new(SubgroupsCursor::new(0));
+        let mut locked = state.lock().into_mut_closed();
+        locked.reader_cursors.push(Arc::downgrade(&cursor));
+        locked.template_cursor = Some(Arc::downgrade(&cursor));
+        drop(locked);
         Self {
             info: track_info,
             state,
-            cursor: None,
+            cursor: Some(cursor),
+            initial: VecDeque::new(),
+            claim_template: true,
+            template_source: true,
         }
     }
 
     fn register(&mut self) {
+        if self.claim_template {
+            let mut state = self.state.lock().into_mut_closed();
+            let original_template = state
+                .template_cursor
+                .as_ref()
+                .and_then(Weak::upgrade)
+                .zip(self.cursor.as_ref())
+                .is_some_and(|(template, cursor)| Arc::ptr_eq(&template, cursor));
+            if !state.template_claimed {
+                state.template_claimed = true;
+                if let Some(template) = state.template_cursor.as_ref().and_then(Weak::upgrade) {
+                    if self
+                        .cursor
+                        .as_ref()
+                        .is_some_and(|cursor| !Arc::ptr_eq(cursor, &template))
+                    {
+                        template.active.store(false, Ordering::Relaxed);
+                    }
+                }
+            }
+            self.claim_template = false;
+            if original_template {
+                self.template_source = false;
+            }
+            return;
+        }
+
         if self.cursor.is_some() {
             return;
         }
 
         let state = self.state.lock();
-        let sequence = state
-            .pending_subgroups
-            .back()
-            .map_or(state.next_sequence, |(sequence, _)| *sequence);
-        let cursor = Arc::new(AtomicUsize::new(sequence));
+        let initial = state
+            .live_subgroups
+            .iter()
+            .map(|live| live.reader.clone())
+            .collect();
+        let cursor = Arc::new(SubgroupsCursor::new(state.next_sequence));
         let mut state = state.into_mut_closed();
         state
             .reader_cursors
             .retain(|reader| reader.strong_count() > 0);
         state.reader_cursors.push(Arc::downgrade(&cursor));
         self.cursor = Some(cursor);
+        self.initial = initial;
     }
 
     pub async fn next(&mut self) -> Result<Option<SubgroupReader>, ServeError> {
@@ -270,10 +414,21 @@ impl SubgroupsReader {
         loop {
             {
                 let state = self.state.lock();
+                let cursor = self.cursor.as_ref().ok_or_else(|| {
+                    ServeError::Internal("subgroup reader is not registered".into())
+                })?;
+                if cursor.lagged.load(Ordering::Relaxed) {
+                    return Err(ServeError::Internal(
+                        "subgroup reader exceeded its pending stream limit".into(),
+                    ));
+                }
+                if let Some(initial) = self.initial.pop_front() {
+                    return Ok(Some(initial));
+                }
                 if let (Some(cursor), Some((first_sequence, _))) =
                     (&self.cursor, state.pending_subgroups.front())
                 {
-                    let sequence = cursor.load(Ordering::Relaxed);
+                    let sequence = cursor.sequence.load(Ordering::Relaxed);
                     let index = sequence.checked_sub(*first_sequence).ok_or_else(|| {
                         ServeError::Internal("subgroup reader fell behind retained history".into())
                     })?;
@@ -282,7 +437,7 @@ impl SubgroupsReader {
                         .get(index)
                         .map(|(_, subgroup)| subgroup.clone())
                     {
-                        cursor.store(sequence + 1, Ordering::Relaxed);
+                        cursor.sequence.store(sequence + 1, Ordering::Relaxed);
                         let mut state = state.into_mut_closed();
                         state.prune_consumed();
                         return Ok(Some(subgroup));
@@ -302,16 +457,19 @@ impl SubgroupsReader {
     #[cfg(test)]
     pub(crate) fn delivery_cursor(&mut self) -> Arc<AtomicUsize> {
         self.register();
-        self.cursor.as_ref().cloned().unwrap()
+        self.cursor.as_ref().unwrap().sequence.clone()
+    }
+
+    pub(crate) fn lag_watcher(&mut self) -> SubgroupsLagWatcher {
+        self.register();
+        SubgroupsLagWatcher {
+            cursor: self.cursor.as_ref().cloned().unwrap(),
+        }
     }
 
     // Returns the largest group/sequence
     pub fn latest(&self) -> Option<(u64, u64)> {
-        let state = self.state.lock();
-        state
-            .latest_subgroup_reader
-            .as_ref()
-            .and_then(|group| group.latest().map(|object_id| (group.group_id, object_id)))
+        self.state.lock().largest_location
     }
 
     /// Check if the subgroups writer has been closed or dropped.
@@ -321,19 +479,67 @@ impl SubgroupsReader {
     }
 }
 
+impl SubgroupsLagWatcher {
+    pub(crate) async fn lagged(&self) {
+        loop {
+            let notified = self.cursor.notify.notified();
+            if self.cursor.lagged.load(Ordering::Relaxed) {
+                return;
+            }
+            notified.await;
+        }
+    }
+}
+
 impl Clone for SubgroupsReader {
     fn clone(&self) -> Self {
         let state = self.state.lock();
-        let sequence = self.cursor.as_ref().map_or_else(
-            || {
+        let claim_template = self.claim_template && !state.template_claimed;
+        let (sequence, lagged, initial) = if claim_template {
+            let cursor = self.cursor.as_ref().unwrap();
+            (
+                cursor.sequence.load(Ordering::Relaxed),
+                cursor.lagged.load(Ordering::Relaxed),
+                self.initial.clone(),
+            )
+        } else if self.template_source {
+            (
+                state.next_sequence,
+                false,
                 state
-                    .pending_subgroups
-                    .back()
-                    .map_or(state.next_sequence, |(sequence, _)| *sequence)
-            },
-            |cursor| cursor.load(Ordering::Relaxed),
-        );
-        let cursor = Arc::new(AtomicUsize::new(sequence));
+                    .live_subgroups
+                    .iter()
+                    .map(|live| live.reader.clone())
+                    .collect(),
+            )
+        } else {
+            self.cursor.as_ref().map_or_else(
+                || {
+                    (
+                        state.next_sequence,
+                        false,
+                        state
+                            .live_subgroups
+                            .iter()
+                            .map(|live| live.reader.clone())
+                            .collect(),
+                    )
+                },
+                |cursor| {
+                    (
+                        cursor.sequence.load(Ordering::Relaxed),
+                        cursor.lagged.load(Ordering::Relaxed),
+                        self.initial.clone(),
+                    )
+                },
+            )
+        };
+        let cursor = Arc::new(SubgroupsCursor {
+            sequence: Arc::new(AtomicUsize::new(sequence)),
+            lagged: AtomicBool::new(lagged),
+            active: AtomicBool::new(true),
+            notify: Notify::new(),
+        });
         let mut state = state.into_mut_closed();
         state
             .reader_cursors
@@ -344,6 +550,9 @@ impl Clone for SubgroupsReader {
             info: self.info.clone(),
             state: self.state.clone(),
             cursor: Some(cursor),
+            initial,
+            claim_template,
+            template_source: false,
         }
     }
 }
@@ -465,6 +674,12 @@ impl SubgroupState {
 }
 
 /// Used to write data to a stream and notify readers.
+struct SubgroupParent {
+    state: State<SubgroupsState>,
+    key: (u64, u64),
+    instance: usize,
+}
+
 pub struct SubgroupWriter {
     // Mutable stream state.
     state: State<SubgroupState>,
@@ -474,6 +689,8 @@ pub struct SubgroupWriter {
 
     // The next object sequence number to use.
     next_object_id: Option<u64>,
+
+    parent: Option<SubgroupParent>,
 }
 
 impl SubgroupWriter {
@@ -482,6 +699,7 @@ impl SubgroupWriter {
             state,
             info: group,
             next_object_id: Some(0),
+            parent: None,
         }
     }
 
@@ -516,6 +734,17 @@ impl SubgroupWriter {
             return Err(ServeError::Duplicate);
         }
 
+        let group_id = self.group_id;
+        if let Some(parent) = &self.parent {
+            let mut state = parent.state.lock().into_mut_closed();
+            let location = (group_id, object_id);
+            state.largest_location = Some(
+                state
+                    .largest_location
+                    .map_or(location, |largest| largest.max(location)),
+            );
+        }
+
         let (writer, reader) = SubgroupObject {
             group: self.info.clone(),
             object_id,
@@ -528,6 +757,7 @@ impl SubgroupWriter {
         let mut state = self.state.lock_mut().ok_or(ServeError::Cancel)?;
         state.objects.push(reader);
         self.next_object_id = object_id.checked_add(1);
+        drop(state);
 
         Ok(writer)
     }
@@ -556,6 +786,25 @@ impl Deref for SubgroupWriter {
 
     fn deref(&self) -> &Self::Target {
         &self.info
+    }
+}
+
+impl Drop for SubgroupWriter {
+    fn drop(&mut self) {
+        let Some(parent) = self.parent.take() else {
+            return;
+        };
+        let mut state = parent.state.lock().into_mut_closed();
+        state
+            .live_subgroups
+            .retain(|live| live.instance != parent.instance);
+        if let Some(logical) = state
+            .logical_subgroups
+            .iter_mut()
+            .find(|logical| logical.key == parent.key)
+        {
+            logical.live_streams = logical.live_streams.saturating_sub(1);
+        }
     }
 }
 
@@ -904,6 +1153,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn blocked_reader_wakes_when_a_subgroup_arrives() {
+        let (mut writer, template) = subgroups();
+        let mut reader = template.clone();
+
+        let waiting = reader.next();
+        let publish = async {
+            tokio::task::yield_now().await;
+            create_subgroup(&mut writer, 0, 0)
+        };
+        let (received, _subgroup) =
+            tokio::time::timeout(std::time::Duration::from_secs(1), async {
+                tokio::join!(waiting, publish)
+            })
+            .await
+            .unwrap();
+
+        let received = received.unwrap().unwrap();
+        assert_eq!((received.group_id, received.subgroup_id), (0, 0));
+    }
+
+    #[tokio::test]
+    async fn blocked_reader_wakes_when_the_source_is_cancelled() {
+        let (writer, template) = subgroups();
+        let mut reader = template.clone();
+
+        let waiting = reader.next();
+        let cancel = async {
+            tokio::task::yield_now().await;
+            writer.close(ServeError::Cancel).unwrap();
+        };
+        let (received, ()) = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            tokio::join!(waiting, cancel)
+        })
+        .await
+        .unwrap();
+
+        assert!(matches!(received, Err(ServeError::Cancel)));
+    }
+
+    #[tokio::test]
     async fn delivers_two_groups_in_arrival_order() {
         let (mut writer, template) = subgroups();
         let mut reader = template.clone();
@@ -941,12 +1230,31 @@ mod tests {
         assert_subgroups(&mut first, &[(0, 0), (0, 1)]).await;
     }
 
-    #[test]
-    fn rejects_active_duplicate_after_out_of_order_delivery() {
+    #[tokio::test]
+    async fn rejects_duplicate_while_the_first_stream_is_live() {
         let (mut writer, template) = subgroups();
-        let _reader = template.clone();
-        let _one = create_subgroup(&mut writer, 0, 1);
-        let _zero = create_subgroup(&mut writer, 0, 0);
+        let mut reader = template.clone();
+        let zero = create_subgroup(&mut writer, 0, 0);
+        assert_subgroups(&mut reader, &[(0, 0)]).await;
+
+        assert!(matches!(
+            writer.create(Subgroup {
+                group_id: 0,
+                subgroup_id: 0,
+                priority: 128,
+            }),
+            Err(ServeError::Duplicate)
+        ));
+        drop(zero);
+    }
+
+    #[tokio::test]
+    async fn public_create_rejects_a_recently_completed_duplicate() {
+        let (mut writer, template) = subgroups();
+        let mut reader = template.clone();
+        let first = create_subgroup(&mut writer, 0, 0);
+        assert_subgroups(&mut reader, &[(0, 0)]).await;
+        drop(first);
 
         assert!(matches!(
             writer.create(Subgroup {
@@ -958,36 +1266,187 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn completed_duplicate_registry_stays_bounded() {
+        let (mut writer, _reader) = subgroups();
+        for group_id in 0..=MAX_LOGICAL_SUBGROUPS as u64 {
+            drop(create_subgroup(&mut writer, group_id, 0));
+        }
+
+        assert_eq!(
+            writer.state.lock().logical_subgroups.len(),
+            MAX_LOGICAL_SUBGROUPS
+        );
+        assert!(matches!(
+            writer.create(Subgroup {
+                group_id: MAX_LOGICAL_SUBGROUPS as u64,
+                subgroup_id: 0,
+                priority: 128,
+            }),
+            Err(ServeError::Duplicate)
+        ));
+    }
+
     #[tokio::test]
-    async fn backlog_overflow_closes_the_subgroup_source() {
+    async fn ingress_can_continue_a_reset_logical_subgroup() {
         let (mut writer, template) = subgroups();
         let mut reader = template.clone();
-        let mut open = Vec::new();
-        for group_id in 0..MAX_PENDING_SUBGROUPS as u64 {
-            open.push(create_subgroup(&mut writer, group_id, 0));
-        }
+        let subgroup = Subgroup {
+            group_id: 0,
+            subgroup_id: 0,
+            priority: 128,
+        };
+        let mut first = writer
+            .create_with_metadata(subgroup.clone(), SubgroupStreamMetadata::default())
+            .unwrap();
+        drop(first.create_with_id(0, 0, None).unwrap());
+        assert_subgroups(&mut reader, &[(0, 0)]).await;
+        first.close(ServeError::Cancel).unwrap();
+
+        let _continuation = writer
+            .create_with_metadata(
+                subgroup,
+                SubgroupStreamMetadata {
+                    first_object: false,
+                    ..SubgroupStreamMetadata::default()
+                },
+            )
+            .unwrap();
+        assert_subgroups(&mut reader, &[(0, 0)]).await;
+    }
+
+    #[tokio::test]
+    async fn concurrent_ingress_continuations_have_independent_lifetimes() {
+        let (mut writer, template) = subgroups();
+        let mut reader = template.clone();
+        let subgroup = Subgroup {
+            group_id: 0,
+            subgroup_id: 0,
+            priority: 128,
+        };
+        let first = writer
+            .create_with_metadata(subgroup.clone(), SubgroupStreamMetadata::default())
+            .unwrap();
+        let second = writer
+            .create_with_metadata(
+                subgroup.clone(),
+                SubgroupStreamMetadata {
+                    first_object: false,
+                    ..SubgroupStreamMetadata::default()
+                },
+            )
+            .unwrap();
+        assert_subgroups(&mut reader, &[(0, 0), (0, 0)]).await;
+        drop(first);
+
+        let _third = writer
+            .create_with_metadata(
+                subgroup,
+                SubgroupStreamMetadata {
+                    first_object: false,
+                    ..SubgroupStreamMetadata::default()
+                },
+            )
+            .unwrap();
+        drop(second);
+        assert_eq!(writer.state.lock().live_subgroups.len(), 1);
+        assert_eq!(writer.state.lock().logical_subgroups[0].live_streams, 1);
+    }
+
+    #[test]
+    fn continuation_rejects_changed_priority_as_malformed_track() {
+        let (mut writer, _reader) = subgroups();
+        let mut first = writer
+            .create_with_metadata(
+                Subgroup {
+                    group_id: 0,
+                    subgroup_id: 0,
+                    priority: 128,
+                },
+                SubgroupStreamMetadata::default(),
+            )
+            .unwrap();
+        drop(first.create_with_id(0, 0, None).unwrap());
+        drop(first);
 
         assert!(matches!(
-            writer.create(Subgroup {
-                group_id: MAX_PENDING_SUBGROUPS as u64,
-                subgroup_id: 0,
-                priority: 128,
-            }),
-            Err(ServeError::Internal(_))
+            writer.create_with_metadata(
+                Subgroup {
+                    group_id: 0,
+                    subgroup_id: 0,
+                    priority: 127,
+                },
+                SubgroupStreamMetadata {
+                    first_object: false,
+                    ..SubgroupStreamMetadata::default()
+                },
+            ),
+            Err(ServeError::Closed(code))
+                if code == PublishDoneCode::MalformedTrack as u64
         ));
-
-        for group_id in 0..MAX_PENDING_SUBGROUPS as u64 {
-            assert_subgroups(&mut reader, &[(group_id, 0)]).await;
-        }
-        assert!(matches!(reader.next().await, Err(ServeError::Internal(_))));
         assert!(matches!(
-            writer.create(Subgroup {
-                group_id: MAX_PENDING_SUBGROUPS as u64,
-                subgroup_id: 0,
-                priority: 128,
-            }),
-            Err(ServeError::Internal(_))
+            writer.state.lock().closed,
+            Err(ServeError::Closed(code))
+                if code == PublishDoneCode::MalformedTrack as u64
         ));
+    }
+
+    #[test]
+    fn continuation_allows_repeated_and_reordered_first_object_markers() {
+        let (mut writer, _reader) = subgroups();
+        let subgroup = Subgroup {
+            group_id: 0,
+            subgroup_id: 0,
+            priority: 128,
+        };
+        let mut later = writer
+            .create_with_metadata(
+                subgroup.clone(),
+                SubgroupStreamMetadata {
+                    first_object: false,
+                    ..SubgroupStreamMetadata::default()
+                },
+            )
+            .unwrap();
+        drop(later.create_with_id(3, 0, None).unwrap());
+        drop(later);
+
+        let mut first = writer
+            .create_with_metadata(subgroup.clone(), SubgroupStreamMetadata::default())
+            .unwrap();
+        drop(first.create_with_id(0, 0, None).unwrap());
+        drop(first);
+
+        assert!(writer
+            .create_with_metadata(
+                Subgroup {
+                    group_id: 0,
+                    subgroup_id: 0,
+                    priority: 128,
+                },
+                SubgroupStreamMetadata::default(),
+            )
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn slow_reader_is_isolated_without_closing_the_source() {
+        let (mut writer, template) = subgroups();
+        let mut fast = template.clone();
+        let mut slow = template.clone();
+        for group_id in 0..MAX_PENDING_SUBGROUPS as u64 {
+            let _subgroup = create_subgroup(&mut writer, group_id, 0);
+            assert_subgroups(&mut fast, &[(group_id, 0)]).await;
+        }
+
+        let _subgroup = create_subgroup(&mut writer, MAX_PENDING_SUBGROUPS as u64, 0);
+        assert_subgroups(&mut fast, &[(MAX_PENDING_SUBGROUPS as u64, 0)]).await;
+        assert!(matches!(slow.next().await, Err(ServeError::Internal(_))));
+        assert!(writer.state.lock().closed.is_ok());
+        assert!(writer.state.lock().pending_subgroups.is_empty());
+
+        let _next = create_subgroup(&mut writer, MAX_PENDING_SUBGROUPS as u64 + 1, 0);
+        assert_subgroups(&mut fast, &[(MAX_PENDING_SUBGROUPS as u64 + 1, 0)]).await;
     }
 
     #[tokio::test]
@@ -1000,7 +1459,7 @@ mod tests {
             assert_subgroups(&mut reader, &[(group_id, 0)]).await;
         }
 
-        assert_eq!(writer.state.lock().pending_subgroups.len(), 1);
+        assert!(writer.state.lock().pending_subgroups.is_empty());
     }
 
     #[tokio::test]
@@ -1016,7 +1475,7 @@ mod tests {
         for group_id in 0..8 {
             assert_subgroups(&mut reader, &[(group_id, 0)]).await;
         }
-        assert_eq!(reader.state.lock().pending_subgroups.len(), 1);
+        assert!(reader.state.lock().pending_subgroups.is_empty());
         assert!(reader.next().await.unwrap().is_none());
     }
 
@@ -1036,7 +1495,182 @@ mod tests {
         assert_eq!(fast.state.lock().pending_subgroups.len(), 8);
 
         drop(slow);
-        assert_eq!(fast.state.lock().pending_subgroups.len(), 1);
+        assert!(fast.state.lock().pending_subgroups.is_empty());
+    }
+
+    #[tokio::test]
+    async fn lagged_clone_inherits_only_its_source_readers_failure() {
+        let (mut writer, template) = subgroups();
+        let mut fast = template.clone();
+        let mut slow = template.clone();
+
+        for group_id in 0..MAX_PENDING_SUBGROUPS as u64 {
+            let _subgroup = create_subgroup(&mut writer, group_id, 0);
+            assert_subgroups(&mut fast, &[(group_id, 0)]).await;
+        }
+        let _subgroup = create_subgroup(&mut writer, MAX_PENDING_SUBGROUPS as u64, 0);
+        let mut lagged_clone = slow.clone();
+
+        assert!(matches!(slow.next().await, Err(ServeError::Internal(_))));
+        assert!(matches!(
+            lagged_clone.next().await,
+            Err(ServeError::Internal(_))
+        ));
+        assert_subgroups(&mut fast, &[(MAX_PENDING_SUBGROUPS as u64, 0)]).await;
+        assert!(writer.state.lock().closed.is_ok());
+    }
+
+    #[tokio::test]
+    async fn late_reader_snapshots_all_live_subgroups_then_receives_new_arrivals() {
+        let (mut writer, template) = subgroups();
+        let mut high = create_subgroup(&mut writer, 1, 0);
+        high.write(Bytes::from_static(b"x")).unwrap();
+        let _low = create_subgroup(&mut writer, 0, 0);
+        let mut late = template.clone();
+
+        assert_subgroups(&mut late, &[(1, 0), (0, 0)]).await;
+        assert_eq!(late.latest(), Some((1, 0)));
+
+        let _future = create_subgroup(&mut writer, 0, 1);
+        assert_subgroups(&mut late, &[(0, 1)]).await;
+    }
+
+    #[tokio::test]
+    async fn cloned_late_readers_share_the_live_snapshot_independently() {
+        let (mut writer, template) = subgroups();
+        let _high = create_subgroup(&mut writer, 2, 0);
+        let _low = create_subgroup(&mut writer, 1, 0);
+        let mut first = template.clone();
+        let mut second = first.clone();
+
+        assert_subgroups(&mut first, &[(2, 0), (1, 0)]).await;
+        assert_subgroups(&mut second, &[(2, 0), (1, 0)]).await;
+    }
+
+    #[tokio::test]
+    async fn clone_of_directly_polled_original_inherits_its_cursor() {
+        let (mut writer, mut original) = subgroups();
+        let _zero = create_subgroup(&mut writer, 0, 0);
+        assert_subgroups(&mut original, &[(0, 0)]).await;
+        let _one = create_subgroup(&mut writer, 0, 1);
+        let mut cloned = original.clone();
+
+        assert_subgroups(&mut original, &[(0, 1)]).await;
+        assert_subgroups(&mut cloned, &[(0, 1)]).await;
+    }
+
+    #[tokio::test]
+    async fn track_inspection_does_not_claim_the_initial_reader_backlog() {
+        let (track_writer, track_reader) =
+            Track::new(TrackNamespace::from_utf8_path("test"), "inspection").produce();
+        let mut writer = track_writer.subgroups().unwrap();
+        let mut zero = create_subgroup(&mut writer, 0, 0);
+        drop(zero.create_with_id(0, 0, None).unwrap());
+        drop(zero);
+        let one = create_subgroup(&mut writer, 1, 0);
+        drop(one);
+
+        assert_eq!(
+            track_reader.largest_location(),
+            Some(crate::coding::Location::new(0, 0))
+        );
+        assert!(!track_reader.is_closed());
+
+        let super::super::TrackReaderMode::Subgroups(mut reader) =
+            track_reader.mode().await.unwrap()
+        else {
+            panic!("expected subgroup delivery");
+        };
+        assert_subgroups(&mut reader, &[(0, 0), (1, 0)]).await;
+    }
+
+    #[tokio::test]
+    async fn explicit_close_drains_buffered_subgroups_before_error() {
+        let (mut writer, template) = subgroups();
+        let mut reader = template.clone();
+        let _zero = create_subgroup(&mut writer, 0, 0);
+        let _one = create_subgroup(&mut writer, 0, 1);
+        writer.close(ServeError::Cancel).unwrap();
+
+        assert_subgroups(&mut reader, &[(0, 0), (0, 1)]).await;
+        assert!(matches!(reader.next().await, Err(ServeError::Cancel)));
+    }
+
+    #[tokio::test]
+    async fn active_subgroup_limit_closes_with_excessive_load() {
+        let (mut writer, template) = subgroups();
+        let _reader = template.clone();
+        let mut active = Vec::new();
+        for group_id in 0..MAX_LIVE_SUBGROUPS as u64 {
+            active.push(create_subgroup(&mut writer, group_id, 0));
+        }
+
+        assert!(matches!(
+            writer.create(Subgroup {
+                group_id: u64::MAX,
+                subgroup_id: 0,
+                priority: 128,
+            }),
+            Err(ServeError::Closed(code))
+                if code == PublishDoneCode::ExcessiveLoad as u64
+        ));
+        assert_eq!(writer.state.lock().live_subgroups.len(), MAX_LIVE_SUBGROUPS);
+        assert!(matches!(
+            writer.state.lock().closed,
+            Err(ServeError::Closed(code))
+                if code == PublishDoneCode::ExcessiveLoad as u64
+        ));
+    }
+
+    #[tokio::test]
+    async fn cancelled_subgroup_can_reopen_without_closing_the_track() {
+        let (mut writer, template) = subgroups();
+        let mut reader = template.clone();
+        let cancelled = create_subgroup(&mut writer, 0, 0);
+        assert_subgroups(&mut reader, &[(0, 0)]).await;
+        cancelled.close(ServeError::Cancel).unwrap();
+
+        let _replacement = writer
+            .create_with_metadata(
+                Subgroup {
+                    group_id: 0,
+                    subgroup_id: 0,
+                    priority: 128,
+                },
+                SubgroupStreamMetadata {
+                    first_object: false,
+                    ..SubgroupStreamMetadata::default()
+                },
+            )
+            .unwrap();
+        assert_subgroups(&mut reader, &[(0, 0)]).await;
+        assert!(writer.state.lock().closed.is_ok());
+    }
+
+    #[tokio::test]
+    async fn largest_location_is_independent_of_subgroup_id_order() {
+        let (mut writer, template) = subgroups();
+        let reader = template.clone();
+        let mut high_subgroup = create_subgroup(&mut writer, 0, 1);
+        drop(high_subgroup.create_with_id(5, 0, None).unwrap());
+        let mut low_subgroup = create_subgroup(&mut writer, 0, 0);
+        drop(low_subgroup.create_with_id(100, 0, None).unwrap());
+
+        assert_eq!(reader.latest(), Some((0, 100)));
+    }
+
+    #[tokio::test]
+    async fn child_cleanup_and_location_survive_parent_writer_drop() {
+        let (mut writer, mut reader) = subgroups();
+        let mut child = create_subgroup(&mut writer, 0, 0);
+        drop(writer);
+        drop(child.create_with_id(7, 0, None).unwrap());
+
+        assert_eq!(reader.latest(), Some((0, 7)));
+        drop(child);
+        assert!(reader.state.lock().live_subgroups.is_empty());
+        assert_subgroups(&mut reader, &[(0, 0)]).await;
+        assert!(reader.next().await.unwrap().is_none());
     }
 
     #[tokio::test]

--- a/moq-transport/src/serve/subgroup.rs
+++ b/moq-transport/src/serve/subgroup.rs
@@ -10,7 +10,14 @@
 //! The reader can be cloned, in which case each reader receives a copy of each object. (fanout)
 //!
 //! The stream is closed with [ServeError::Closed] when all writers or readers are dropped.
-use std::{cmp, ops::Deref, sync::Arc};
+use std::{
+    collections::VecDeque,
+    ops::Deref,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Weak,
+    },
+};
 
 use bytes::Bytes;
 
@@ -45,16 +52,49 @@ impl Deref for Subgroups {
 // State shared between the writer and reader.
 struct SubgroupsState {
     latest_subgroup_reader: Option<SubgroupReader>,
-    epoch: u64, // Updated each time latest changes
+    pending_subgroups: VecDeque<(usize, SubgroupReader)>,
+    reader_cursors: Vec<Weak<AtomicUsize>>,
+    active_subgroups: Vec<((u64, u64), Weak<SubgroupInfo>)>,
+    next_sequence: usize,
     closed: Result<(), ServeError>,
 }
+
+const MAX_PENDING_SUBGROUPS: usize = 1024;
 
 impl Default for SubgroupsState {
     fn default() -> Self {
         Self {
             latest_subgroup_reader: None,
-            epoch: 0,
+            pending_subgroups: VecDeque::new(),
+            reader_cursors: Vec::new(),
+            active_subgroups: Vec::new(),
+            next_sequence: 0,
             closed: Ok(()),
+        }
+    }
+}
+
+impl SubgroupsState {
+    fn prune_consumed(&mut self) {
+        self.reader_cursors
+            .retain(|reader| reader.strong_count() > 0);
+        let oldest_unread = self
+            .reader_cursors
+            .iter()
+            .filter_map(Weak::upgrade)
+            .map(|cursor| cursor.load(Ordering::Relaxed))
+            .min()
+            .unwrap_or(self.next_sequence);
+
+        // Preserve the current latest subgroup for a reader activated after an
+        // idle period, even when every active reader has advanced past it.
+        while self.pending_subgroups.len() > 1
+            && self
+                .pending_subgroups
+                .front()
+                .is_some_and(|(sequence, _)| *sequence < oldest_unread)
+        {
+            self.pending_subgroups.pop_front();
         }
     }
 }
@@ -120,28 +160,52 @@ impl SubgroupsWriter {
         let (writer, reader) = subgroup.produce_with_metadata(metadata);
 
         let mut state = self.state.lock_mut().ok_or(ServeError::Cancel)?;
+        state.closed.clone()?;
 
-        if let Some(latest) = &state.latest_subgroup_reader {
-            // TODO: Check this logic again
-            if writer.group_id.cmp(&latest.group_id) == cmp::Ordering::Equal {
-                match writer.subgroup_id.cmp(&latest.subgroup_id) {
-                    cmp::Ordering::Less => return Ok(writer), // dropped immediately, lul
-                    cmp::Ordering::Equal => return Err(ServeError::Duplicate),
-                    cmp::Ordering::Greater => state.latest_subgroup_reader = Some(reader),
-                }
-            } else if writer.group_id.cmp(&latest.group_id) == cmp::Ordering::Greater {
-                state.latest_subgroup_reader = Some(reader);
-            } else {
-                return Ok(writer); // drop here as well
-            }
-        } else {
-            state.latest_subgroup_reader = Some(reader);
+        state
+            .active_subgroups
+            .retain(|(_, subgroup)| subgroup.strong_count() > 0);
+        let key = (writer.group_id, writer.subgroup_id);
+        if state
+            .active_subgroups
+            .iter()
+            .any(|(active, _)| *active == key)
+        {
+            return Err(ServeError::Duplicate);
         }
 
-        self.next_subgroup_id = state.latest_subgroup_reader.as_ref().unwrap().subgroup_id + 1;
-        self.next_group_id = state.latest_subgroup_reader.as_ref().unwrap().group_id + 1;
-        self.last_group_id = state.latest_subgroup_reader.as_ref().unwrap().group_id;
-        state.epoch += 1;
+        state.prune_consumed();
+        if state.pending_subgroups.len() >= MAX_PENDING_SUBGROUPS {
+            let err =
+                ServeError::Internal("subgroup reader exceeded its pending stream limit".into());
+            state.closed = Err(err.clone());
+            return Err(err);
+        }
+
+        let sequence = state.next_sequence;
+        let Some(next_sequence) = state.next_sequence.checked_add(1) else {
+            let err = ServeError::Internal("subgroup delivery sequence exhausted".into());
+            state.closed = Err(err.clone());
+            return Err(err);
+        };
+        state.next_sequence = next_sequence;
+        state
+            .pending_subgroups
+            .push_back((sequence, reader.clone()));
+        state
+            .active_subgroups
+            .push((key, Arc::downgrade(&reader.info)));
+
+        let advances_latest = state
+            .latest_subgroup_reader
+            .as_ref()
+            .is_none_or(|latest| key > (latest.group_id, latest.subgroup_id));
+        if advances_latest {
+            self.next_subgroup_id = writer.subgroup_id.saturating_add(1);
+            self.next_group_id = writer.group_id.saturating_add(1);
+            self.last_group_id = writer.group_id;
+            state.latest_subgroup_reader = Some(reader);
+        }
 
         Ok(writer)
     }
@@ -166,11 +230,10 @@ impl Deref for SubgroupsWriter {
     }
 }
 
-#[derive(Clone)]
 pub struct SubgroupsReader {
     pub info: Arc<Track>,
     state: State<SubgroupsState>,
-    epoch: u64,
+    cursor: Option<Arc<AtomicUsize>>,
 }
 
 impl SubgroupsReader {
@@ -178,18 +241,52 @@ impl SubgroupsReader {
         Self {
             info: track_info,
             state,
-            epoch: 0,
+            cursor: None,
         }
     }
 
+    fn register(&mut self) {
+        if self.cursor.is_some() {
+            return;
+        }
+
+        let state = self.state.lock();
+        let sequence = state
+            .pending_subgroups
+            .back()
+            .map_or(state.next_sequence, |(sequence, _)| *sequence);
+        let cursor = Arc::new(AtomicUsize::new(sequence));
+        let mut state = state.into_mut_closed();
+        state
+            .reader_cursors
+            .retain(|reader| reader.strong_count() > 0);
+        state.reader_cursors.push(Arc::downgrade(&cursor));
+        self.cursor = Some(cursor);
+    }
+
     pub async fn next(&mut self) -> Result<Option<SubgroupReader>, ServeError> {
+        self.register();
+
         loop {
             {
                 let state = self.state.lock();
-
-                if self.epoch != state.epoch {
-                    self.epoch = state.epoch;
-                    return Ok(state.latest_subgroup_reader.clone());
+                if let (Some(cursor), Some((first_sequence, _))) =
+                    (&self.cursor, state.pending_subgroups.front())
+                {
+                    let sequence = cursor.load(Ordering::Relaxed);
+                    let index = sequence.checked_sub(*first_sequence).ok_or_else(|| {
+                        ServeError::Internal("subgroup reader fell behind retained history".into())
+                    })?;
+                    if let Some(subgroup) = state
+                        .pending_subgroups
+                        .get(index)
+                        .map(|(_, subgroup)| subgroup.clone())
+                    {
+                        cursor.store(sequence + 1, Ordering::Relaxed);
+                        let mut state = state.into_mut_closed();
+                        state.prune_consumed();
+                        return Ok(Some(subgroup));
+                    }
                 }
 
                 state.closed.clone()?;
@@ -200,6 +297,12 @@ impl SubgroupsReader {
             }
             .await; // Try again when the state changes
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn delivery_cursor(&mut self) -> Arc<AtomicUsize> {
+        self.register();
+        self.cursor.as_ref().cloned().unwrap()
     }
 
     // Returns the largest group/sequence
@@ -215,6 +318,41 @@ impl SubgroupsReader {
     pub fn is_closed(&self) -> bool {
         let state = self.state.lock();
         state.closed.is_err() || state.modified().is_none()
+    }
+}
+
+impl Clone for SubgroupsReader {
+    fn clone(&self) -> Self {
+        let state = self.state.lock();
+        let sequence = self.cursor.as_ref().map_or_else(
+            || {
+                state
+                    .pending_subgroups
+                    .back()
+                    .map_or(state.next_sequence, |(sequence, _)| *sequence)
+            },
+            |cursor| cursor.load(Ordering::Relaxed),
+        );
+        let cursor = Arc::new(AtomicUsize::new(sequence));
+        let mut state = state.into_mut_closed();
+        state
+            .reader_cursors
+            .retain(|reader| reader.strong_count() > 0);
+        state.reader_cursors.push(Arc::downgrade(&cursor));
+
+        Self {
+            info: self.info.clone(),
+            state: self.state.clone(),
+            cursor: Some(cursor),
+        }
+    }
+}
+
+impl Drop for SubgroupsReader {
+    fn drop(&mut self) {
+        self.cursor = None;
+        let mut state = self.state.lock().into_mut_closed();
+        state.prune_consumed();
     }
 }
 
@@ -706,10 +844,234 @@ mod tests {
         .produce()
     }
 
+    fn subgroups() -> (SubgroupsWriter, SubgroupsReader) {
+        Subgroups {
+            track: Arc::new(Track::new(TrackNamespace::from_utf8_path("test"), "track")),
+        }
+        .produce()
+    }
+
+    fn create_subgroup(
+        writer: &mut SubgroupsWriter,
+        group_id: u64,
+        subgroup_id: u64,
+    ) -> SubgroupWriter {
+        writer
+            .create(Subgroup {
+                group_id,
+                subgroup_id,
+                priority: 128,
+            })
+            .unwrap()
+    }
+
+    async fn assert_subgroups(reader: &mut SubgroupsReader, expected: &[(u64, u64)]) {
+        for &(group_id, subgroup_id) in expected {
+            let subgroup = reader.next().await.unwrap().unwrap();
+            assert_eq!(
+                (subgroup.group_id, subgroup.subgroup_id),
+                (group_id, subgroup_id)
+            );
+        }
+    }
+
     #[test]
     fn locally_created_subgroup_begins_with_first_object() {
         let (_writer, reader) = subgroup();
         assert!(reader.metadata().first_object);
+    }
+
+    #[tokio::test]
+    async fn delivers_reverse_order_subgroups() {
+        let (mut writer, template) = subgroups();
+        let mut reader = template.clone();
+
+        let _one = create_subgroup(&mut writer, 0, 1);
+        let _zero = create_subgroup(&mut writer, 0, 0);
+
+        assert_subgroups(&mut reader, &[(0, 1), (0, 0)]).await;
+    }
+
+    #[tokio::test]
+    async fn delivers_burst_without_coalescing() {
+        let (mut writer, template) = subgroups();
+        let mut reader = template.clone();
+
+        let _zero = create_subgroup(&mut writer, 0, 0);
+        let _one = create_subgroup(&mut writer, 0, 1);
+
+        assert_subgroups(&mut reader, &[(0, 0), (0, 1)]).await;
+    }
+
+    #[tokio::test]
+    async fn delivers_two_groups_in_arrival_order() {
+        let (mut writer, template) = subgroups();
+        let mut reader = template.clone();
+        let mut subgroups = Vec::new();
+        let expected = [(0, 1), (0, 0), (1, 1), (1, 0)];
+
+        for &(group_id, subgroup_id) in &expected {
+            subgroups.push(create_subgroup(&mut writer, group_id, subgroup_id));
+        }
+
+        assert_subgroups(&mut reader, &expected).await;
+    }
+
+    #[tokio::test]
+    async fn cloned_reader_inherits_pending_and_future_subgroups() {
+        let (mut writer, template) = subgroups();
+        let mut first = template.clone();
+        let _zero = create_subgroup(&mut writer, 0, 0);
+        let mut second = first.clone();
+        let _one = create_subgroup(&mut writer, 0, 1);
+
+        assert_subgroups(&mut first, &[(0, 0), (0, 1)]).await;
+        assert_subgroups(&mut second, &[(0, 0), (0, 1)]).await;
+    }
+
+    #[tokio::test]
+    async fn cloned_readers_receive_subgroups_independently() {
+        let (mut writer, template) = subgroups();
+        let mut first = template.clone();
+        let mut second = template.clone();
+        let _zero = create_subgroup(&mut writer, 0, 0);
+        let _one = create_subgroup(&mut writer, 0, 1);
+
+        assert_subgroups(&mut second, &[(0, 0), (0, 1)]).await;
+        assert_subgroups(&mut first, &[(0, 0), (0, 1)]).await;
+    }
+
+    #[test]
+    fn rejects_active_duplicate_after_out_of_order_delivery() {
+        let (mut writer, template) = subgroups();
+        let _reader = template.clone();
+        let _one = create_subgroup(&mut writer, 0, 1);
+        let _zero = create_subgroup(&mut writer, 0, 0);
+
+        assert!(matches!(
+            writer.create(Subgroup {
+                group_id: 0,
+                subgroup_id: 0,
+                priority: 128,
+            }),
+            Err(ServeError::Duplicate)
+        ));
+    }
+
+    #[tokio::test]
+    async fn backlog_overflow_closes_the_subgroup_source() {
+        let (mut writer, template) = subgroups();
+        let mut reader = template.clone();
+        let mut open = Vec::new();
+        for group_id in 0..MAX_PENDING_SUBGROUPS as u64 {
+            open.push(create_subgroup(&mut writer, group_id, 0));
+        }
+
+        assert!(matches!(
+            writer.create(Subgroup {
+                group_id: MAX_PENDING_SUBGROUPS as u64,
+                subgroup_id: 0,
+                priority: 128,
+            }),
+            Err(ServeError::Internal(_))
+        ));
+
+        for group_id in 0..MAX_PENDING_SUBGROUPS as u64 {
+            assert_subgroups(&mut reader, &[(group_id, 0)]).await;
+        }
+        assert!(matches!(reader.next().await, Err(ServeError::Internal(_))));
+        assert!(matches!(
+            writer.create(Subgroup {
+                group_id: MAX_PENDING_SUBGROUPS as u64,
+                subgroup_id: 0,
+                priority: 128,
+            }),
+            Err(ServeError::Internal(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn consumed_history_does_not_exhaust_the_bound() {
+        let (mut writer, template) = subgroups();
+        let mut reader = template.clone();
+
+        for group_id in 0..(MAX_PENDING_SUBGROUPS as u64 * 2) {
+            let _subgroup = create_subgroup(&mut writer, group_id, 0);
+            assert_subgroups(&mut reader, &[(group_id, 0)]).await;
+        }
+
+        assert_eq!(writer.state.lock().pending_subgroups.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn terminal_history_is_pruned_as_the_reader_advances() {
+        let (mut writer, template) = subgroups();
+        let mut reader = template.clone();
+
+        for group_id in 0..8 {
+            let _subgroup = create_subgroup(&mut writer, group_id, 0);
+        }
+        drop(writer);
+
+        for group_id in 0..8 {
+            assert_subgroups(&mut reader, &[(group_id, 0)]).await;
+        }
+        assert_eq!(reader.state.lock().pending_subgroups.len(), 1);
+        assert!(reader.next().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn dropping_the_slowest_reader_prunes_terminal_history() {
+        let (mut writer, template) = subgroups();
+        let mut fast = template.clone();
+        let slow = fast.clone();
+
+        for group_id in 0..8 {
+            let _subgroup = create_subgroup(&mut writer, group_id, 0);
+        }
+        drop(writer);
+        for group_id in 0..8 {
+            assert_subgroups(&mut fast, &[(group_id, 0)]).await;
+        }
+        assert_eq!(fast.state.lock().pending_subgroups.len(), 8);
+
+        drop(slow);
+        assert_eq!(fast.state.lock().pending_subgroups.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn delivery_sequence_exhaustion_closes_the_source() {
+        let (mut writer, template) = subgroups();
+        let mut reader = template.clone();
+        writer.state.lock_mut().unwrap().next_sequence = usize::MAX;
+
+        assert!(matches!(
+            writer.create(Subgroup {
+                group_id: 0,
+                subgroup_id: 0,
+                priority: 128,
+            }),
+            Err(ServeError::Internal(_))
+        ));
+        assert!(matches!(reader.next().await, Err(ServeError::Internal(_))));
+    }
+
+    #[tokio::test]
+    async fn dropping_a_slow_reader_releases_backlog_capacity() {
+        let (mut writer, template) = subgroups();
+        let mut fast = template.clone();
+        let slow = fast.clone();
+
+        for group_id in 0..(MAX_PENDING_SUBGROUPS as u64 - 1) {
+            let _subgroup = create_subgroup(&mut writer, group_id, 0);
+            assert_subgroups(&mut fast, &[(group_id, 0)]).await;
+        }
+
+        drop(slow);
+        for group_id in (MAX_PENDING_SUBGROUPS as u64 - 1)..=(MAX_PENDING_SUBGROUPS as u64) {
+            let _subgroup = create_subgroup(&mut writer, group_id, 0);
+            assert_subgroups(&mut fast, &[(group_id, 0)]).await;
+        }
     }
 
     #[tokio::test]

--- a/moq-transport/src/session/subscribe.rs
+++ b/moq-transport/src/session/subscribe.rs
@@ -644,6 +644,69 @@ mod tests {
         assert!(datagram.extension_headers.has(2));
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn publish_done_drain_preserves_reverse_order_subgroups() {
+        let (_send, mut recv, reader) = test_recv_with_reader().await;
+        recv.ok(42, 200).unwrap();
+        assert_eq!(recv.recv_done(ServeError::Done, 2), DoneOutcome::DrainArmed);
+
+        recv.note_stream_received();
+        let mut one = recv
+            .subgroup(data::SubgroupHeader {
+                header_type: data::StreamHeaderType::SubgroupIdDefaultPriorityFirstObject,
+                track_alias: 42,
+                group_id: 0,
+                subgroup_id: Some(1),
+                publisher_priority: 128,
+            })
+            .unwrap();
+        for object_id in [3, 5] {
+            let mut object = one.create_with_id(object_id, 1, None).unwrap();
+            object
+                .write(bytes::Bytes::from(vec![object_id as u8]))
+                .unwrap();
+        }
+        drop(one);
+        assert!(!recv.note_stream_finished());
+
+        let serve::TrackReaderMode::Subgroups(mut subgroups) = reader.mode().await.unwrap() else {
+            panic!("expected subgroup delivery");
+        };
+
+        recv.note_stream_received();
+        let mut zero = recv
+            .subgroup(data::SubgroupHeader {
+                header_type:
+                    data::StreamHeaderType::SubgroupZeroIdEndOfGroupDefaultPriorityFirstObject,
+                track_alias: 42,
+                group_id: 0,
+                subgroup_id: None,
+                publisher_priority: 128,
+            })
+            .unwrap();
+        for object_id in [4, 6] {
+            let mut object = zero.create_with_id(object_id, 1, None).unwrap();
+            object
+                .write(bytes::Bytes::from(vec![object_id as u8]))
+                .unwrap();
+        }
+        drop(zero);
+        assert!(recv.note_stream_finished());
+
+        for (subgroup_id, object_ids) in [(1, [3, 5]), (0, [4, 6])] {
+            let mut subgroup = subgroups.next().await.unwrap().unwrap();
+            assert_eq!(subgroup.subgroup_id, subgroup_id);
+            for object_id in object_ids {
+                let mut object = subgroup.next().await.unwrap().unwrap();
+                assert_eq!(object.object_id, object_id);
+                assert_eq!(
+                    object.read_all().await.unwrap().as_ref(),
+                    &[object_id as u8]
+                );
+            }
+        }
+    }
+
     /// §10.11: the request stream can die while a data stream is still being
     /// read. Tearing down here discards Objects already in flight — the same
     /// loss the drain exists to prevent.

--- a/moq-transport/src/session/subscribed.rs
+++ b/moq-transport/src/session/subscribed.rs
@@ -21,6 +21,8 @@ use super::{DeliveryError, DeliveryFilter, Publisher, SessionError, SubscribeInf
 
 // This file defines Publisher handling of inbound Subscriptions
 
+const MAX_CONCURRENT_SUBGROUPS: usize = 128;
+
 #[derive(Debug)]
 struct ObjectForwarderState {
     largest_location: Option<Location>,
@@ -677,7 +679,7 @@ impl ObjectForwarder {
 
         loop {
             tokio::select! {
-                res = subgroups.next(), if done.is_none() => match res {
+                res = subgroups.next(), if done.is_none() && tasks.len() < MAX_CONCURRENT_SUBGROUPS => match res {
                     Ok(Some(subgroup)) => {
                         let publisher = self.publisher.clone();
                         let state = self.state.clone();
@@ -1353,6 +1355,208 @@ mod tests {
         reader
     }
 
+    async fn forward_mixed_subgroups(
+        publisher_session: web_transport::Session,
+        peer_session: web_transport::Session,
+    ) {
+        let (outgoing, _outgoing_recv) = crate::watch::Queue::default().split();
+        let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+        let publisher = Publisher::new(
+            outgoing,
+            publisher_session,
+            None,
+            crate::session::RequestId::new(0, 1),
+            bidi_task_tx,
+        );
+        let (mut forwarder, _recv) = ObjectForwarder::new(publisher, 42, None);
+        let (track_writer, track_reader) = serve::Track::new(
+            crate::coding::TrackNamespace::from_utf8_path("test"),
+            "mixed",
+        )
+        .produce();
+        let mut subgroups_writer = track_writer.subgroups().unwrap();
+        let serve::TrackReaderMode::Subgroups(subgroups_reader) =
+            track_reader.mode().await.unwrap()
+        else {
+            panic!("expected subgroup delivery");
+        };
+
+        for (subgroup_id, object_ids, end_of_group) in [(1, [3, 5], false), (0, [4, 6], true)] {
+            let mut subgroup = subgroups_writer
+                .create_with_metadata(
+                    serve::Subgroup {
+                        group_id: 0,
+                        subgroup_id,
+                        priority: 200,
+                    },
+                    serve::SubgroupStreamMetadata {
+                        has_properties: false,
+                        end_of_group,
+                        first_object: true,
+                    },
+                )
+                .unwrap();
+            for object_id in object_ids {
+                let mut object = subgroup.create_with_id(object_id, 1, None).unwrap();
+                object.write(Bytes::from(vec![object_id as u8])).unwrap();
+            }
+        }
+        drop(subgroups_writer);
+
+        let receive = async move {
+            let mut received = Vec::new();
+            for _ in 0..2 {
+                let stream = peer_session.accept_uni().await.unwrap();
+                let mut reader = Reader::new(stream);
+                let stream_header: data::StreamHeader = reader.decode().await.unwrap();
+                let header = stream_header.subgroup_header.unwrap();
+                assert_eq!(header.track_alias, 42);
+                assert!(header.header_type.begins_with_first_object());
+                assert_eq!(
+                    header.header_type.end_of_group(),
+                    header.subgroup_id == Some(0)
+                );
+
+                let mut previous = None;
+                for _ in 0..2 {
+                    let object: data::SubgroupObject = reader.decode().await.unwrap();
+                    let object_id =
+                        data::decode_object_id_delta(&mut previous, object.object_id_delta)
+                            .unwrap();
+                    let payload = reader
+                        .read_chunk(object.payload_length)
+                        .await
+                        .unwrap()
+                        .unwrap();
+                    assert_eq!(payload.as_ref(), &[object_id as u8]);
+                    received.push((header.group_id, header.subgroup_id.unwrap(), object_id));
+                }
+                assert!(reader.done().await.unwrap());
+            }
+            received.sort_unstable();
+            received
+        };
+        let send = forwarder.serve_subgroups(
+            subgroups_reader,
+            DeliveryFilter {
+                forward: true,
+                start_location: None,
+                end_group_id: None,
+            },
+        );
+
+        let (send, received) = tokio::join!(send, receive);
+        send.unwrap();
+        assert_eq!(forwarder.stream_count.get(), 2);
+        assert_eq!(received, [(0, 0, 4), (0, 0, 6), (0, 1, 3), (0, 1, 5),]);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn subgroup_forwarding_limits_blocked_tasks() {
+        let (publisher_session, peer_session) = loopback_session_pair().await;
+        let (outgoing, _outgoing_recv) = crate::watch::Queue::default().split();
+        let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+        let publisher = Publisher::new(
+            outgoing,
+            publisher_session,
+            None,
+            crate::session::RequestId::new(0, 1),
+            bidi_task_tx,
+        );
+        let (mut forwarder, _recv) = ObjectForwarder::new(publisher, 42, None);
+        let (track_writer, track_reader) = serve::Track::new(
+            crate::coding::TrackNamespace::from_utf8_path("test"),
+            "bounded",
+        )
+        .produce();
+        let mut subgroups_writer = track_writer.subgroups().unwrap();
+        let serve::TrackReaderMode::Subgroups(mut subgroups_reader) =
+            track_reader.mode().await.unwrap()
+        else {
+            panic!("expected subgroup delivery");
+        };
+        let delivery_cursor = subgroups_reader.delivery_cursor();
+
+        let mut blocked = Vec::new();
+        for group_id in 0..MAX_CONCURRENT_SUBGROUPS as u64 {
+            blocked.push(
+                subgroups_writer
+                    .create(serve::Subgroup {
+                        group_id,
+                        subgroup_id: 0,
+                        priority: 128,
+                    })
+                    .unwrap(),
+            );
+        }
+        let mut admitted_after_capacity = subgroups_writer
+            .create(serve::Subgroup {
+                group_id: MAX_CONCURRENT_SUBGROUPS as u64,
+                subgroup_id: 0,
+                priority: 128,
+            })
+            .unwrap();
+        admitted_after_capacity
+            .write(Bytes::from_static(b"x"))
+            .unwrap();
+        drop(admitted_after_capacity);
+        drop(subgroups_writer);
+
+        let send = tokio::spawn(async move {
+            forwarder
+                .serve_subgroups(
+                    subgroups_reader,
+                    DeliveryFilter {
+                        forward: true,
+                        start_location: None,
+                        end_group_id: None,
+                    },
+                )
+                .await
+        });
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while delivery_cursor.load(Ordering::Relaxed) < MAX_CONCURRENT_SUBGROUPS {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        for _ in 0..4 {
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(
+            delivery_cursor.load(Ordering::Relaxed),
+            MAX_CONCURRENT_SUBGROUPS
+        );
+
+        blocked.pop();
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while delivery_cursor.load(Ordering::Relaxed) == MAX_CONCURRENT_SUBGROUPS {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        assert_eq!(
+            delivery_cursor.load(Ordering::Relaxed),
+            MAX_CONCURRENT_SUBGROUPS + 1
+        );
+        let stream =
+            tokio::time::timeout(std::time::Duration::from_secs(2), peer_session.accept_uni())
+                .await
+                .unwrap()
+                .unwrap();
+        let mut reader = Reader::new(stream);
+        let header: data::StreamHeader = reader.decode().await.unwrap();
+        assert_eq!(
+            header.subgroup_header.unwrap().group_id,
+            MAX_CONCURRENT_SUBGROUPS as u64
+        );
+
+        drop(blocked);
+        send.await.unwrap().unwrap();
+    }
+
     fn assert_payload_datagram((received, largest): (data::Datagram, Option<Location>)) {
         assert_eq!(
             received.datagram_type,
@@ -1378,6 +1582,18 @@ mod tests {
     async fn forwards_datagram_semantics_over_raw_quic() {
         let (publisher, peer) = loopback_raw_session_pair().await;
         assert_payload_datagram(forward_datagram(publisher, peer, payload_datagram()).await);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn forwards_mixed_reverse_order_subgroups_over_webtransport() {
+        let (publisher, peer) = loopback_session_pair().await;
+        forward_mixed_subgroups(publisher, peer).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn forwards_mixed_reverse_order_subgroups_over_raw_quic() {
+        let (publisher, peer) = loopback_raw_session_pair().await;
+        forward_mixed_subgroups(publisher, peer).await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/moq-transport/src/session/subscribed.rs
+++ b/moq-transport/src/session/subscribed.rs
@@ -665,6 +665,7 @@ impl ObjectForwarder {
         mut subgroups: serve::SubgroupsReader,
         delivery_filter: DeliveryFilter,
     ) -> Result<(), SessionError> {
+        let lag_watcher = subgroups.lag_watcher();
         let mut tasks = FuturesUnordered::new();
         let mut done: Option<Result<(), ServeError>> = None;
         // A subgroup that could not be sent means the peer did not receive
@@ -679,6 +680,11 @@ impl ObjectForwarder {
 
         loop {
             tokio::select! {
+                _ = lag_watcher.lagged(), if done.is_none() => {
+                    return Err(ServeError::Internal(
+                        "subgroup reader exceeded its pending stream limit".into(),
+                    ).into());
+                },
                 res = subgroups.next(), if done.is_none() && tasks.len() < MAX_CONCURRENT_SUBGROUPS => match res {
                     Ok(Some(subgroup)) => {
                         let publisher = self.publisher.clone();
@@ -1445,7 +1451,11 @@ mod tests {
             },
         );
 
-        let (send, received) = tokio::join!(send, receive);
+        let (send, received) = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            tokio::join!(send, receive)
+        })
+        .await
+        .unwrap();
         send.unwrap();
         assert_eq!(forwarder.stream_count.get(), 2);
         assert_eq!(received, [(0, 0, 4), (0, 0, 6), (0, 1, 3), (0, 1, 5),]);
@@ -1554,7 +1564,100 @@ mod tests {
         );
 
         drop(blocked);
-        send.await.unwrap().unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(2), send)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn lagged_forwarder_is_cancelled_without_disrupting_a_healthy_reader() {
+        let (publisher_session, _peer_session) = loopback_session_pair().await;
+        let (outgoing, _outgoing_recv) = crate::watch::Queue::default().split();
+        let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+        let publisher = Publisher::new(
+            outgoing,
+            publisher_session,
+            None,
+            crate::session::RequestId::new(0, 1),
+            bidi_task_tx,
+        );
+        let (mut forwarder, _recv) = ObjectForwarder::new(publisher, 42, None);
+        let (track_writer, track_reader) = serve::Track::new(
+            crate::coding::TrackNamespace::from_utf8_path("test"),
+            "isolated",
+        )
+        .produce();
+        let mut subgroups_writer = track_writer.subgroups().unwrap();
+        let serve::TrackReaderMode::Subgroups(subgroups_reader) =
+            track_reader.mode().await.unwrap()
+        else {
+            panic!("expected subgroup delivery");
+        };
+        let mut healthy = subgroups_reader.clone();
+
+        let mut blocked = Vec::new();
+        for group_id in 0..MAX_CONCURRENT_SUBGROUPS as u64 {
+            blocked.push(
+                subgroups_writer
+                    .create(serve::Subgroup {
+                        group_id,
+                        subgroup_id: 0,
+                        priority: 128,
+                    })
+                    .unwrap(),
+            );
+            let delivered = healthy.next().await.unwrap().unwrap();
+            assert_eq!(delivered.group_id, group_id);
+        }
+
+        let send = tokio::spawn(async move {
+            forwarder
+                .serve_subgroups(
+                    subgroups_reader,
+                    DeliveryFilter {
+                        forward: true,
+                        start_location: None,
+                        end_group_id: None,
+                    },
+                )
+                .await
+        });
+        tokio::task::yield_now().await;
+
+        for offset in 0..=serve::MAX_PENDING_SUBGROUPS as u64 {
+            let group_id = MAX_CONCURRENT_SUBGROUPS as u64 + offset;
+            let subgroup = subgroups_writer
+                .create(serve::Subgroup {
+                    group_id,
+                    subgroup_id: 0,
+                    priority: 128,
+                })
+                .unwrap();
+            drop(subgroup);
+            let delivered = healthy.next().await.unwrap().unwrap();
+            assert_eq!(delivered.group_id, group_id);
+        }
+
+        let err = tokio::time::timeout(std::time::Duration::from_secs(2), send)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap_err();
+        assert!(matches!(err, SessionError::Serve(ServeError::Internal(_))));
+
+        let next_group = MAX_CONCURRENT_SUBGROUPS as u64 + serve::MAX_PENDING_SUBGROUPS as u64 + 1;
+        let _next = subgroups_writer
+            .create(serve::Subgroup {
+                group_id: next_group,
+                subgroup_id: 0,
+                priority: 128,
+            })
+            .unwrap();
+        let delivered = healthy.next().await.unwrap().unwrap();
+        assert_eq!(delivered.group_id, next_group);
+        drop(blocked);
     }
 
     fn assert_payload_datagram((received, largest): (data::Datagram, Option<Location>)) {

--- a/moq-transport/src/session/subscriber.rs
+++ b/moq-transport/src/session/subscriber.rs
@@ -2513,6 +2513,103 @@ mod tests {
         writer.finish().unwrap();
     }
 
+    async fn send_subgroup_objects(
+        session: &web_transport::Session,
+        header: data::SubgroupHeader,
+        object_ids: &[u64],
+    ) {
+        let stream = session.open_uni().await.unwrap();
+        let mut writer = Writer::new(stream);
+        writer.encode(&header).await.unwrap();
+        let mut previous = None;
+        for &object_id in object_ids {
+            writer
+                .encode(&data::SubgroupObject {
+                    object_id_delta: data::encode_object_id_delta(&mut previous, object_id)
+                        .unwrap(),
+                    payload_length: 1,
+                    status: None,
+                })
+                .await
+                .unwrap();
+            writer.write(&[object_id as u8]).await.unwrap();
+        }
+        writer.finish().unwrap();
+    }
+
+    async fn receive_subgroup_stream(
+        receiver_session: &web_transport::Session,
+        subscriber: &Subscriber,
+    ) {
+        let stream = receiver_session.accept_uni().await.unwrap();
+        Subscriber::recv_stream(subscriber.clone(), stream)
+            .await
+            .unwrap();
+    }
+
+    async fn assert_mixed_subgroups_ingress(
+        receiver_session: web_transport::Session,
+        peer_session: web_transport::Session,
+        transport: super::super::Transport,
+    ) {
+        let subscriber = test_subscriber_for_transport(receiver_session.clone(), transport);
+        let (track_writer, track_reader) =
+            serve::Track::new(TrackNamespace::from_utf8_path("test/ns"), "mixed").produce();
+        let _subscribe =
+            register_test_subscribe_with_priority(&subscriber, track_writer, 0, 42, 200);
+
+        let send_one = send_subgroup_objects(
+            &peer_session,
+            data::SubgroupHeader {
+                header_type: data::StreamHeaderType::SubgroupIdDefaultPriorityFirstObject,
+                track_alias: 42,
+                group_id: 0,
+                subgroup_id: Some(1),
+                publisher_priority: 128,
+            },
+            &[3, 5],
+        );
+        let receive_one = receive_subgroup_stream(&receiver_session, &subscriber);
+        tokio::join!(send_one, receive_one);
+
+        let serve::TrackReaderMode::Subgroups(mut subgroups) = track_reader.mode().await.unwrap()
+        else {
+            panic!("expected subgroup delivery");
+        };
+        let mut one = subgroups.next().await.unwrap().unwrap();
+        assert_eq!(one.subgroup_id, 1);
+        for expected in [3, 5] {
+            let mut object = one.next().await.unwrap().unwrap();
+            assert_eq!(object.object_id, expected);
+            assert_eq!(object.read_all().await.unwrap().as_ref(), &[expected as u8]);
+        }
+
+        let send_zero = send_subgroup_objects(
+            &peer_session,
+            data::SubgroupHeader {
+                header_type:
+                    data::StreamHeaderType::SubgroupZeroIdEndOfGroupDefaultPriorityFirstObject,
+                track_alias: 42,
+                group_id: 0,
+                subgroup_id: None,
+                publisher_priority: 128,
+            },
+            &[4, 6],
+        );
+        let receive_zero = receive_subgroup_stream(&receiver_session, &subscriber);
+        tokio::join!(send_zero, receive_zero);
+
+        let mut zero = subgroups.next().await.unwrap().unwrap();
+        assert_eq!(zero.subgroup_id, 0);
+        assert!(zero.metadata().first_object);
+        assert!(zero.metadata().end_of_group);
+        for expected in [4, 6] {
+            let mut object = zero.next().await.unwrap().unwrap();
+            assert_eq!(object.object_id, expected);
+            assert_eq!(object.read_all().await.unwrap().as_ref(), &[expected as u8]);
+        }
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn decoded_subgroup_object_ids_are_preserved() {
         let (receiver_session, peer_session) = loopback_session_pair().await;
@@ -2538,6 +2635,18 @@ mod tests {
             assert_eq!(object.object_id, expected_object_id);
             assert_eq!(object.read_all().await.unwrap().as_ref(), &[0]);
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn receives_mixed_reverse_order_subgroups_over_webtransport() {
+        let (receiver, peer) = loopback_session_pair().await;
+        assert_mixed_subgroups_ingress(receiver, peer, super::super::Transport::WebTransport).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn receives_mixed_reverse_order_subgroups_over_raw_quic() {
+        let (receiver, peer) = loopback_raw_session_pair().await;
+        assert_mixed_subgroups_ingress(receiver, peer, super::super::Transport::RawQuic).await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/moq-transport/src/session/subscriber.rs
+++ b/moq-transport/src/session/subscriber.rs
@@ -2640,13 +2640,23 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn receives_mixed_reverse_order_subgroups_over_webtransport() {
         let (receiver, peer) = loopback_session_pair().await;
-        assert_mixed_subgroups_ingress(receiver, peer, super::super::Transport::WebTransport).await;
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            assert_mixed_subgroups_ingress(receiver, peer, super::super::Transport::WebTransport),
+        )
+        .await
+        .unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn receives_mixed_reverse_order_subgroups_over_raw_quic() {
         let (receiver, peer) = loopback_raw_session_pair().await;
-        assert_mixed_subgroups_ingress(receiver, peer, super::super::Transport::RawQuic).await;
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            assert_mixed_subgroups_ingress(receiver, peer, super::super::Transport::RawQuic),
+        )
+        .await
+        .unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## Summary

Preserve subgroup fanout when streams arrive in bursts or with out-of-order subgroup IDs. Each active reader receives subgroup announcements in arrival order, while a reader that falls more than 1,024 subgroup announcements behind is cancelled independently without closing the source or disrupting healthy readers.

Late consumers receive the bounded initial subscription backlog or a snapshot of every currently live subgroup stream. Reset and forced out-of-order continuation streams may reuse a logical subgroup identity, while recent public duplicate creation remains rejected. Logical subgroup priority remains consistent across continuations, with mismatches ending the source as `MALFORMED_TRACK`.

Largest Object tracking is independent of subgroup ID ordering. Concurrent forwarding is capped at 128 tasks per subscription, concurrently live subgroup streams are capped at 1,024 with `EXCESSIVE_LOAD`, and recent logical metadata is retained in a bounded 1,024-entry registry.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p moq-transport --locked` (448 tests passed)
- `cargo build --workspace --locked`
- `cargo clippy --workspace --all-targets --locked` (pre-existing warnings only)
- Independent concurrency, protocol, API-semantics, memory, and test reviews

Pinned moxygen revision `0d886e3e907e2236a6d927afefd09bb0c3dc8211`:

- Focused section-3 test 5: baseline failed and candidate passed over raw QUIC and WebTransport
- Supported sections 1-7: baseline 32/41, candidate 34/41 over raw QUIC
- Supported sections 1-7: baseline 32/41, candidate 34/41 over WebTransport
- No baseline passing case regressed
- FETCH and section-8 PUBLISH/SUBSCRIBE_TRACKS cases were excluded because those paths are unsupported

## Limitations

- This change bounds subgroup announcement history, live subgroup metadata, and forwarding task count. Existing per-stream object and payload chunk storage remains append-only and is not byte-bounded by this change.
- End-of-group Object status is currently decoded and recreated as `NormalObject`. That separate pre-existing issue accounts for the seven remaining conformance failures and is not changed here.
- Exact duplicate history for arbitrary subgroup IDs cannot be retained forever with bounded memory. Public creation rejects duplicates retained in the bounded recent registry; transport ingress permits draft-18 reset and forced out-of-order continuation streams.