### PR TITLE
fix(moq-transport): preserve subgroup object status

### DIFF
--- a/moq-transport/src/serve/subgroup.rs
+++ b/moq-transport/src/serve/subgroup.rs
@@ -729,28 +729,50 @@ impl SubgroupWriter {
         size: usize,
         extension_headers: Option<crate::data::ExtensionHeaders>,
     ) -> Result<SubgroupObjectWriter, ServeError> {
+        self.create_with_id_and_status(
+            object_id,
+            size,
+            ObjectStatus::NormalObject,
+            extension_headers,
+        )
+    }
+
+    pub(crate) fn create_with_id_and_status(
+        &mut self,
+        object_id: u64,
+        size: usize,
+        status: ObjectStatus,
+        extension_headers: Option<crate::data::ExtensionHeaders>,
+    ) -> Result<SubgroupObjectWriter, ServeError> {
         let next_object_id = self.next_object_id.ok_or(ServeError::Duplicate)?;
         if object_id < next_object_id {
             return Err(ServeError::Duplicate);
         }
 
+        let extension_headers = extension_headers.unwrap_or_default();
+        if status != ObjectStatus::NormalObject && (size != 0 || !extension_headers.is_empty()) {
+            return Err(ServeError::Size);
+        }
+
         let group_id = self.group_id;
-        if let Some(parent) = &self.parent {
-            let mut state = parent.state.lock().into_mut_closed();
-            let location = (group_id, object_id);
-            state.largest_location = Some(
-                state
-                    .largest_location
-                    .map_or(location, |largest| largest.max(location)),
-            );
+        if status == ObjectStatus::NormalObject {
+            if let Some(parent) = &self.parent {
+                let mut state = parent.state.lock().into_mut_closed();
+                let location = (group_id, object_id);
+                state.largest_location = Some(
+                    state
+                        .largest_location
+                        .map_or(location, |largest| largest.max(location)),
+                );
+            }
         }
 
         let (writer, reader) = SubgroupObject {
             group: self.info.clone(),
             object_id,
-            status: ObjectStatus::NormalObject,
+            status,
             size,
-            extension_headers: extension_headers.unwrap_or_default(),
+            extension_headers,
         }
         .produce();
 
@@ -1657,6 +1679,58 @@ mod tests {
         drop(low_subgroup.create_with_id(100, 0, None).unwrap());
 
         assert_eq!(reader.latest(), Some((0, 100)));
+    }
+
+    #[tokio::test]
+    async fn status_aware_creation_preserves_status_and_largest_location() {
+        let (mut writer, template) = subgroups();
+        let mut reader = template.clone();
+        let mut subgroup = create_subgroup(&mut writer, 0, 0);
+        drop(subgroup.create_with_id(5, 0, None).unwrap());
+        drop(
+            subgroup
+                .create_with_id_and_status(6, 0, ObjectStatus::EndOfGroup, None)
+                .unwrap(),
+        );
+        let mut end_track = create_subgroup(&mut writer, 1, 0);
+        drop(
+            end_track
+                .create_with_id_and_status(7, 0, ObjectStatus::EndOfTrack, None)
+                .unwrap(),
+        );
+
+        let mut subgroup = reader.next().await.unwrap().unwrap();
+        for (object_id, status) in [
+            (5, ObjectStatus::NormalObject),
+            (6, ObjectStatus::EndOfGroup),
+        ] {
+            let object = subgroup.next().await.unwrap().unwrap();
+            assert_eq!(object.object_id, object_id);
+            assert_eq!(object.status, status);
+            assert_eq!(object.size, 0);
+        }
+        let mut end_track = reader.next().await.unwrap().unwrap();
+        let object = end_track.next().await.unwrap().unwrap();
+        assert_eq!(object.object_id, 7);
+        assert_eq!(object.status, ObjectStatus::EndOfTrack);
+        assert_eq!(object.size, 0);
+        assert_eq!(reader.latest(), Some((0, 5)));
+    }
+
+    #[test]
+    fn status_aware_creation_rejects_payload_and_properties() {
+        let (mut writer, _reader) = subgroup();
+        assert!(matches!(
+            writer.create_with_id_and_status(0, 1, ObjectStatus::EndOfGroup, None),
+            Err(ServeError::Size)
+        ));
+
+        let mut properties = crate::data::ExtensionHeaders::new();
+        properties.set_intvalue(2, 1);
+        assert!(matches!(
+            writer.create_with_id_and_status(0, 0, ObjectStatus::EndOfGroup, Some(properties),),
+            Err(ServeError::Size)
+        ));
     }
 
     #[tokio::test]

--- a/moq-transport/src/session/subscribed.rs
+++ b/moq-transport/src/session/subscribed.rs
@@ -936,13 +936,15 @@ impl ObjectForwarder {
 
             // Check cancellation before the object header commits us to its
             // payload length.
-            state
-                .lock_mut()
-                .ok_or(ServeError::Done)?
-                .update_largest_location(
-                    subgroup_reader.group_id,
-                    subgroup_object_reader.object_id,
-                )?;
+            {
+                let mut forwarder_state = state.lock_mut().ok_or(ServeError::Done)?;
+                if subgroup_object_reader.status == data::ObjectStatus::NormalObject {
+                    forwarder_state.update_largest_location(
+                        subgroup_reader.group_id,
+                        subgroup_object_reader.object_id,
+                    )?;
+                }
+            }
 
             if header.header_type.has_properties() {
                 let subgroup_object = data::SubgroupObjectExt {
@@ -1461,6 +1463,142 @@ mod tests {
         assert_eq!(received, [(0, 0, 4), (0, 0, 6), (0, 1, 3), (0, 1, 5),]);
     }
 
+    async fn forward_subgroup_statuses(
+        publisher_session: web_transport::Session,
+        peer_session: web_transport::Session,
+    ) {
+        let (outgoing, _outgoing_recv) = crate::watch::Queue::default().split();
+        let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+        let publisher = Publisher::new(
+            outgoing,
+            publisher_session,
+            None,
+            crate::session::RequestId::new(0, 1),
+            bidi_task_tx,
+        );
+        let (mut forwarder, _recv) = ObjectForwarder::new(publisher, 42, None);
+        let (track_writer, track_reader) = serve::Track::new(
+            crate::coding::TrackNamespace::from_utf8_path("test"),
+            "status",
+        )
+        .produce();
+        let mut subgroups_writer = track_writer.subgroups().unwrap();
+        let serve::TrackReaderMode::Subgroups(subgroups_reader) =
+            track_reader.mode().await.unwrap()
+        else {
+            panic!("expected subgroup delivery");
+        };
+
+        for (group_id, object_id, status, has_properties) in [
+            (0, 6, data::ObjectStatus::EndOfGroup, false),
+            (1, 7, data::ObjectStatus::EndOfTrack, true),
+        ] {
+            let mut subgroup = subgroups_writer
+                .create_with_metadata(
+                    serve::Subgroup {
+                        group_id,
+                        subgroup_id: 0,
+                        priority: 200,
+                    },
+                    serve::SubgroupStreamMetadata {
+                        has_properties,
+                        end_of_group: true,
+                        first_object: true,
+                    },
+                )
+                .unwrap();
+            if group_id == 0 {
+                for normal_object_id in [3, 5] {
+                    let mut object = subgroup.create_with_id(normal_object_id, 1, None).unwrap();
+                    object
+                        .write(Bytes::from(vec![normal_object_id as u8]))
+                        .unwrap();
+                }
+            }
+            drop(
+                subgroup
+                    .create_with_id_and_status(object_id, 0, status, None)
+                    .unwrap(),
+            );
+        }
+        drop(subgroups_writer);
+
+        let receive = async move {
+            let mut received = Vec::new();
+            for _ in 0..2 {
+                let stream = peer_session.accept_uni().await.unwrap();
+                let mut reader = Reader::new(stream);
+                let stream_header: data::StreamHeader = reader.decode().await.unwrap();
+                let header = stream_header.subgroup_header.unwrap();
+                assert_eq!(header.subgroup_id, Some(0));
+                let (normal_objects, expected_object, expected_status, expected_properties) =
+                    match header.group_id {
+                        0 => (&[3, 5][..], 6, data::ObjectStatus::EndOfGroup, false),
+                        1 => (&[][..], 7, data::ObjectStatus::EndOfTrack, true),
+                        group_id => panic!("unexpected group {group_id}"),
+                    };
+                assert_eq!(header.header_type.has_properties(), expected_properties);
+                let mut previous = None;
+
+                for &expected in normal_objects {
+                    let object: data::SubgroupObject = reader.decode().await.unwrap();
+                    let object_id =
+                        data::decode_object_id_delta(&mut previous, object.object_id_delta)
+                            .unwrap();
+                    assert_eq!(object_id, expected);
+                    assert_eq!(object.payload_length, 1);
+                    assert_eq!(object.status, None);
+                    assert_eq!(
+                        reader.read_chunk(1).await.unwrap().unwrap().as_ref(),
+                        &[expected as u8]
+                    );
+                }
+
+                if expected_properties {
+                    let object: data::SubgroupObjectExt = reader.decode().await.unwrap();
+                    let object_id =
+                        data::decode_object_id_delta(&mut previous, object.object_id_delta)
+                            .unwrap();
+                    assert_eq!(object_id, expected_object);
+                    assert_eq!(object.payload_length, 0);
+                    assert_eq!(object.status, Some(expected_status));
+                    assert!(object.extension_headers.is_empty());
+                } else {
+                    let object: data::SubgroupObject = reader.decode().await.unwrap();
+                    let object_id =
+                        data::decode_object_id_delta(&mut previous, object.object_id_delta)
+                            .unwrap();
+                    assert_eq!(object_id, expected_object);
+                    assert_eq!(object.payload_length, 0);
+                    assert_eq!(object.status, Some(expected_status));
+                }
+                assert!(reader.done().await.unwrap());
+                received.push(header.group_id);
+            }
+            received.sort_unstable();
+            assert_eq!(received, [0, 1]);
+        };
+        let send = forwarder.serve_subgroups(
+            subgroups_reader,
+            DeliveryFilter {
+                forward: true,
+                start_location: None,
+                end_group_id: None,
+            },
+        );
+
+        let (send, ()) = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            tokio::join!(send, receive)
+        })
+        .await
+        .unwrap();
+        send.unwrap();
+        assert_eq!(
+            forwarder.state.lock().largest_location,
+            Some(Location::new(0, 5))
+        );
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn subgroup_forwarding_limits_blocked_tasks() {
         let (publisher_session, peer_session) = loopback_session_pair().await;
@@ -1697,6 +1835,18 @@ mod tests {
     async fn forwards_mixed_reverse_order_subgroups_over_raw_quic() {
         let (publisher, peer) = loopback_raw_session_pair().await;
         forward_mixed_subgroups(publisher, peer).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn forwards_subgroup_statuses_over_webtransport() {
+        let (publisher, peer) = loopback_session_pair().await;
+        forward_subgroup_statuses(publisher, peer).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn forwards_subgroup_statuses_over_raw_quic() {
+        let (publisher, peer) = loopback_raw_session_pair().await;
+        forward_subgroup_statuses(publisher, peer).await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/moq-transport/src/session/subscriber.rs
+++ b/moq-transport/src/session/subscriber.rs
@@ -2073,13 +2073,11 @@ impl Subscriber {
                 }
             }
 
-            // Pass the absolute Object ID and extension headers through to the serve layer.
-            // TODO SLG - object status is still being ignored.
-
             let subgroup_writer = subgroup.as_mut().ok_or(SessionError::Internal)?;
-            let mut object_writer = subgroup_writer.create_with_id(
+            let mut object_writer = subgroup_writer.create_with_id_and_status(
                 current_object_id,
                 remaining_bytes,
+                status.unwrap_or(data::ObjectStatus::NormalObject),
                 extension_headers,
             )?;
             tracing::trace!(
@@ -2537,6 +2535,67 @@ mod tests {
         writer.finish().unwrap();
     }
 
+    async fn send_subgroup_status(
+        session: &web_transport::Session,
+        header: data::SubgroupHeader,
+        normal_object_ids: &[u64],
+        object_id: u64,
+        status: data::ObjectStatus,
+    ) {
+        let has_properties = header.header_type.has_properties();
+        let stream = session.open_uni().await.unwrap();
+        let mut writer = Writer::new(stream);
+        writer.encode(&header).await.unwrap();
+        let mut previous = None;
+        for &normal_object_id in normal_object_ids {
+            let object_id_delta =
+                data::encode_object_id_delta(&mut previous, normal_object_id).unwrap();
+            if has_properties {
+                writer
+                    .encode(&data::SubgroupObjectExt {
+                        object_id_delta,
+                        extension_headers: Default::default(),
+                        payload_length: 1,
+                        status: None,
+                    })
+                    .await
+                    .unwrap();
+            } else {
+                writer
+                    .encode(&data::SubgroupObject {
+                        object_id_delta,
+                        payload_length: 1,
+                        status: None,
+                    })
+                    .await
+                    .unwrap();
+            }
+            writer.write(&[normal_object_id as u8]).await.unwrap();
+        }
+        let object_id_delta = data::encode_object_id_delta(&mut previous, object_id).unwrap();
+        if has_properties {
+            writer
+                .encode(&data::SubgroupObjectExt {
+                    object_id_delta,
+                    extension_headers: Default::default(),
+                    payload_length: 0,
+                    status: Some(status),
+                })
+                .await
+                .unwrap();
+        } else {
+            writer
+                .encode(&data::SubgroupObject {
+                    object_id_delta,
+                    payload_length: 0,
+                    status: Some(status),
+                })
+                .await
+                .unwrap();
+        }
+        writer.finish().unwrap();
+    }
+
     async fn receive_subgroup_stream(
         receiver_session: &web_transport::Session,
         subscriber: &Subscriber,
@@ -2610,6 +2669,89 @@ mod tests {
         }
     }
 
+    async fn assert_subgroup_status_ingress(
+        receiver_session: web_transport::Session,
+        peer_session: web_transport::Session,
+        transport: super::super::Transport,
+    ) {
+        let subscriber = test_subscriber_for_transport(receiver_session.clone(), transport);
+        let (track_writer, track_reader) =
+            serve::Track::new(TrackNamespace::from_utf8_path("test/ns"), "status").produce();
+        let _subscribe =
+            register_test_subscribe_with_priority(&subscriber, track_writer, 0, 42, 200);
+        let cases = [
+            (
+                data::SubgroupHeader {
+                    header_type: data::StreamHeaderType::SubgroupIdEndOfGroupFirstObject,
+                    track_alias: 42,
+                    group_id: 0,
+                    subgroup_id: Some(0),
+                    publisher_priority: 128,
+                },
+                &[3, 5][..],
+                6,
+                data::ObjectStatus::EndOfGroup,
+                false,
+            ),
+            (
+                data::SubgroupHeader {
+                    header_type: data::StreamHeaderType::SubgroupIdExtEndOfGroupFirstObject,
+                    track_alias: 42,
+                    group_id: 1,
+                    subgroup_id: Some(0),
+                    publisher_priority: 128,
+                },
+                &[][..],
+                7,
+                data::ObjectStatus::EndOfTrack,
+                true,
+            ),
+        ];
+
+        for (header, normal_object_ids, object_id, status, _) in &cases {
+            tokio::join!(
+                send_subgroup_status(
+                    &peer_session,
+                    header.clone(),
+                    normal_object_ids,
+                    *object_id,
+                    *status,
+                ),
+                receive_subgroup_stream(&receiver_session, &subscriber),
+            );
+        }
+
+        let serve::TrackReaderMode::Subgroups(mut subgroups) = track_reader.mode().await.unwrap()
+        else {
+            panic!("expected subgroup delivery");
+        };
+        for (header, normal_object_ids, object_id, status, has_properties) in cases {
+            let mut subgroup = subgroups.next().await.unwrap().unwrap();
+            assert_eq!(subgroup.group_id, header.group_id);
+            assert_eq!(subgroup.subgroup_id, 0);
+            assert_eq!(subgroup.metadata().has_properties, has_properties);
+            for &normal_object_id in normal_object_ids {
+                let mut object = subgroup.next().await.unwrap().unwrap();
+                assert_eq!(object.object_id, normal_object_id);
+                assert_eq!(object.status, data::ObjectStatus::NormalObject);
+                assert_eq!(
+                    object.read_all().await.unwrap().as_ref(),
+                    &[normal_object_id as u8]
+                );
+            }
+            let mut object = subgroup.next().await.unwrap().unwrap();
+            assert_eq!(object.object_id, object_id);
+            assert_eq!(object.status, status);
+            assert_eq!(object.size, 0);
+            assert!(object.extension_headers.is_empty());
+            assert!(object.read_all().await.unwrap().is_empty());
+        }
+        assert_eq!(
+            track_reader.largest_location(),
+            Some(crate::coding::Location::new(0, 5))
+        );
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn decoded_subgroup_object_ids_are_preserved() {
         let (receiver_session, peer_session) = loopback_session_pair().await;
@@ -2654,6 +2796,28 @@ mod tests {
         tokio::time::timeout(
             std::time::Duration::from_secs(5),
             assert_mixed_subgroups_ingress(receiver, peer, super::super::Transport::RawQuic),
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn receives_subgroup_statuses_over_webtransport() {
+        let (receiver, peer) = loopback_session_pair().await;
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            assert_subgroup_status_ingress(receiver, peer, super::super::Transport::WebTransport),
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn receives_subgroup_statuses_over_raw_quic() {
+        let (receiver, peer) = loopback_raw_session_pair().await;
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            assert_subgroup_status_ingress(receiver, peer, super::super::Transport::RawQuic),
         )
         .await
         .unwrap();


### PR DESCRIPTION
## Summary

Preserve decoded draft-18 subgroup Object Status through relay storage and forwarding. EndOfGroup and EndOfTrack markers are no longer recreated as zero-length Normal objects, and terminal markers no longer advance Largest Object.

Existing public constructors remain unchanged. A crate-private status-aware constructor is used by transport ingress, while the existing egress grammar emits the stored status for plain and properties-capable subgroup streams.

## Validation

- `cargo fmt --all -- --check`
- focused serve, ingress, egress, raw QUIC, and WebTransport status tests (6 passed)
- `cargo test -p moq-transport --locked` (454 passed)
- `cargo build --workspace --locked`
- `cargo clippy --workspace --all-targets --locked` (pre-existing warnings only)
- pinned moxygen `0d886e3e907e2236a6d927afefd09bb0c3dc8211`
- baseline `3b3eacf7`: 34/41 over raw QUIC and 34/41 over WebTransport
- candidate `926867fd`: 41/41 over raw QUIC and 41/41 over WebTransport
- no baseline passing case regressed

## Specification

- draft-ietf-moq-transport-18 sections 2.1, 2.4.2, 5.1.2, 9.7, 10.2.11, 11.2.1.1, 11.2.1.2, 11.4.2, and 11.4.3

## Limitations

Datagrams, fanout, FETCH, SUBSCRIBE_TRACKS, broad malformed-track enforcement, public status origination, changelogs, and workflows are unchanged.