### PR TITLE
test(moq-test-client): add rendezvous timeout interop scenario

### DIFF
--- a/moq-test-client/CHANGELOG.md
+++ b/moq-test-client/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add a rendezvous timeout interoperability scenario.
+
 ## [0.1.12](https://github.com/cloudflare/moq-rs/compare/moq-test-client-v0.1.11...moq-test-client-v0.1.12) - 2026-07-31
 
 ### Fixed

--- a/moq-test-client/README.md
+++ b/moq-test-client/README.md
@@ -9,7 +9,7 @@ This tool enables automated interoperability testing between MoQT implementation
 **Key Features:**
 - Test scenarios for basic MoQT operations
 - Human-readable output with timing information
-- Machine-parseable result format (`MOQT_TEST_RESULT: SUCCESS/FAILURE`)
+- Machine-parseable TAP version 14 output with YAML diagnostics
 - Designed to be implementation-agnostic (interface can be reproduced by other implementations)
 
 ## Usage
@@ -52,6 +52,7 @@ moq-test-client --relay https://localhost:4443 --tls-disable-verify
 | `publish-namespace-done` | Send PUBLISH_NAMESPACE, then send PUBLISH_NAMESPACE_DONE |
 | `publish-track-only` | Publisher sends direct PUBLISH, receives PUBLISH_OK, then sends PUBLISH_DONE |
 | `publish-track-subscribe` | Publisher sends direct PUBLISH, subscriber subscribes to the exact track |
+| `rendezvous-timeout` | Subscribe with RENDEZVOUS_TIMEOUT and expect REQUEST_ERROR TIMEOUT |
 
 ## Running with moq-relay
 
@@ -72,26 +73,8 @@ cargo run --bin moq-test-client -- --relay https://localhost:4443 --tls-disable-
 
 ## Output Format
 
-The tool outputs human-readable results during execution and ends with a machine-parseable line:
-
-```
-MoQT Interop Test Client
-========================
-Relay: https://localhost:4443
-
-✓ setup-only (42 ms)
-✓ publish-namespace-only (38 ms)
-✓ subscribe-error (51 ms)
-✓ publish-namespace-subscribe (127 ms)
-✓ subscribe-before-publish-namespace (89 ms)
-✓ publish-namespace-done (45 ms)
-✓ publish-track-only (42 ms)
-✓ publish-track-subscribe (76 ms)
-
-Results: 8 passed, 0 failed
-
-MOQT_TEST_RESULT: SUCCESS
-```
+The client writes TAP version 14 to stdout and logs to stderr. Each test point
+includes its duration and available connection IDs in a YAML diagnostic block.
 
 ## Environment Variable Interface
 
@@ -117,12 +100,13 @@ The test cases implemented here correspond to the specifications in [moq-interop
 |-----------|---------------------|
 | `setup-only` | MoQT §3.3, §9.3 |
 | `publish-namespace-only` | MoQT §6.2, §9.23-9.24 |
-| `publish-namespace-done` | MoQT §6.2, §9.26 |
-| `publish-track-only` | MoQT §9.13-9.15 |
-| `publish-track-subscribe` | MoQT §5.1, §9.9-9.15 |
 | `subscribe-error` | MoQT §5.1, §9.7, §9.9 |
 | `publish-namespace-subscribe` | MoQT §5.1, §6.2, §9.7-9.8, §9.23-9.24 |
 | `subscribe-before-publish-namespace` | MoQT §5.1, §6.2 |
+| `publish-namespace-done` | MoQT §6.2, §9.26 |
+| `publish-track-only` | MoQT §9.13-9.15 |
+| `publish-track-subscribe` | MoQT §5.1, §9.9-9.15 |
+| `rendezvous-timeout` | MoQT §10.2.6, §10.6 |
 
 Protocol references are to [draft-ietf-moq-transport-18](https://www.ietf.org/archive/id/draft-ietf-moq-transport-18.html).
 

--- a/moq-test-client/src/main.rs
+++ b/moq-test-client/src/main.rs
@@ -83,6 +83,8 @@ pub enum TestCase {
     PublishTrackOnly,
     /// T0.8: Publisher sends PUBLISH for one track, subscriber receives it through relay routing
     PublishTrackSubscribe,
+    /// T0.9: SUBSCRIBE with RENDEZVOUS_TIMEOUT expires with TIMEOUT
+    RendezvousTimeout,
 }
 
 impl TestCase {
@@ -96,6 +98,7 @@ impl TestCase {
             TestCase::PublishNamespaceDone,
             TestCase::PublishTrackOnly,
             TestCase::PublishTrackSubscribe,
+            TestCase::RendezvousTimeout,
         ]
     }
 
@@ -109,6 +112,7 @@ impl TestCase {
             TestCase::PublishNamespaceDone => "publish-namespace-done",
             TestCase::PublishTrackOnly => "publish-track-only",
             TestCase::PublishTrackSubscribe => "publish-track-subscribe",
+            TestCase::RendezvousTimeout => "rendezvous-timeout",
         }
     }
 }
@@ -162,6 +166,7 @@ async fn run_test(args: &Args, test_case: TestCase) -> TestResult {
         TestCase::PublishNamespaceDone => scenarios::test_publish_namespace_done(args).await,
         TestCase::PublishTrackOnly => scenarios::test_publish_track_only(args).await,
         TestCase::PublishTrackSubscribe => scenarios::test_publish_track_subscribe(args).await,
+        TestCase::RendezvousTimeout => scenarios::test_rendezvous_timeout(args).await,
     };
 
     let duration = start.elapsed();

--- a/moq-test-client/src/scenarios.rs
+++ b/moq-test-client/src/scenarios.rs
@@ -41,6 +41,12 @@ const PUBLISH_TRACK: &str = "published-track";
 /// Payload carried by the single Object the direct PUBLISH tests send
 const PUBLISH_PAYLOAD: &[u8] = b"publish-track-subscribe";
 
+/// Wait requested by the rendezvous timeout scenario, in milliseconds.
+const RENDEZVOUS_TIMEOUT_MS: u64 = 500;
+
+/// Allows transport scheduling slack beyond the requested rendezvous window.
+const RENDEZVOUS_RESPONSE_TIMEOUT: Duration = Duration::from_secs(2);
+
 /// Helper to connect to a relay and establish a session
 /// Returns (session, connection_id, transport) so we can report CIDs for mlog correlation
 async fn connect(
@@ -221,6 +227,69 @@ pub async fn test_subscribe_error(args: &Args) -> Result<TestConnectionIds> {
                 }
                 Ok(cids)
             }
+        }
+    })
+    .await
+    .context("test timed out")?
+}
+
+/// T0.9: Rendezvous Timeout
+///
+/// Subscribe to a track with no publisher and verify the relay reports TIMEOUT
+/// after processing a nonzero RENDEZVOUS_TIMEOUT.
+pub async fn test_rendezvous_timeout(args: &Args) -> Result<TestConnectionIds> {
+    timeout(TEST_TIMEOUT, async {
+        let (session, cid, transport) =
+            connect(args).await.context("failed to connect to relay")?;
+        let mut cids = TestConnectionIds::default();
+        cids.add(cid);
+
+        let (session, _publisher, mut subscriber) = Session::connect(session, None, transport)
+            .await
+            .context("SETUP exchange failed")?;
+
+        let namespace = TrackNamespace::from_utf8_path("nonexistent/rendezvous");
+        let (mut writer, _, _reader) = Tracks::new(namespace).produce();
+        let track = writer
+            .create(TEST_TRACK)
+            .ok_or_else(|| anyhow::anyhow!("failed to create subscriber track"))?;
+
+        let mut params = KeyValuePairs::default();
+        params.set_rendezvous_timeout(RENDEZVOUS_TIMEOUT_MS);
+
+        tracing::info!(
+            timeout_ms = RENDEZVOUS_TIMEOUT_MS,
+            "Subscribing with RENDEZVOUS_TIMEOUT to a track with no publisher"
+        );
+
+        let result = timeout(RENDEZVOUS_RESPONSE_TIMEOUT, async {
+            tokio::select! {
+                res = subscriber.subscribe_open_with_params(track, params) => res,
+                res = session.run() => {
+                    match res {
+                        Ok(()) => Err(ServeError::Internal(
+                            "session ended before subscribe completed".to_string(),
+                        )),
+                        Err(err) => Err(ServeError::Internal(format!("session error: {}", err))),
+                    }
+                }
+            }
+        })
+        .await
+        .with_context(|| {
+            format!(
+                "relay did not answer rendezvous subscribe within {:?}",
+                RENDEZVOUS_RESPONSE_TIMEOUT
+            )
+        })?;
+
+        match result {
+            Err(ServeError::Timeout) => {
+                tracing::info!("Received expected REQUEST_ERROR TIMEOUT");
+                Ok(cids)
+            }
+            Err(err) => anyhow::bail!("expected REQUEST_ERROR TIMEOUT, got: {}", err),
+            Ok(_) => anyhow::bail!("subscribe succeeded but no publisher serves the track"),
         }
     })
     .await


### PR DESCRIPTION
Add a draft-18 interop scenario that subscribes to an unpublished track with a 500 ms RENDEZVOUS_TIMEOUT. The scenario passes only when the relay returns REQUEST_ERROR with error code TIMEOUT.