### PR TITLE
fix(moq-transport): reject duplicate namespace requests locally

### DIFF
--- a/moq-transport/src/session/mod.rs
+++ b/moq-transport/src/session/mod.rs
@@ -1900,6 +1900,34 @@ pub(crate) mod test_support {
 mod tests {
     use super::*;
 
+    async fn open_publish_namespace_request(
+        peer: &web_transport::Session,
+        request_id: u64,
+        namespace: &str,
+    ) -> (Writer, Reader) {
+        let (send, recv) = peer.open_bi().await.unwrap();
+        let mut writer = Writer::new(send);
+        writer
+            .encode(&Message::PublishNamespace(message::PublishNamespace {
+                id: request_id,
+                track_namespace: crate::coding::TrackNamespace::from_utf8_path(namespace),
+                params: Default::default(),
+            }))
+            .await
+            .unwrap();
+        (writer, Reader::new(recv))
+    }
+
+    async fn next_published_namespace(subscriber: &mut Subscriber) -> PublishedNamespace {
+        tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            subscriber.published_namespace(),
+        )
+        .await
+        .unwrap()
+        .unwrap()
+    }
+
     async fn open_inbound_subscribe() -> (
         web_transport::Session,
         Publisher,
@@ -2540,6 +2568,31 @@ mod tests {
         );
     }
 
+    #[test]
+    fn encode_active_namespace_rejection_has_exact_draft18_wire_image() {
+        use message::wire_id;
+
+        let reason = published_namespace::ACTIVE_NAMESPACE_REASON;
+        let msg = Message::RequestError(message::RequestError {
+            id: 99,
+            error_code: message::RequestErrorCode::ExcessiveLoad as u64,
+            retry_interval: 0,
+            reason: crate::coding::ReasonPhrase(reason.to_string()),
+        });
+        let bytes = encode_bidi_response_bytes(&msg);
+        let mut expected = vec![
+            wire_id::RequestError as u8,
+            0,
+            44,
+            message::RequestErrorCode::ExcessiveLoad as u8,
+            0,
+            41,
+        ];
+        expected.extend_from_slice(reason.as_bytes());
+
+        assert_eq!(bytes, expected);
+    }
+
     /// NAMESPACE and NAMESPACE_DONE carry no Request ID field, so their bidi
     /// framing must be byte-identical to the ordinary message encoding.
     #[test]
@@ -2791,6 +2844,127 @@ mod tests {
             panic!("expected raw QUIC application close, got {close_error:?}");
         };
         assert_eq!(close.error_code.into_inner(), 0x3);
+        drop(client_session);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn duplicate_publish_namespace_is_request_local_and_reannounceable() {
+        let (client_transport, server_transport) = test_support::loopback_session_pair().await;
+        let client_peer = client_transport.clone();
+        let (client, server) = tokio::join!(
+            Session::connect(client_transport, None, Transport::WebTransport),
+            Session::accept(server_transport, None, Transport::WebTransport),
+        );
+        let (client_session, _client_publisher, _client_subscriber) = client.unwrap();
+        let (server_session, _server_publisher, server_subscriber) = server.unwrap();
+        let mut server_subscriber = server_subscriber.unwrap();
+        let server_run = tokio::spawn(server_session.run());
+
+        let (mut first_request, mut first_response) =
+            open_publish_namespace_request(&client_peer, 0, "ping").await;
+        let mut first = next_published_namespace(&mut server_subscriber).await;
+        assert_eq!(first.info.request_id, 0);
+        first.ok().unwrap();
+        assert!(matches!(
+            Session::decode_bidi_response(&mut first_response, 0)
+                .await
+                .unwrap(),
+            Message::RequestOk(_)
+        ));
+
+        first_request.finish().unwrap();
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(20), first.closed())
+                .await
+                .is_err(),
+            "requester FIN must not withdraw the accepted namespace"
+        );
+
+        let (mut duplicate_request, mut duplicate_response) =
+            open_publish_namespace_request(&client_peer, 2, "ping").await;
+        let Message::RequestError(error) =
+            Session::decode_bidi_response(&mut duplicate_response, 2)
+                .await
+                .unwrap()
+        else {
+            panic!("expected duplicate request rejection");
+        };
+        assert_eq!(
+            error.error_code,
+            message::RequestErrorCode::ExcessiveLoad as u64
+        );
+        assert_eq!(error.retry_interval, 0);
+        assert_eq!(error.reason.0, published_namespace::ACTIVE_NAMESPACE_REASON);
+        assert!(error.reason.0.len() <= 1024);
+        assert!(duplicate_response.done().await.unwrap());
+        assert_eq!(
+            duplicate_request.closed().await.unwrap(),
+            Some(u8::try_from(CANCELLED_STREAM_CODE).unwrap())
+        );
+        assert!(
+            tokio::time::timeout(
+                std::time::Duration::from_millis(20),
+                server_subscriber.published_namespace(),
+            )
+            .await
+            .is_err(),
+            "the rejected request must not reach the application"
+        );
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(20), first.closed())
+                .await
+                .is_err(),
+            "rejected-request cleanup must not remove the original owner"
+        );
+        assert!(
+            !server_run.is_finished(),
+            "duplicate must not end the session"
+        );
+
+        let (mut unrelated_request, mut unrelated_response) =
+            open_publish_namespace_request(&client_peer, 4, "unrelated").await;
+        let mut unrelated = next_published_namespace(&mut server_subscriber).await;
+        assert_eq!(unrelated.info.request_id, 4);
+        unrelated.ok().unwrap();
+        assert!(matches!(
+            Session::decode_bidi_response(&mut unrelated_response, 4)
+                .await
+                .unwrap(),
+            Message::RequestOk(_)
+        ));
+        unrelated_request.reset(CANCELLED_STREAM_CODE);
+        unrelated_response.stop(CANCELLED_STREAM_CODE);
+        unrelated.closed().await.unwrap();
+        assert!(
+            !server_run.is_finished(),
+            "unrelated request must remain usable"
+        );
+
+        first_response.stop(CANCELLED_STREAM_CODE);
+        first.closed().await.unwrap();
+
+        let (mut reannounce_request, mut reannounce_response) =
+            open_publish_namespace_request(&client_peer, 6, "ping").await;
+        let mut reannounced = next_published_namespace(&mut server_subscriber).await;
+        assert_eq!(reannounced.info.request_id, 6);
+        reannounced.ok().unwrap();
+        assert!(matches!(
+            Session::decode_bidi_response(&mut reannounce_response, 6)
+                .await
+                .unwrap(),
+            Message::RequestOk(_)
+        ));
+
+        drop(reannounced);
+        assert_eq!(
+            reannounce_request.closed().await.unwrap(),
+            Some(u8::try_from(CANCELLED_STREAM_CODE).unwrap())
+        );
+        assert!(reannounce_response.done().await.unwrap());
+        assert!(!server_run.is_finished());
+
+        server_run.abort();
+        assert!(server_run.await.unwrap_err().is_cancelled());
         drop(client_session);
     }
 }

--- a/moq-transport/src/session/published_namespace.rs
+++ b/moq-transport/src/session/published_namespace.rs
@@ -21,6 +21,7 @@ use super::{
 
 // Immediate cancellation can queue after REQUEST_OK before the stream task runs.
 const RESPONSE_QUEUE_CAPACITY: usize = 2;
+pub(super) const ACTIVE_NAMESPACE_REASON: &str = "namespace already has an active publisher";
 
 enum StreamAction {
     Response(Message),
@@ -49,7 +50,7 @@ pub struct PublishedNamespace {
     pub info: PublishNamespaceInfo,
 
     ok: bool,
-    error: Option<ServeError>,
+    error: Option<message::RequestError>,
 }
 
 impl PublishedNamespace {
@@ -79,6 +80,22 @@ impl PublishedNamespace {
         };
 
         (send, recv)
+    }
+
+    pub(super) fn reject_active_namespace(
+        subscriber: Subscriber,
+        request_id: u64,
+        namespace: TrackNamespace,
+    ) -> PublishedNamespaceRecv {
+        let (mut published, recv) = Self::new(subscriber, request_id, namespace);
+        published.error = Some(message::RequestError {
+            id: request_id,
+            error_code: RequestErrorCode::ExcessiveLoad as u64,
+            retry_interval: 0,
+            reason: ReasonPhrase(ACTIVE_NAMESPACE_REASON.to_string()),
+        });
+        drop(published);
+        recv
     }
 
     /// Accept the PUBLISH_NAMESPACE by sending REQUEST_OK.
@@ -114,7 +131,12 @@ impl PublishedNamespace {
 
     /// Reject the PUBLISH_NAMESPACE; the error is sent on drop.
     pub fn close(mut self, err: ServeError) -> Result<(), ServeError> {
-        self.error = Some(err);
+        self.error = Some(message::RequestError {
+            id: self.info.request_id,
+            error_code: RequestErrorCode::Uninterested as u64,
+            retry_interval: 0,
+            reason: ReasonPhrase(err.to_string()),
+        });
         Ok(())
     }
 }
@@ -140,16 +162,13 @@ impl Drop for PublishedNamespace {
             return;
         }
 
-        let err = self.error.clone().unwrap_or(ServeError::Done);
-        let _ = self.outgoing.try_send(StreamAction::Response(
-            message::RequestError {
-                id: self.info.request_id,
-                error_code: RequestErrorCode::Uninterested as u64,
-                retry_interval: 0,
-                reason: ReasonPhrase(err.to_string()),
-            }
-            .into(),
-        ));
+        let error = self.error.clone().unwrap_or_else(|| message::RequestError {
+            id: self.info.request_id,
+            error_code: RequestErrorCode::Uninterested as u64,
+            retry_interval: 0,
+            reason: ReasonPhrase(ServeError::Done.to_string()),
+        });
+        let _ = self.outgoing.try_send(StreamAction::Response(error.into()));
     }
 }
 
@@ -202,7 +221,24 @@ impl PublishedNamespaceRecv {
                     };
                     self.emit_mlog(&mlog, &response);
                     let terminal = matches!(response, Message::RequestError(_));
-                    match Session::encode_bidi_response(&mut writer, &response).await {
+                    let encoded = if terminal {
+                        match tokio::time::timeout(
+                            Session::BIDI_REQUEST_TIMEOUT,
+                            Session::encode_bidi_response(&mut writer, &response),
+                        )
+                        .await
+                        {
+                            Ok(encoded) => encoded,
+                            Err(_) => {
+                                writer.reset(CANCELLED_STREAM_CODE);
+                                reader.stop(CANCELLED_STREAM_CODE);
+                                return Ok(());
+                            }
+                        }
+                    } else {
+                        Session::encode_bidi_response(&mut writer, &response).await
+                    };
+                    match encoded {
                         Ok(()) => {}
                         Err(err) if err.is_stream_error() => return Ok(()),
                         Err(err) => return Err(err),
@@ -269,10 +305,10 @@ impl PublishedNamespaceRecv {
 
 impl Drop for PublishedNamespaceRecv {
     fn drop(&mut self) {
+        self.subscriber.remove_published_namespace(self.request_id);
         if let Some(mut state) = self.state.lock_mut() {
             state.done = true;
         }
-        self.subscriber.remove_published_namespace(self.request_id);
     }
 }
 
@@ -375,6 +411,48 @@ mod tests {
         run.await.unwrap().unwrap();
         let reset = response_reader.done().await.unwrap_err();
         assert!(reset.is_stream_error());
+    }
+
+    #[tokio::test]
+    async fn publisher_reset_closes_namespace_and_resets_response_direction() {
+        let (client, server) = loopback_session_pair().await;
+        let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+        let subscriber = Subscriber::new(
+            Queue::default(),
+            server.clone(),
+            Transport::WebTransport,
+            None,
+            RequestId::new(0, 1),
+            bidi_task_tx,
+            Default::default(),
+        );
+        let (mut published, recv) =
+            PublishedNamespace::new(subscriber, 0, TrackNamespace::from_utf8_path("test"));
+
+        let (mut request_send, response_recv) = client.open_bi().await.unwrap();
+        request_send.write(b"request").await.unwrap();
+        let (response_send, mut request_recv) = server.accept_bi().await.unwrap();
+        assert_eq!(
+            request_recv.read(7).await.unwrap().unwrap().as_ref(),
+            b"request"
+        );
+
+        published.ok().unwrap();
+        let run =
+            tokio::spawn(recv.run(Writer::new(response_send), Reader::new(request_recv), None));
+        let mut response_reader = Reader::new(response_recv);
+        assert!(matches!(
+            Session::decode_bidi_response(&mut response_reader, 0)
+                .await
+                .unwrap(),
+            Message::RequestOk(_)
+        ));
+
+        request_send.reset(CANCELLED_STREAM_CODE);
+
+        published.closed().await.unwrap();
+        run.await.unwrap().unwrap();
+        assert!(response_reader.done().await.unwrap_err().is_stream_error());
     }
 
     #[tokio::test]

--- a/moq-transport/src/session/publisher.rs
+++ b/moq-transport/src/session/publisher.rs
@@ -1884,6 +1884,48 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn local_namespace_cancel_resets_request_and_stops_response() {
+        let (client, server) = loopback_session_pair().await;
+        let (bidi_task_tx, mut bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut publisher = Publisher::new(
+            Queue::default(),
+            client,
+            None,
+            RequestId::new(0, 1),
+            bidi_task_tx,
+        );
+        let namespace = TrackNamespace::from_utf8_path("test");
+        let (publish, recv, cancel) = PublishNamespace::new(0, namespace.clone());
+        publisher
+            .publish_namespaces
+            .lock()
+            .unwrap()
+            .insert(namespace, recv);
+        publisher
+            .open_publish_namespace_stream(0, publish.wire_message(), cancel)
+            .await
+            .unwrap();
+
+        let pump = tokio::spawn(bidi_task_rx.recv().await.unwrap());
+        let (mut peer_send, peer_recv) = server.accept_bi().await.unwrap();
+        let mut peer_reader = Reader::new(peer_recv);
+        assert!(matches!(
+            peer_reader.decode::<Message>().await.unwrap(),
+            Message::PublishNamespace(_)
+        ));
+
+        drop(publish);
+
+        assert!(peer_reader.done().await.unwrap_err().is_stream_error());
+        assert_eq!(
+            peer_send.closed().await.unwrap(),
+            Some(u8::try_from(super::super::CANCELLED_STREAM_CODE).unwrap())
+        );
+        pump.await.unwrap().unwrap();
+        assert!(publisher.publish_namespaces.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
     async fn response_reset_closes_accepted_namespace() {
         let (client, server) = loopback_session_pair().await;
         let (bidi_task_tx, mut bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();

--- a/moq-transport/src/session/subscriber.rs
+++ b/moq-transport/src/session/subscriber.rs
@@ -924,9 +924,18 @@ impl Subscriber {
             .lock()
             .map_err(|_| SessionError::Internal)?;
 
-        // Duplicate PUBLISH_NAMESPACE for the same namespace within a session is invalid.
+        // Routing currently supports one publisher per namespace. Reject only
+        // the additional request so multi-publisher support can later replace
+        // this policy without changing request-stream ownership.
         match published_namespaces.entry(msg.track_namespace.clone()) {
-            hash_map::Entry::Occupied(_) => return Err(SessionError::Duplicate),
+            hash_map::Entry::Occupied(_) => {
+                drop(published_namespaces);
+                return Ok(PublishedNamespace::reject_active_namespace(
+                    self.clone(),
+                    msg.id,
+                    msg.track_namespace.clone(),
+                ));
+            }
             hash_map::Entry::Vacant(entry) => entry.insert(msg.id),
         };
         drop(published_namespaces);
@@ -2438,6 +2447,44 @@ mod tests {
         let (writer, _reader) =
             serve::Track::new(TrackNamespace::from_utf8_path("test/ns"), name).produce();
         writer
+    }
+
+    #[tokio::test]
+    async fn namespace_close_is_observed_after_ownership_is_removed() {
+        let mut subscriber = test_subscriber(loopback_session().await);
+        let namespace = TrackNamespace::from_utf8_path("test/ns");
+        let first = message::PublishNamespace {
+            id: 1,
+            track_namespace: namespace.clone(),
+            params: Default::default(),
+        };
+        let recv = subscriber.recv_publish_namespace(&first).unwrap();
+        let published = subscriber.published_namespace().await.unwrap();
+
+        drop(recv);
+        published.closed().await.unwrap();
+        assert!(!subscriber
+            .published_namespaces
+            .lock()
+            .unwrap()
+            .contains_key(&namespace));
+
+        let second = message::PublishNamespace {
+            id: 3,
+            track_namespace: namespace,
+            params: Default::default(),
+        };
+        let replacement = subscriber.recv_publish_namespace(&second).unwrap();
+        assert_eq!(
+            subscriber
+                .published_namespace()
+                .await
+                .unwrap()
+                .info
+                .request_id,
+            3
+        );
+        drop(replacement);
     }
 
     fn register_test_subscribe(


### PR DESCRIPTION
## Summary

- reject an additional active `PUBLISH_NAMESPACE` with request-local `REQUEST_ERROR(EXCESSIVE_LOAD, retry=0)`
- preserve the established namespace publisher and healthy session
- prevent rejected-request cleanup from removing the incumbent publisher
- remove namespace ownership before notifying closure, allowing deterministic reannouncement
- bound terminal rejection writes
- retain requester-direction FIN as a non-cancelling half-close

## Why

The current implementation supports one active publisher for a namespace. When another `PUBLISH_NAMESPACE` arrived for the same namespace, it was treated as a session-fatal duplicate using `DUPLICATE_TRACK_ALIAS`.

That error is not applicable because `PUBLISH_NAMESPACE` carries no Track Alias. Closing the session also terminated unrelated requests and the valid incumbent publication.

Draft-18 permits an implementation that cannot accept another publisher to reject the new request with `REQUEST_ERROR`. This change applies that rejection only to the additional request while preserving the original publisher, namespace ownership, and session.

## Protocol behavior

A FIN on only the requester direction remains a graceful half-close indicating that no more request messages will be sent in that direction. It does not withdraw the namespace.

Withdrawal remains unambiguous through request cancellation. Once cancellation removes the active publication, the namespace can be announced again using a fresh Request ID.

Full multi-publisher acceptance and fanout remain out of scope.

## Validation

- `cargo test -p moq-transport` — 459 passed
- `cargo test --workspace`
- request-error wire encoding
- incumbent owner and session survival
- rejected-request cleanup isolation
- requester and responder FIN behavior
- `RESET_STREAM` and `STOP_SENDING` cancellation
- fresh-ID reannouncement after cancellation
- raw QUIC and WebTransport collision reproductions

## Scope

This change does not decide the separate specification question of how two clean FINs after `REQUEST_OK` affect an accepted, long-lived namespace publication. It is safe under either outcome because an incumbent remains active until its request is cancelled or otherwise terminated.