### PR TITLE
feat(moq): support inbound SUBSCRIBE_TRACKS

### DIFF
--- a/moq-relay-ietf/src/consumer.rs
+++ b/moq-relay-ietf/src/consumer.rs
@@ -547,7 +547,11 @@ impl Consumer {
 
         let _registration = match self
             .locals
-            .register_track(self.context.scope(), reader)
+            .register_track_for_session(
+                self.context.scope(),
+                reader,
+                self.context.identity().clone(),
+            )
             .await
         {
             Ok(registration) => registration,

--- a/moq-relay-ietf/src/local.rs
+++ b/moq-relay-ietf/src/local.rs
@@ -15,6 +15,7 @@ use tokio::sync::{broadcast, mpsc, watch, OwnedSemaphorePermit, Semaphore};
 
 use crate::interest::{TrackInterest, TrackInterestGuard};
 use crate::metrics::GaugeGuard;
+use crate::SessionIdentity;
 
 /// Scope key for the outer level of the two-level registry.
 ///
@@ -346,6 +347,7 @@ struct RemoteNamespaceSource {
 struct TrackEntry {
     reader: TrackReader,
     source: TrackSource,
+    origin: Option<SessionIdentity>,
 
     /// Downstream interest in this entry, for [`TrackSource::Cache`] entries only.
     ///
@@ -407,6 +409,25 @@ pub enum TrackChange {
     },
 }
 
+#[derive(Clone)]
+pub(crate) enum PublishedTrackChange {
+    Added {
+        scope: Option<String>,
+        track: TrackReader,
+        origin: Option<SessionIdentity>,
+    },
+    Removed {
+        scope: Option<String>,
+        full_name: FullTrackName,
+        track: TrackReader,
+    },
+}
+
+pub(crate) enum TrackSnapshot {
+    Tracks(Vec<TrackReader>),
+    TooLarge,
+}
+
 /// Relay-local registry.
 ///
 /// Actual media tracks are always stored by exact Full Track Name. Namespace
@@ -427,6 +448,9 @@ pub struct Locals {
 
     /// Actual PUBLISH track add/remove notifications for Publish/Both fan-out.
     track_changes: broadcast::Sender<TrackChange>,
+
+    /// Generation- and origin-aware PUBLISH changes for SUBSCRIBE_TRACKS.
+    published_track_changes: broadcast::Sender<PublishedTrackChange>,
 
     /// How long an unwatched pull-through cache entry is retained before its
     /// upstream subscription is released. Zero disables eviction.
@@ -492,11 +516,13 @@ impl Locals {
     ) -> Self {
         let (namespace_changes, _) = broadcast::channel(NAMESPACE_CHANGE_CHANNEL_CAPACITY);
         let (track_changes, _) = broadcast::channel(TRACK_CHANGE_CHANNEL_CAPACITY);
+        let (published_track_changes, _) = broadcast::channel(TRACK_CHANGE_CHANNEL_CAPACITY);
         Self {
             tracks: Default::default(),
             namespaces: Default::default(),
             namespace_changes,
             track_changes,
+            published_track_changes,
             cache_idle_timeout,
             rendezvous_hold_permits: Arc::new(Semaphore::new(rendezvous_capacity)),
             rendezvous_retry_sequence: Arc::new(AtomicU64::new(0)),
@@ -554,6 +580,12 @@ impl Locals {
         self.track_changes.subscribe()
     }
 
+    pub(crate) fn subscribe_published_track_changes(
+        &self,
+    ) -> broadcast::Receiver<PublishedTrackChange> {
+        self.published_track_changes.subscribe()
+    }
+
     pub fn list_namespaces_matching(
         &self,
         scope: Option<&str>,
@@ -609,6 +641,44 @@ impl Locals {
         }
 
         matches
+    }
+
+    pub(crate) fn list_tracks_matching_for_session(
+        &self,
+        scope: Option<&str>,
+        prefix: &TrackNamespacePrefix,
+        session: &SessionIdentity,
+        limit: usize,
+    ) -> Result<TrackSnapshot, ServeError> {
+        let scope_key = scope.unwrap_or(UNSCOPED);
+        let tracks = self
+            .tracks
+            .read()
+            .map_err(|_| ServeError::internal_ctx("locals track registry lock poisoned"))?;
+        let Some(bucket) = tracks.get(scope_key) else {
+            return Ok(TrackSnapshot::Tracks(Vec::new()));
+        };
+
+        // This bounded scan runs only for initial setup and lag recovery. Keep
+        // the registry simple until scope sizes justify a second prefix index.
+        let mut matches = Vec::new();
+        for (full_name, entry) in bucket {
+            if entry.source == TrackSource::Published
+                && !entry.reader.is_closed()
+                && prefix.is_prefix_of(&full_name.namespace)
+                && !entry
+                    .origin
+                    .as_ref()
+                    .is_some_and(|origin| origin.same_as(session))
+            {
+                if matches.len() == limit {
+                    return Ok(TrackSnapshot::TooLarge);
+                }
+                matches.push(entry.reader.clone());
+            }
+        }
+
+        Ok(TrackSnapshot::Tracks(matches))
     }
 
     /// Mark closed cache entries as closing without removing published generations.
@@ -755,7 +825,21 @@ impl Locals {
             namespace: track.namespace.clone(),
             name: track.name.clone(),
         };
-        self.insert_track_with_registration(scope, full_name, track)
+        self.insert_track_with_registration(scope, full_name, track, None)
+            .await
+    }
+
+    pub(crate) async fn register_track_for_session(
+        &mut self,
+        scope: Option<&str>,
+        track: TrackReader,
+        origin: SessionIdentity,
+    ) -> anyhow::Result<LocalTrackRegistration> {
+        let full_name = FullTrackName {
+            namespace: track.namespace.clone(),
+            name: track.name.clone(),
+        };
+        self.insert_track_with_registration(scope, full_name, track, Some(origin))
             .await
     }
 
@@ -764,6 +848,7 @@ impl Locals {
         scope: Option<&str>,
         full_name: FullTrackName,
         track: TrackReader,
+        origin: Option<SessionIdentity>,
     ) -> anyhow::Result<LocalTrackRegistration> {
         let scope_key = scope.unwrap_or(UNSCOPED).to_string();
 
@@ -776,6 +861,7 @@ impl Locals {
             hash_map::Entry::Vacant(entry) => entry.insert(TrackEntry {
                 reader: track.clone(),
                 source: TrackSource::Published,
+                origin: origin.clone(),
                 // A locally published track has no upstream subscription to
                 // release, so there is nothing to count interest against and
                 // nothing to wait for before accepting a downstream SUBSCRIBE.
@@ -789,6 +875,13 @@ impl Locals {
             scope: scope_key_to_option(&scope_key),
             track: track.clone(),
         });
+        let _ = self
+            .published_track_changes
+            .send(PublishedTrackChange::Added {
+                scope: scope_key_to_option(&scope_key),
+                track: track.clone(),
+                origin: origin.clone(),
+            });
 
         Ok(LocalTrackRegistration {
             locals: self.clone(),
@@ -986,7 +1079,7 @@ impl Locals {
             // owns requesting it from the source; concurrent callers share the reserved
             // reader instead of racing to insert and failing with a spurious `None`.
             let mut closing_generation = None;
-            let mut removed_published = false;
+            let mut removed_published = None;
             let created = {
                 let mut tracks = self.tracks.write().ok()?;
                 let bucket = tracks.entry(scope_key.clone()).or_default();
@@ -1010,7 +1103,7 @@ impl Locals {
                         interest.mark_closing();
                         closing_generation = Some(interest.clone());
                     } else if entry.source == TrackSource::Published {
-                        removed_published = true;
+                        removed_published = Some(entry.reader.clone());
                     }
                 }
 
@@ -1038,6 +1131,7 @@ impl Locals {
                         TrackEntry {
                             reader: reader.clone(),
                             source: TrackSource::Cache,
+                            origin: None,
                             interest: Some(interest.clone()),
                             upstream: Some(upstream.clone()),
                         },
@@ -1053,11 +1147,18 @@ impl Locals {
                 }
             };
 
-            if removed_published {
+            if let Some(track) = removed_published {
                 let _ = self.track_changes.send(TrackChange::Removed {
                     scope: scope_key_to_option(&scope_key),
                     full_name: full_name.clone(),
                 });
+                let _ = self
+                    .published_track_changes
+                    .send(PublishedTrackChange::Removed {
+                        scope: scope_key_to_option(&scope_key),
+                        full_name: full_name.clone(),
+                        track,
+                    });
             }
 
             if let Some(closing) = closing_generation {
@@ -1297,6 +1398,14 @@ impl Drop for LocalTrackRegistration {
                         scope: scope_key_to_option(&self.scope_key),
                         full_name: self.full_name.clone(),
                     });
+                    let _ =
+                        self.locals
+                            .published_track_changes
+                            .send(PublishedTrackChange::Removed {
+                                scope: scope_key_to_option(&self.scope_key),
+                                full_name: self.full_name.clone(),
+                                track: self.reader.clone(),
+                            });
                 }
                 if bucket.is_empty() {
                     tracks.remove(self.scope_key.as_str());
@@ -1321,6 +1430,78 @@ mod tests {
             namespace: namespace.clone(),
             name: TrackName::from(name),
         }
+    }
+
+    #[tokio::test]
+    async fn subscribe_tracks_snapshot_excludes_only_the_originating_session() {
+        let namespace = ns("room/123");
+        let (_writer, reader) = Track::new(namespace, "video").produce();
+        let origin = crate::SessionContext::public(None);
+        let other = crate::SessionContext::public(None);
+        let mut locals = Locals::new();
+        let mut changes = locals.subscribe_published_track_changes();
+        let _registration = locals
+            .register_track_for_session(None, reader, origin.identity().clone())
+            .await
+            .expect("register track");
+        let PublishedTrackChange::Added {
+            origin: Some(change_origin),
+            ..
+        } = changes.recv().await.expect("published track change")
+        else {
+            panic!("expected published track addition with an origin");
+        };
+        assert!(change_origin.same_as(origin.identity()));
+        let prefix = TrackNamespacePrefix::from_utf8_path("room");
+
+        let TrackSnapshot::Tracks(origin_tracks) = locals
+            .list_tracks_matching_for_session(None, &prefix, origin.identity(), 1)
+            .unwrap()
+        else {
+            panic!("origin snapshot exceeded bound");
+        };
+        let TrackSnapshot::Tracks(other_tracks) = locals
+            .list_tracks_matching_for_session(None, &prefix, other.identity(), 1)
+            .unwrap()
+        else {
+            panic!("other snapshot exceeded bound");
+        };
+        assert!(origin_tracks.is_empty());
+        assert_eq!(other_tracks.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn subscribe_tracks_snapshot_stops_at_the_bound() {
+        let namespace = ns("room/123");
+        let origin = crate::SessionContext::public(None);
+        let mut locals = Locals::new();
+        let mut writers = Vec::new();
+        let mut registrations = Vec::new();
+        for name in ["audio", "video"] {
+            let (writer, reader) = Track::new(namespace.clone(), name).produce();
+            writers.push(writer);
+            registrations.push(
+                locals
+                    .register_track_for_session(None, reader, origin.identity().clone())
+                    .await
+                    .expect("register track"),
+            );
+        }
+        let other = crate::SessionContext::public(None);
+
+        assert!(matches!(
+            locals
+                .list_tracks_matching_for_session(
+                    None,
+                    &TrackNamespacePrefix::from_utf8_path("room"),
+                    other.identity(),
+                    1,
+                )
+                .unwrap(),
+            TrackSnapshot::TooLarge
+        ));
+        drop(writers);
+        drop(registrations);
     }
 
     async fn assert_no_namespace_change(changes: &mut broadcast::Receiver<NamespaceChange>) {
@@ -2099,7 +2280,7 @@ mod tests {
 
         let added = changes.recv().await.expect("added event");
         match added {
-            TrackChange::Added { scope, track } => {
+            TrackChange::Added { scope, track, .. } => {
                 assert_eq!(scope, Some("scope-a".to_string()));
                 assert_eq!(track.namespace, namespace);
                 assert_eq!(track.name, TrackName::from("audio"));
@@ -2111,7 +2292,9 @@ mod tests {
 
         let removed = changes.recv().await.expect("removed event");
         match removed {
-            TrackChange::Removed { scope, full_name } => {
+            TrackChange::Removed {
+                scope, full_name, ..
+            } => {
                 assert_eq!(scope, Some("scope-a".to_string()));
                 assert_eq!(full_name.namespace, ns("room/123"));
                 assert_eq!(full_name.name, TrackName::from("audio"));

--- a/moq-relay-ietf/src/producer.rs
+++ b/moq-relay-ietf/src/producer.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024-2026 Cloudflare Inc., Luke Curley, Mike English and contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::sync::Arc;
 
@@ -12,7 +12,7 @@ use moq_transport::{
     serve::{FullTrackName, ServeError, TrackReader, TracksReader},
     session::{
         Publisher, ServeWithDeadlineError, SessionError, Subscribed, SubscribedNamespace,
-        TrackStatusRequested,
+        SubscribedTracks, TrackStatusRequested,
     },
 };
 use tokio::sync::{broadcast, OwnedSemaphorePermit, Semaphore};
@@ -22,8 +22,8 @@ use crate::{
     metrics::{GaugeGuard, TimingGuard},
     remote::RemoteSubscribeError,
     upstream_namespaces::UpstreamNamespaces,
-    Coordinator, Locals, NamespaceChange, RemoteManager, SessionContext, TrackChange,
-    UpstreamReady,
+    Coordinator, Locals, NamespaceChange, PublishedTrackChange, RemoteManager, SessionContext,
+    TrackChange, TrackSnapshot, UpstreamReady,
 };
 
 /// Ceiling on how long a SUBSCRIBE is held waiting for a publisher to appear.
@@ -41,6 +41,82 @@ const MAX_RENDEZVOUS_TIMEOUT: std::time::Duration = std::time::Duration::from_se
 /// Keep one session from consuming the relay's entire rendezvous budget. Half
 /// the relay-wide capacity remains available to other sessions.
 const MAX_CONCURRENT_RENDEZVOUS_HOLDS_PER_SESSION: usize = MAX_CONCURRENT_RENDEZVOUS_HOLDS / 2;
+const MAX_SUBSCRIBE_TRACKS_SLOTS_PER_SESSION: usize = 1024;
+const MAX_SUBSCRIBE_TRACKS_CHILDREN_PER_SESSION: usize = 128;
+
+type ProducerTask = futures::future::BoxFuture<'static, ()>;
+
+struct SubscribeTracksSlot {
+    desired: Option<TrackReader>,
+    active: Option<TrackReader>,
+    /// draft-18 section 6.1 forbids a later PUBLISH for this track after
+    /// PUBLISH_BLOCKED. The parent SUBSCRIBE_TRACKS owns this tombstone until
+    /// it is cancelled, which drops its slot map and releases the permit.
+    publish_blocked_tombstone: bool,
+    _session_slot_permit: OwnedSemaphorePermit,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+enum SubscribeTracksSlotAction {
+    None,
+    Publish,
+    Remove,
+}
+
+impl SubscribeTracksSlot {
+    fn set_desired(&mut self, track: TrackReader) -> bool {
+        if self.publish_blocked_tombstone
+            || self
+                .active
+                .as_ref()
+                .is_some_and(|active| same_track_generation(active, &track))
+        {
+            return false;
+        }
+        self.desired = Some(track);
+        true
+    }
+
+    fn complete(&mut self, generation: &TrackReader) -> SubscribeTracksSlotAction {
+        if self
+            .active
+            .as_ref()
+            .is_some_and(|active| same_track_generation(active, generation))
+        {
+            self.active = None;
+        }
+        if self
+            .desired
+            .as_ref()
+            .is_some_and(|desired| same_track_generation(desired, generation))
+        {
+            self.desired = None;
+        }
+        if self.active.is_some() || self.publish_blocked_tombstone {
+            SubscribeTracksSlotAction::None
+        } else if self.desired.is_some() {
+            SubscribeTracksSlotAction::Publish
+        } else {
+            SubscribeTracksSlotAction::Remove
+        }
+    }
+
+    fn remove_desired(&mut self, generation: &TrackReader) -> bool {
+        if self
+            .desired
+            .as_ref()
+            .is_some_and(|desired| same_track_generation(desired, generation))
+        {
+            self.desired = None;
+        }
+        self.active.is_none() && self.desired.is_none() && !self.publish_blocked_tombstone
+    }
+}
+
+struct PublishCompletion {
+    full_name: FullTrackName,
+    generation: TrackReader,
+}
 
 /// How often a held SUBSCRIBE asks the coordinator again whether a publisher has
 /// turned up.
@@ -123,6 +199,11 @@ pub struct Producer {
     rendezvous_hold_permits: Arc<Semaphore>,
     /// Relay-level context for this MoQT session.
     context: SessionContext,
+    /// Shared only by SUBSCRIBE_TRACKS requests on this transport session. Its
+    /// bound must match the child-task channel capacity in [`Self::run`].
+    subscribe_tracks_session_child_permits: Arc<Semaphore>,
+    /// Shared only by SUBSCRIBE_TRACKS requests on this transport session.
+    subscribe_tracks_session_slot_permits: Arc<Semaphore>,
 }
 
 /// Why the wait for upstream readiness ended without the subscription being
@@ -174,6 +255,12 @@ impl Producer {
                 MAX_CONCURRENT_RENDEZVOUS_HOLDS_PER_SESSION,
             )),
             context,
+            subscribe_tracks_session_child_permits: Arc::new(Semaphore::new(
+                MAX_SUBSCRIBE_TRACKS_CHILDREN_PER_SESSION,
+            )),
+            subscribe_tracks_session_slot_permits: Arc::new(Semaphore::new(
+                MAX_SUBSCRIBE_TRACKS_SLOTS_PER_SESSION,
+            )),
         }
     }
 
@@ -224,13 +311,17 @@ impl Producer {
 
     /// Run the producer to serve subscribe requests.
     pub async fn run(self) -> Result<(), SessionError> {
-        let mut tasks: FuturesUnordered<futures::future::BoxFuture<'static, ()>> =
-            FuturesUnordered::new();
+        let mut tasks: FuturesUnordered<ProducerTask> = FuturesUnordered::new();
+        // A SUBSCRIBE_TRACKS child acquires a permit from the semaphore with
+        // this same bound before sending, so the parent cannot stall here.
+        let (child_tasks, mut child_task_rx) =
+            tokio::sync::mpsc::channel(MAX_SUBSCRIBE_TRACKS_CHILDREN_PER_SESSION);
 
         loop {
             let mut publisher_subscribed = self.publisher.clone();
             let mut publisher_track_status = self.publisher.clone();
             let mut publisher_subscribed_namespace = self.publisher.clone();
+            let mut publisher_subscribed_tracks = self.publisher.clone();
 
             tokio::select! {
                 // Handle a new subscribe request
@@ -290,6 +381,22 @@ impl Producer {
                         }
                     }.boxed())
                 },
+                Some(subscribed_tracks) = publisher_subscribed_tracks.subscribed_tracks() => {
+                    let this = self.clone();
+                    let child_tasks = child_tasks.clone();
+                    tasks.push(async move {
+                        let prefix = subscribed_tracks.namespace_prefix.to_utf8_path();
+                        tracing::info!(namespace_prefix = %prefix, "serving subscribe tracks");
+                        if let Err(err) = this.serve_subscribe_tracks(subscribed_tracks, child_tasks).await {
+                            if Self::is_expected_serve_shutdown(&err) {
+                                tracing::debug!(namespace_prefix = %prefix, error = %err, "stopped serving subscribe tracks");
+                            } else {
+                                tracing::warn!(namespace_prefix = %prefix, error = %err, "failed serving subscribe tracks");
+                            }
+                        }
+                    }.boxed())
+                },
+                Some(task) = child_task_rx.recv() => tasks.push(task),
                 _= tasks.next(), if !tasks.is_empty() => {},
                 else => return Ok(()),
             };
@@ -821,7 +928,7 @@ impl Producer {
 
                 change = track_changes.recv() => {
                     match change {
-                        Ok(TrackChange::Added { scope: change_scope, track })
+                        Ok(TrackChange::Added { scope: change_scope, track, .. })
                             if change_scope.as_deref() == scope
                                 && track.info.namespace == *namespace
                                 && track.info.name == *track_name =>
@@ -1067,7 +1174,7 @@ impl Producer {
         change: TrackChange,
     ) -> Result<(), anyhow::Error> {
         match change {
-            TrackChange::Added { scope, track } => {
+            TrackChange::Added { scope, track, .. } => {
                 if scope.as_deref() != self.context.scope()
                     || !subscribed_namespace
                         .namespace_prefix
@@ -1079,7 +1186,9 @@ impl Producer {
                 self.publish_track_for_namespace(subscribed_namespace, known, publish_tasks, track)
                     .await
             }
-            TrackChange::Removed { scope, full_name } => {
+            TrackChange::Removed {
+                scope, full_name, ..
+            } => {
                 if scope.as_deref() == self.context.scope() {
                     known.remove(&full_name);
                 }
@@ -1148,6 +1257,363 @@ impl Producer {
             .boxed(),
         );
 
+        Ok(())
+    }
+
+    async fn serve_subscribe_tracks(
+        self,
+        mut request: SubscribedTracks,
+        child_tasks: tokio::sync::mpsc::Sender<ProducerTask>,
+    ) -> Result<(), anyhow::Error> {
+        let mut changes = self.locals.subscribe_published_track_changes();
+        let snapshot = match self.locals.list_tracks_matching_for_session(
+            self.context.scope(),
+            &request.namespace_prefix,
+            self.context.identity(),
+            MAX_SUBSCRIBE_TRACKS_SLOTS_PER_SESSION,
+        ) {
+            Ok(TrackSnapshot::Tracks(snapshot)) => snapshot,
+            Ok(TrackSnapshot::TooLarge) => {
+                request.reject(
+                    RequestErrorCode::NamespaceTooLarge as u64,
+                    "too many matching tracks",
+                )?;
+                return Ok(());
+            }
+            Err(error) => {
+                let prefix = request.namespace_prefix.to_utf8_path();
+                request.reject(RequestErrorCode::InternalError as u64, "internal error")?;
+                return Err(anyhow::Error::new(error)
+                    .context(format!("failed to snapshot tracks for prefix {prefix}")));
+            }
+        };
+
+        // This map belongs to one parent SUBSCRIBE_TRACKS. Every cancellation
+        // path returns from this function, dropping the map and its session
+        // slot permits without affecting other sessions.
+        let mut slots = HashMap::with_capacity(snapshot.len());
+        for track in snapshot {
+            let permit = match self
+                .subscribe_tracks_session_slot_permits
+                .clone()
+                .try_acquire_owned()
+            {
+                Ok(permit) => permit,
+                Err(_) => {
+                    request.reject(
+                        RequestErrorCode::ExcessiveLoad as u64,
+                        "subscribe tracks session limit exceeded",
+                    )?;
+                    return Ok(());
+                }
+            };
+            slots.insert(
+                full_name_for_track(&track),
+                SubscribeTracksSlot {
+                    desired: Some(track),
+                    active: None,
+                    publish_blocked_tombstone: false,
+                    _session_slot_permit: permit,
+                },
+            );
+        }
+
+        request.ok()?;
+        let (completed, mut completions) =
+            tokio::sync::mpsc::channel(MAX_SUBSCRIBE_TRACKS_CHILDREN_PER_SESSION);
+        let initial: Vec<_> = slots.keys().cloned().collect();
+        for full_name in initial {
+            self.start_subscribe_tracks_publish(
+                &mut request,
+                &mut slots,
+                &full_name,
+                &child_tasks,
+                &completed,
+            )
+            .await?;
+        }
+
+        loop {
+            tokio::select! {
+                biased;
+                result = request.closed() => {
+                    result?;
+                    return Ok(());
+                }
+                Some(completion) = completions.recv() => {
+                    let action = slots
+                        .get_mut(&completion.full_name)
+                        .map(|slot| slot.complete(&completion.generation));
+                    match action {
+                        Some(SubscribeTracksSlotAction::Remove) => {
+                            slots.remove(&completion.full_name);
+                        }
+                        Some(SubscribeTracksSlotAction::Publish) => {
+                            self.start_subscribe_tracks_publish(
+                                &mut request,
+                                &mut slots,
+                                &completion.full_name,
+                                &child_tasks,
+                                &completed,
+                            ).await?;
+                        }
+                        Some(SubscribeTracksSlotAction::None) | None => {}
+                    }
+                }
+                change = changes.recv() => {
+                    match change {
+                        Ok(PublishedTrackChange::Added { scope, track, origin }) => {
+                            if scope.as_deref() != self.context.scope()
+                                || !request.namespace_prefix.is_prefix_of(&track.namespace)
+                                || origin.as_ref().is_some_and(|origin| origin.same_as(self.context.identity()))
+                            {
+                                continue;
+                            }
+                            let full_name = full_name_for_track(&track);
+                            if let Some(slot) = slots.get_mut(&full_name) {
+                                if !slot.set_desired(track) {
+                                    continue;
+                                }
+                            } else {
+                                if slots.len() == MAX_SUBSCRIBE_TRACKS_SLOTS_PER_SESSION {
+                                    request.terminate(RequestErrorCode::ExcessiveLoad as u32)?;
+                                    return Ok(());
+                                }
+                                let permit = match self.subscribe_tracks_session_slot_permits.clone().try_acquire_owned() {
+                                    Ok(permit) => permit,
+                                    Err(_) => {
+                                        request.terminate(RequestErrorCode::ExcessiveLoad as u32)?;
+                                        return Ok(());
+                                    }
+                                };
+                                slots.insert(full_name.clone(), SubscribeTracksSlot {
+                                    desired: Some(track),
+                                    active: None,
+                                    publish_blocked_tombstone: false,
+                                    _session_slot_permit: permit,
+                                });
+                            }
+                            self.start_subscribe_tracks_publish(
+                                &mut request,
+                                &mut slots,
+                                &full_name,
+                                &child_tasks,
+                                &completed,
+                            ).await?;
+                        }
+                        Ok(PublishedTrackChange::Removed { scope, full_name, track }) => {
+                            if scope.as_deref() != self.context.scope() {
+                                continue;
+                            }
+                            let remove = slots
+                                .get_mut(&full_name)
+                                .is_some_and(|slot| slot.remove_desired(&track));
+                            if remove {
+                                slots.remove(&full_name);
+                            }
+                        }
+                        Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                            metrics::counter!("moq_relay_change_channel_lagged_total", "channel" => "subscribe_tracks")
+                                .increment(skipped);
+                            self.resync_subscribe_tracks(
+                                &mut request,
+                                &mut slots,
+                                &child_tasks,
+                                &completed,
+                            ).await?;
+                        }
+                        Err(broadcast::error::RecvError::Closed) => return Ok(()),
+                    }
+                }
+            }
+        }
+    }
+
+    async fn resync_subscribe_tracks(
+        &self,
+        request: &mut SubscribedTracks,
+        slots: &mut HashMap<FullTrackName, SubscribeTracksSlot>,
+        child_tasks: &tokio::sync::mpsc::Sender<ProducerTask>,
+        completed: &tokio::sync::mpsc::Sender<PublishCompletion>,
+    ) -> Result<(), anyhow::Error> {
+        let snapshot = match self.locals.list_tracks_matching_for_session(
+            self.context.scope(),
+            &request.namespace_prefix,
+            self.context.identity(),
+            MAX_SUBSCRIBE_TRACKS_SLOTS_PER_SESSION,
+        ) {
+            Ok(TrackSnapshot::Tracks(snapshot)) => snapshot,
+            Ok(TrackSnapshot::TooLarge) => {
+                request.terminate(RequestErrorCode::ExcessiveLoad as u32)?;
+                return Ok(());
+            }
+            Err(error) => {
+                request.terminate(RequestErrorCode::InternalError as u32)?;
+                return Err(anyhow::Error::new(error).context(format!(
+                    "failed to resync tracks for prefix {}",
+                    request.namespace_prefix.to_utf8_path()
+                )));
+            }
+        };
+
+        let current: HashMap<_, _> = snapshot
+            .into_iter()
+            .map(|track| (full_name_for_track(&track), track))
+            .collect();
+        for (full_name, slot) in slots.iter_mut() {
+            if slot.publish_blocked_tombstone {
+                continue;
+            }
+            slot.desired = current.get(full_name).cloned();
+        }
+        for (full_name, track) in current {
+            if slots.contains_key(&full_name) {
+                continue;
+            }
+            let permit = match self
+                .subscribe_tracks_session_slot_permits
+                .clone()
+                .try_acquire_owned()
+            {
+                Ok(permit) => permit,
+                Err(_) => {
+                    request.terminate(RequestErrorCode::ExcessiveLoad as u32)?;
+                    return Ok(());
+                }
+            };
+            slots.insert(
+                full_name,
+                SubscribeTracksSlot {
+                    desired: Some(track),
+                    active: None,
+                    publish_blocked_tombstone: false,
+                    _session_slot_permit: permit,
+                },
+            );
+        }
+        let pending: Vec<_> = slots
+            .iter()
+            .filter(|(_, slot)| {
+                slot.desired.is_some() && slot.active.is_none() && !slot.publish_blocked_tombstone
+            })
+            .map(|(full_name, _)| full_name.clone())
+            .collect();
+        for full_name in pending {
+            self.start_subscribe_tracks_publish(request, slots, &full_name, child_tasks, completed)
+                .await?;
+        }
+        slots.retain(|_, slot| {
+            slot.desired.is_some() || slot.active.is_some() || slot.publish_blocked_tombstone
+        });
+        Ok(())
+    }
+
+    async fn start_subscribe_tracks_publish(
+        &self,
+        request: &mut SubscribedTracks,
+        slots: &mut HashMap<FullTrackName, SubscribeTracksSlot>,
+        full_name: &FullTrackName,
+        child_tasks: &tokio::sync::mpsc::Sender<ProducerTask>,
+        completed: &tokio::sync::mpsc::Sender<PublishCompletion>,
+    ) -> Result<(), anyhow::Error> {
+        let Some(slot) = slots.get(full_name) else {
+            return Ok(());
+        };
+        if slot.active.is_some() || slot.publish_blocked_tombstone {
+            return Ok(());
+        }
+        let Some(track) = slot.desired.clone() else {
+            return Ok(());
+        };
+
+        let permit = match self
+            .subscribe_tracks_session_child_permits
+            .clone()
+            .try_acquire_owned()
+        {
+            Ok(permit) => permit,
+            Err(_) => {
+                request.publish_blocked(&full_name.namespace, &full_name.name)?;
+                if let Some(slot) = slots.get_mut(full_name) {
+                    // This terminal marker is retained only until this parent
+                    // SUBSCRIBE_TRACKS ends; draft-18 section 6.1 forbids a
+                    // later generated PUBLISH for the same track.
+                    slot.publish_blocked_tombstone = true;
+                    slot.desired = None;
+                }
+                return Ok(());
+            }
+        };
+
+        let mut params = KeyValuePairs::default();
+        if !request.forward {
+            params.set_forward(false);
+        }
+        let mut publisher = self.publisher.clone();
+        let publish = publisher.publish(track.clone(), params);
+        let published = match tokio::select! {
+            biased;
+            closed = request.closed() => {
+                let error = match closed {
+                    Ok(()) => ServeError::Done,
+                    Err(error) => error,
+                };
+                return Err(anyhow::Error::new(error).context(format!(
+                    "parent SUBSCRIBE_TRACKS ended while starting generated PUBLISH for {}--{}",
+                    full_name.namespace.to_utf8_path(),
+                    full_name.name
+                )));
+            }
+            published = publish => published,
+        } {
+            Ok(published) => published,
+            Err(SessionError::Serve(ServeError::Duplicate)) => {
+                slots.remove(full_name);
+                return Ok(());
+            }
+            Err(error) if !error.is_session_fatal() => {
+                tracing::warn!(
+                    namespace = %full_name.namespace.to_utf8_path(),
+                    track = %full_name.name,
+                    error = %error,
+                    "failed to start generated PUBLISH; keeping SUBSCRIBE_TRACKS active"
+                );
+                slots.remove(full_name);
+                return Ok(());
+            }
+            Err(error) => {
+                return Err(anyhow::Error::new(error).context(format!(
+                    "failed to start generated PUBLISH for {}--{}",
+                    full_name.namespace.to_utf8_path(),
+                    full_name.name
+                )));
+            }
+        };
+        if let Some(slot) = slots.get_mut(full_name) {
+            slot.active = Some(track.clone());
+        }
+
+        let completion = PublishCompletion {
+            full_name: full_name.clone(),
+            generation: track,
+        };
+        let completed = completed.clone();
+        let namespace = full_name.namespace.to_utf8_path();
+        let track_name = full_name.name.to_string();
+        child_tasks
+            .send(
+                async move {
+                    let _permit = permit;
+                    match published.serve().await {
+                        Ok(()) => tracing::debug!(namespace = %namespace, track = %track_name, "finished serving PUBLISH for SUBSCRIBE_TRACKS"),
+                        Err(error) => tracing::warn!(namespace = %namespace, track = %track_name, error = %error, "failed serving PUBLISH for SUBSCRIBE_TRACKS"),
+                    }
+                    let _ = completed.send(completion).await;
+                }
+                .boxed(),
+            )
+            .await
+            .map_err(|_| ServeError::Cancel)?;
         Ok(())
     }
 
@@ -1233,23 +1699,35 @@ fn full_name_for_track(track: &TrackReader) -> FullTrackName {
     }
 }
 
+fn same_track_generation(left: &TrackReader, right: &TrackReader) -> bool {
+    Arc::ptr_eq(&left.info, &right.info)
+}
+
 #[cfg(test)]
 mod tests {
     use std::{
+        collections::HashMap,
+        io::Cursor,
         sync::{Arc, Mutex},
         time::Duration,
     };
 
     use async_trait::async_trait;
     use moq_transport::{
-        coding::{KeyValuePairs, TrackNamespace},
-        message::RequestErrorCode,
+        coding::{
+            Decode, DecodeError, Encode, KeyValuePairs, TrackName, TrackNamespace,
+            TrackNamespacePrefix,
+        },
+        message::{wire_id, Message, PublishBlocked, RequestErrorCode, SubscribeTracks},
         serve::{ServeError, Track},
         session::{Session as TransportSession, SessionError, Subscriber, Transport},
     };
+    use tokio::sync::Semaphore;
 
     use super::{
-        namespace_covers, rendezvous_hold, Producer, MAX_CONCURRENT_RENDEZVOUS_HOLDS_PER_SESSION,
+        full_name_for_track, namespace_covers, rendezvous_hold, Producer, SubscribeTracksSlot,
+        SubscribeTracksSlotAction, MAX_CONCURRENT_RENDEZVOUS_HOLDS_PER_SESSION,
+        MAX_SUBSCRIBE_TRACKS_CHILDREN_PER_SESSION, MAX_SUBSCRIBE_TRACKS_SLOTS_PER_SESSION,
     };
     use crate::{
         Coordinator, CoordinatorContext, CoordinatorError, CoordinatorResult, Locals,
@@ -1411,7 +1889,26 @@ mod tests {
         remotes: RemoteManager,
         coordinator: Arc<dyn Coordinator>,
     ) -> Subscriber {
+        let (_, subscriber, _) = spawn_relay_session_with_limits(
+            locals,
+            remotes,
+            coordinator,
+            MAX_SUBSCRIBE_TRACKS_CHILDREN_PER_SESSION,
+            MAX_SUBSCRIBE_TRACKS_SLOTS_PER_SESSION,
+        )
+        .await;
+        subscriber
+    }
+
+    async fn spawn_relay_session_with_limits(
+        locals: Locals,
+        remotes: RemoteManager,
+        coordinator: Arc<dyn Coordinator>,
+        child_limit: usize,
+        slot_limit: usize,
+    ) -> (web_transport::Session, Subscriber, Arc<Semaphore>) {
         let (server_transport, client_transport) = loopback_webtransport_pair().await;
+        let request_transport = client_transport.clone();
         let (server, client) = tokio::time::timeout(Duration::from_secs(10), async {
             tokio::join!(
                 TransportSession::accept(server_transport, None, Transport::WebTransport),
@@ -1422,19 +1919,63 @@ mod tests {
         .expect("MoQT setup timed out");
         let (server, publisher, _server_subscriber) = server.expect("accept MoQT session");
         let (client, _client_publisher, subscriber) = client.expect("connect MoQT session");
-        let producer = Producer::new(
+        let mut producer = Producer::new(
             publisher.expect("server publisher"),
             locals,
             remotes,
             coordinator,
             SessionContext::public(None),
         );
+        producer.subscribe_tracks_session_child_permits = Arc::new(Semaphore::new(child_limit));
+        producer.subscribe_tracks_session_slot_permits = Arc::new(Semaphore::new(slot_limit));
+        let slot_permits = producer.subscribe_tracks_session_slot_permits.clone();
 
         tokio::spawn(async move { server.run().await });
         tokio::spawn(async move { client.run().await });
         tokio::spawn(async move { producer.run().await });
 
-        subscriber
+        (request_transport, subscriber, slot_permits)
+    }
+
+    async fn read_bidi_response_frame(
+        recv: &mut web_transport::RecvStream,
+        buffer: &mut Vec<u8>,
+    ) -> (u64, Vec<u8>) {
+        loop {
+            let mut cursor = Cursor::new(buffer.as_slice());
+            let message_type = match u64::decode(&mut cursor) {
+                Ok(message_type) => Some(message_type),
+                Err(DecodeError::More(_)) => None,
+                Err(error) => panic!("invalid response message type: {error}"),
+            };
+            let message_length = if message_type.is_some() {
+                match u16::decode(&mut cursor) {
+                    Ok(message_length) => Some(message_length as usize),
+                    Err(DecodeError::More(_)) => None,
+                    Err(error) => panic!("invalid response message length: {error}"),
+                }
+            } else {
+                None
+            };
+            if let (Some(message_type), Some(message_length)) = (message_type, message_length) {
+                let header_length = cursor.position() as usize;
+                let frame_length = header_length + message_length;
+                if buffer.len() >= frame_length {
+                    let payload = buffer[header_length..frame_length].to_vec();
+                    buffer.drain(..frame_length);
+                    return (message_type, payload);
+                }
+            }
+
+            if recv
+                .read_buf(buffer)
+                .await
+                .expect("read response frame")
+                .is_none()
+            {
+                panic!("response stream ended before a complete frame");
+            }
+        }
     }
 
     async fn subscribe_result(
@@ -1460,6 +2001,207 @@ mod tests {
             Ok(_) => panic!("expected {track_name} subscription to be rejected"),
             Err(err) => err,
         }
+    }
+
+    fn test_track(name: &str) -> moq_transport::serve::TrackReader {
+        let (_writer, reader) =
+            Track::new(TrackNamespace::from_utf8_path("subscribe-tracks"), name).produce();
+        reader
+    }
+
+    #[test]
+    fn cancelling_parent_releases_blocked_session_slot() {
+        let permits = Arc::new(Semaphore::new(1));
+        let generation = test_track("blocked");
+        let full_name = full_name_for_track(&generation);
+        let permit = permits
+            .clone()
+            .try_acquire_owned()
+            .expect("acquire slot permit");
+        let mut slots = HashMap::from([(
+            full_name.clone(),
+            SubscribeTracksSlot {
+                desired: None,
+                active: None,
+                publish_blocked_tombstone: true,
+                _session_slot_permit: permit,
+            },
+        )]);
+
+        let replacement = test_track("blocked");
+        assert!(!slots
+            .get_mut(&full_name)
+            .expect("blocked slot")
+            .set_desired(replacement));
+        assert_eq!(permits.available_permits(), 0);
+
+        // Cancelling the parent returns from serve_subscribe_tracks and drops
+        // this request-owned slot map.
+        drop(slots);
+        assert_eq!(permits.available_permits(), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn subscribe_tracks_resyncs_after_lag_and_releases_blocked_slots_on_cancellation() {
+        let locals = Locals::new();
+        let namespace = TrackNamespace::from_utf8_path("subscribe-tracks");
+        let (_writer, reader) = Track::new(namespace.clone(), "blocked").produce();
+        let mut registering_locals = locals.clone();
+        let _registration = registering_locals
+            .register_track(None, reader)
+            .await
+            .expect("register matching track");
+        let coordinator = Arc::new(CountingCoordinator::default());
+        let remotes = RemoteManager::new(coordinator.clone(), Vec::new());
+        let (request_transport, _subscriber, slot_permits) =
+            spawn_relay_session_with_limits(locals, remotes, coordinator, 0, 2).await;
+        let (mut request_send, mut response_recv) = request_transport
+            .open_bi()
+            .await
+            .expect("open SUBSCRIBE_TRACKS stream");
+        let request = Message::SubscribeTracks(SubscribeTracks {
+            id: 0,
+            track_namespace_prefix: TrackNamespacePrefix::from_utf8_path("subscribe-tracks"),
+            params: KeyValuePairs::default(),
+        });
+        let mut frame = Vec::new();
+        request.encode(&mut frame).expect("encode SUBSCRIBE_TRACKS");
+        let mut frame = Cursor::new(frame);
+        while frame.position() < frame.get_ref().len() as u64 {
+            request_send
+                .write_buf(&mut frame)
+                .await
+                .expect("write SUBSCRIBE_TRACKS");
+        }
+
+        let mut response_buffer = Vec::new();
+        let (message_type, _) = tokio::time::timeout(
+            Duration::from_secs(2),
+            read_bidi_response_frame(&mut response_recv, &mut response_buffer),
+        )
+        .await
+        .expect("REQUEST_OK timed out");
+        assert_eq!(message_type, wire_id::RequestOk);
+
+        let (message_type, payload) = tokio::time::timeout(
+            Duration::from_secs(2),
+            read_bidi_response_frame(&mut response_recv, &mut response_buffer),
+        )
+        .await
+        .expect("PUBLISH_BLOCKED timed out");
+        assert_eq!(message_type, wire_id::PublishBlocked);
+        let blocked = PublishBlocked::decode(&mut Cursor::new(payload))
+            .expect("decode PUBLISH_BLOCKED payload");
+        assert_eq!(blocked.track_name, TrackName::from("blocked"));
+        assert_eq!(slot_permits.available_permits(), 1);
+
+        // Keep this task scheduled while overflowing the 1024-entry broadcast
+        // channel, with the matching change outside the retained tail.
+        const CHANGE_BURST: usize = 1025;
+        let mut registrations = Vec::with_capacity(CHANGE_BURST * 2 + 1);
+        for index in 0..CHANGE_BURST {
+            let (_writer, reader) = Track::new(
+                TrackNamespace::from_utf8_path(&format!("unrelated/before/{index}")),
+                "noise",
+            )
+            .produce();
+            registrations.push(
+                registering_locals
+                    .register_track(None, reader)
+                    .await
+                    .expect("register leading unrelated track"),
+            );
+        }
+        let (_writer, reader) = Track::new(namespace, "resynced").produce();
+        registrations.push(
+            registering_locals
+                .register_track(None, reader)
+                .await
+                .expect("register matching track for resync"),
+        );
+        for index in 0..CHANGE_BURST {
+            let (_writer, reader) = Track::new(
+                TrackNamespace::from_utf8_path(&format!("unrelated/after/{index}")),
+                "noise",
+            )
+            .produce();
+            registrations.push(
+                registering_locals
+                    .register_track(None, reader)
+                    .await
+                    .expect("register trailing unrelated track"),
+            );
+        }
+
+        let (message_type, payload) = tokio::time::timeout(
+            Duration::from_secs(2),
+            read_bidi_response_frame(&mut response_recv, &mut response_buffer),
+        )
+        .await
+        .expect("resynced PUBLISH_BLOCKED timed out");
+        assert_eq!(message_type, wire_id::PublishBlocked);
+        let blocked = PublishBlocked::decode(&mut Cursor::new(payload))
+            .expect("decode resynced PUBLISH_BLOCKED payload");
+        assert_eq!(blocked.track_name, TrackName::from("resynced"));
+        assert_eq!(slot_permits.available_permits(), 0);
+
+        request_send
+            .finish()
+            .expect("finish SUBSCRIBE_TRACKS request");
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while slot_permits.available_permits() < 2 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("request cancellation did not release slot permit");
+        assert_eq!(slot_permits.available_permits(), 2);
+    }
+
+    #[test]
+    fn subscribe_tracks_generation_replacement_waits_for_completion() {
+        let permits = Arc::new(Semaphore::new(1));
+        let first = test_track("replacement");
+        let replacement = test_track("replacement");
+        let mut slot = SubscribeTracksSlot {
+            desired: Some(first.clone()),
+            active: Some(first.clone()),
+            publish_blocked_tombstone: false,
+            _session_slot_permit: permits.try_acquire_owned().expect("acquire slot permit"),
+        };
+
+        assert!(slot.set_desired(replacement.clone()));
+        assert_eq!(slot.complete(&first), SubscribeTracksSlotAction::Publish);
+        assert!(slot.active.is_none());
+        assert!(slot
+            .desired
+            .as_ref()
+            .is_some_and(|desired| super::same_track_generation(desired, &replacement)));
+
+        slot.active = Some(replacement.clone());
+        assert_eq!(
+            slot.complete(&replacement),
+            SubscribeTracksSlotAction::Remove
+        );
+    }
+
+    #[test]
+    fn stale_subscribe_tracks_removal_preserves_replacement() {
+        let permits = Arc::new(Semaphore::new(1));
+        let first = test_track("stale-removal");
+        let replacement = test_track("stale-removal");
+        let mut slot = SubscribeTracksSlot {
+            desired: Some(replacement.clone()),
+            active: Some(first.clone()),
+            publish_blocked_tombstone: false,
+            _session_slot_permit: permits.try_acquire_owned().expect("acquire slot permit"),
+        };
+
+        assert!(!slot.remove_desired(&first));
+        assert!(slot
+            .desired
+            .as_ref()
+            .is_some_and(|desired| super::same_track_generation(desired, &replacement)));
     }
 
     /// draft-18 §10.2.6: absent and 0 both mean answer immediately, so neither

--- a/moq-relay-ietf/src/session.rs
+++ b/moq-relay-ietf/src/session.rs
@@ -3,6 +3,7 @@
 
 use std::collections::BTreeMap;
 use std::net::{IpAddr, SocketAddr};
+use std::sync::Arc;
 
 use futures::{stream::FuturesUnordered, FutureExt, StreamExt};
 use moq_transport::session::{Publisher, SessionError, Subscriber};
@@ -251,6 +252,19 @@ pub trait ConnectionTagger: Send + Sync {
 
 /// Context carried by relay-side producer and consumer tasks for one MoQT session.
 #[derive(Debug, Clone)]
+pub(crate) struct SessionIdentity(Arc<()>);
+
+impl SessionIdentity {
+    fn new() -> Self {
+        Self(Arc::new(()))
+    }
+
+    pub(crate) fn same_as(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct SessionContext {
     /// The resolved scope identity for this session, if any.
     pub scope: Option<String>,
@@ -264,6 +278,8 @@ pub struct SessionContext {
     /// destination URL is known. Inbound connections leave this `None` even
     /// when classified internal, since only the remote socket address is known.
     pub peer: Option<RelayInfo>,
+
+    identity: SessionIdentity,
 }
 
 impl SessionContext {
@@ -273,6 +289,7 @@ impl SessionContext {
             scope,
             interface: SessionInterface::Public,
             peer: None,
+            identity: SessionIdentity::new(),
         }
     }
 
@@ -282,6 +299,7 @@ impl SessionContext {
             scope,
             interface: SessionInterface::Internal,
             peer,
+            identity: SessionIdentity::new(),
         }
     }
 
@@ -308,12 +326,17 @@ impl SessionContext {
             scope,
             interface,
             peer,
+            identity: SessionIdentity::new(),
         }
     }
 
     /// The resolved scope identity, if any.
     pub fn scope(&self) -> Option<&str> {
         self.scope.as_deref()
+    }
+
+    pub(crate) fn identity(&self) -> &SessionIdentity {
+        &self.identity
     }
 
     /// Build the [`CoordinatorContext`] for coordinator calls made on behalf
@@ -409,7 +432,7 @@ impl Session {
         }
     }
 
-    /// Drain incoming SUBSCRIBE and SUBSCRIBE_NAMESPACE requests and reject each one.
+    /// Drain incoming subscribe requests and reject each one.
     ///
     /// The transport `Publisher` queues incoming SUBSCRIBE messages as
     /// `Subscribed` events. Dropping a `Subscribed` without calling `ok()`
@@ -418,6 +441,7 @@ impl Session {
     async fn drain_and_reject_subscribes(mut publisher: Publisher) -> Result<(), SessionError> {
         loop {
             let mut namespace_publisher = publisher.clone();
+            let mut tracks_publisher = publisher.clone();
             tokio::select! {
                 Some(subscribed) = publisher.subscribed() => {
                     tracing::debug!(
@@ -433,6 +457,16 @@ impl Session {
                         "rejecting SUBSCRIBE_NAMESPACE: subscribe not permitted for this session"
                     );
                     drop(subscribed_namespace);
+                }
+                Some(subscribed_tracks) = tracks_publisher.subscribed_tracks() => {
+                    tracing::debug!(
+                        namespace_prefix = %subscribed_tracks.namespace_prefix,
+                        "rejecting SUBSCRIBE_TRACKS: subscribe not permitted for this session"
+                    );
+                    subscribed_tracks.reject(
+                        moq_transport::message::RequestErrorCode::Unauthorized as u64,
+                        "subscribe not permitted",
+                    )?;
                 }
                 else => return Ok(()),
             }

--- a/moq-transport/src/coding/kvp.rs
+++ b/moq-transport/src/coding/kvp.rs
@@ -92,7 +92,7 @@ impl KeyValuePair {
         r: &mut R,
         prev: u64,
     ) -> Result<(Self, u64), DecodeError> {
-        Self::decode_with_prev_typed(r, prev, &[])
+        Self::decode_with_prev_typed(r, prev, &[], &[])
     }
 
     /// Like [`decode_with_prev`](KeyValuePair::decode_with_prev), but the
@@ -106,6 +106,7 @@ impl KeyValuePair {
         r: &mut R,
         prev: u64,
         u8_value_types: &[u64],
+        two_varint_value_types: &[u64],
     ) -> Result<(Self, u64), DecodeError> {
         let delta = u64::decode(r)?;
 
@@ -118,6 +119,17 @@ impl KeyValuePair {
             // Draft-17+ typed parameter → single raw uint8 value.
             let value = u8::decode(r)?;
             KeyValuePair::new_int(abs_type, value.into())
+        } else if two_varint_value_types.contains(&abs_type) {
+            let first = u64::decode(r)?;
+            let second = u64::decode(r)?;
+            let mut value = Vec::new();
+            first
+                .encode(&mut value)
+                .map_err(|_| DecodeError::InvalidParameter)?;
+            second
+                .encode(&mut value)
+                .map_err(|_| DecodeError::InvalidParameter)?;
+            KeyValuePair::new_bytes(abs_type, value)
         } else if abs_type % 2 == 0 {
             // Even type → varint value.
             let value = u64::decode(r)?;
@@ -145,7 +157,7 @@ impl KeyValuePair {
         w: &mut W,
         prev: u64,
     ) -> Result<u64, EncodeError> {
-        self.encode_with_prev_typed(w, prev, &[])
+        self.encode_with_prev_typed(w, prev, &[], &[])
     }
 
     /// Like [`encode_with_prev`](KeyValuePair::encode_with_prev), but the keys
@@ -159,6 +171,7 @@ impl KeyValuePair {
         w: &mut W,
         prev: u64,
         u8_value_types: &[u64],
+        two_varint_value_types: &[u64],
     ) -> Result<u64, EncodeError> {
         // Keys must be consistent with their value parity.
         match &self.value {
@@ -186,6 +199,17 @@ impl KeyValuePair {
                 }
             }
             Value::BytesValue(v) => {
+                if two_varint_value_types.contains(&self.key) {
+                    let mut value = bytes::Bytes::copy_from_slice(v);
+                    let first = u64::decode(&mut value).map_err(|_| EncodeError::InvalidValue)?;
+                    let second = u64::decode(&mut value).map_err(|_| EncodeError::InvalidValue)?;
+                    if value.has_remaining() {
+                        return Err(EncodeError::InvalidValue);
+                    }
+                    first.encode(w)?;
+                    second.encode(w)?;
+                    return Ok(self.key);
+                }
                 if v.len() > MAX_BYTES_VALUE_LEN {
                     return Err(EncodeError::KeyValuePairLengthExceeded);
                 }
@@ -265,6 +289,14 @@ impl KeyValuePairs {
         r: &mut R,
         u8_value_types: &[u64],
     ) -> Result<Self, DecodeError> {
+        Self::decode_with_value_types(r, u8_value_types, &[])
+    }
+
+    pub(crate) fn decode_with_value_types<R: bytes::Buf>(
+        r: &mut R,
+        u8_value_types: &[u64],
+        two_varint_value_types: &[u64],
+    ) -> Result<Self, DecodeError> {
         let count = u64::decode(r)?;
 
         // `count` is peer-controlled, so do not allocate directly from it.
@@ -277,7 +309,12 @@ impl KeyValuePairs {
         let mut prev = 0u64;
 
         for _ in 0..count {
-            let (pair, new_prev) = KeyValuePair::decode_with_prev_typed(r, prev, u8_value_types)?;
+            let (pair, new_prev) = KeyValuePair::decode_with_prev_typed(
+                r,
+                prev,
+                u8_value_types,
+                two_varint_value_types,
+            )?;
             prev = new_prev;
             kvps.push(pair);
         }
@@ -294,6 +331,15 @@ impl KeyValuePairs {
         w: &mut W,
         u8_value_types: &[u64],
     ) -> Result<(), EncodeError> {
+        self.encode_with_value_types(w, u8_value_types, &[])
+    }
+
+    pub(crate) fn encode_with_value_types<W: bytes::BufMut>(
+        &self,
+        w: &mut W,
+        u8_value_types: &[u64],
+        two_varint_value_types: &[u64],
+    ) -> Result<(), EncodeError> {
         // Sort a working copy by ascending key before encoding so the delta is
         // always non-negative.  The internal Vec is not required to be sorted.
         let mut sorted: Vec<&KeyValuePair> = self.0.iter().collect();
@@ -303,7 +349,7 @@ impl KeyValuePairs {
 
         let mut prev = 0u64;
         for kvp in &sorted {
-            prev = kvp.encode_with_prev_typed(w, prev, u8_value_types)?;
+            prev = kvp.encode_with_prev_typed(w, prev, u8_value_types, two_varint_value_types)?;
         }
 
         Ok(())

--- a/moq-transport/src/coding/track_namespace.rs
+++ b/moq-transport/src/coding/track_namespace.rs
@@ -453,6 +453,13 @@ impl TrackNamespacePrefix {
             .all(|(left, right)| left == right)
     }
 
+    fn validate_namespace_byte_len(&self) -> Result<(), DecodeError> {
+        if namespace_fields_byte_len(&self.fields) > MAX_FULL_TRACK_NAME_LEN {
+            return Err(DecodeError::TrackNameTooLong);
+        }
+        Ok(())
+    }
+
     /// Build a full namespace from this prefix and a suffix received in NAMESPACE.
     pub fn join_suffix(
         &self,
@@ -475,12 +482,19 @@ impl Decode for TrackNamespacePrefix {
     fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
         // Draft-16 §9.25: prefixes have 0-32 non-empty fields.
         let fields = decode_namespace_fields(r, 0, Self::MAX_FIELDS, "TrackNamespacePrefix")?;
-        Ok(Self { fields })
+        let prefix = Self { fields };
+        prefix.validate_namespace_byte_len()?;
+        Ok(prefix)
     }
 }
 
 impl Encode for TrackNamespacePrefix {
     fn encode<W: bytes::BufMut>(&self, w: &mut W) -> Result<(), EncodeError> {
+        if namespace_fields_byte_len(&self.fields) > MAX_FULL_TRACK_NAME_LEN {
+            return Err(EncodeError::FieldBoundsExceeded(
+                "TrackNamespacePrefix".to_string(),
+            ));
+        }
         encode_namespace_fields(&self.fields, 0, Self::MAX_FIELDS, "TrackNamespacePrefix", w)
     }
 }
@@ -782,6 +796,26 @@ mod tests {
         assert!(matches!(
             prefix.encode(&mut buf).unwrap_err(),
             EncodeError::EmptyNamespaceField
+        ));
+    }
+
+    #[test]
+    fn prefix_rejects_total_over_limit() {
+        let prefix = TrackNamespacePrefix {
+            fields: vec![
+                TupleField {
+                    value: vec![b'a'; 2049],
+                },
+                TupleField {
+                    value: vec![b'b'; 2048],
+                },
+            ],
+        };
+        let mut buf = BytesMut::new();
+
+        assert!(matches!(
+            prefix.encode(&mut buf).unwrap_err(),
+            EncodeError::FieldBoundsExceeded(_)
         ));
     }
 

--- a/moq-transport/src/message/mod.rs
+++ b/moq-transport/src/message/mod.rs
@@ -30,6 +30,7 @@ mod namespace;
 mod params;
 mod pubilsh_namespace_done;
 mod publish;
+mod publish_blocked;
 mod publish_done;
 mod publish_namespace;
 mod publish_namespace_cancel;
@@ -42,6 +43,7 @@ mod request_update;
 mod subscribe;
 mod subscribe_namespace;
 mod subscribe_ok;
+mod subscribe_tracks;
 mod subscriber;
 mod track_status;
 mod unsubscribe;
@@ -58,6 +60,7 @@ pub use namespace::*;
 pub use params::*;
 pub use pubilsh_namespace_done::*;
 pub use publish::*;
+pub use publish_blocked::*;
 pub use publish_done::*;
 pub use publish_namespace::*;
 pub use publish_namespace_cancel::*;
@@ -70,6 +73,7 @@ pub use request_update::*;
 pub use subscribe::*;
 pub use subscribe_namespace::*;
 pub use subscribe_ok::*;
+pub use subscribe_tracks::*;
 pub use subscriber::*;
 pub use track_status::*;
 pub use unsubscribe::*;
@@ -181,6 +185,7 @@ macro_rules! message_types {
                     Self::Fetch(m) => &m.params,
                     Self::FetchOk(m) => &m.params,
                     Self::SubscribeNamespace(m) => &m.params,
+                    Self::SubscribeTracks(m) => &m.params,
                     _ => return true,
                 };
 
@@ -199,6 +204,7 @@ macro_rules! message_types {
                     Self::Fetch(m) => Some(m.id),
                     Self::TrackStatus(m) => Some(m.id),
                     Self::SubscribeNamespace(m) => Some(m.id),
+                    Self::SubscribeTracks(m) => Some(m.id),
                     Self::Publish(m) => Some(m.id),
                     Self::PublishNamespace(m) => Some(m.id),
                     _ => None,
@@ -267,6 +273,7 @@ message_types! {
     Publish         = 0x1d,
     PublishDone     = 0xb,
     PublishOk       = 0x1e,
+    PublishBlocked  = 0x0f,
 
     // ── FETCH family ─────────────────────────────────────────────────────────
     Fetch           = 0x16,
@@ -275,6 +282,7 @@ message_types! {
 
     // ── SUBSCRIBE_NAMESPACE (bidi stream; §10.18) ────────────────────────────
     SubscribeNamespace = 0x50,
+    SubscribeTracks = 0x51,
 
     // ── Session management ────────────────────────────────────────────────────
     GoAway          = 0x10,
@@ -357,24 +365,33 @@ mod tests {
         );
 
         assert_sequenced(
-            Message::Publish(Publish {
+            Message::SubscribeTracks(SubscribeTracks {
                 id: 10,
+                track_namespace_prefix: TrackNamespacePrefix::from_utf8_path("test/ns"),
+                params: KeyValuePairs::default(),
+            }),
+            10,
+        );
+
+        assert_sequenced(
+            Message::Publish(Publish {
+                id: 12,
                 track_namespace: namespace(),
                 track_name: "track".into(),
                 track_alias: 1,
                 params: KeyValuePairs::default(),
                 track_extensions: TrackExtensions::default(),
             }),
-            10,
+            12,
         );
 
         assert_sequenced(
             Message::PublishNamespace(PublishNamespace {
-                id: 12,
+                id: 14,
                 track_namespace: namespace(),
                 params: KeyValuePairs::default(),
             }),
-            12,
+            14,
         );
     }
 
@@ -473,6 +490,34 @@ mod tests {
         };
         assert_eq!(decoded.params.rendezvous_timeout().unwrap(), Some(1_000));
         assert!(decoded.params.get(123).is_some());
+
+        let mut params = KeyValuePairs::default();
+        params.set_subscriber_priority(128);
+        let subscribe_tracks = Message::SubscribeTracks(SubscribeTracks {
+            id: 4,
+            track_namespace_prefix: TrackNamespacePrefix::new(),
+            params,
+        });
+        encoded.clear();
+        assert!(matches!(
+            subscribe_tracks.encode(&mut encoded),
+            Err(EncodeError::InvalidValue)
+        ));
+
+        let mut params = KeyValuePairs::default();
+        params.set_forward(false);
+        params.set_bytesvalue(parameter_type::AUTHORIZATION_TOKEN, vec![1, 2, 3]);
+        let subscribe_tracks = Message::SubscribeTracks(SubscribeTracks {
+            id: 4,
+            track_namespace_prefix: TrackNamespacePrefix::new(),
+            params,
+        });
+        encoded.clear();
+        subscribe_tracks.encode(&mut encoded).unwrap();
+        assert!(matches!(
+            Message::decode(&mut encoded).unwrap(),
+            Message::SubscribeTracks(_)
+        ));
     }
 
     #[test]
@@ -574,6 +619,23 @@ mod tests {
                 params: KeyValuePairs::default(),
             })),
             vec![0x50, 0x00, 0x04, 0x00, 0x00, 0x02, 0x00]
+        );
+
+        assert_eq!(
+            encoded(Message::SubscribeTracks(SubscribeTracks {
+                id: 0,
+                track_namespace_prefix: TrackNamespacePrefix::new(),
+                params: KeyValuePairs::default(),
+            })),
+            vec![0x51, 0x00, 0x03, 0x00, 0x00, 0x00]
+        );
+
+        assert_eq!(
+            encoded(Message::PublishBlocked(PublishBlocked {
+                track_namespace_suffix: TrackNamespacePrefix::new(),
+                track_name: "t".into(),
+            })),
+            vec![0x0f, 0x00, 0x03, 0x00, 0x01, b't']
         );
     }
 }

--- a/moq-transport/src/message/params.rs
+++ b/moq-transport/src/message/params.rs
@@ -41,6 +41,8 @@ pub const U8_VALUE_PARAMETER_TYPES: &[u64] = &[
     parameter_type::GROUP_ORDER,         // 0x22
 ];
 
+const TWO_VARINT_VALUE_PARAMETER_TYPES: &[u64] = &[parameter_type::LARGEST_OBJECT];
+
 /// Message scopes enforced for supported parameters with restricted use.
 /// Unknown parameter types remain available for negotiated extensions.
 const MESSAGE_PARAMETER_SCOPES: &[(u64, &[u64])] =
@@ -291,16 +293,32 @@ impl KeyValuePairs {
     /// generic [`KeyValuePairs::decode`], otherwise a peer's single-byte
     /// SUBSCRIBER_PRIORITY (default 128) desynchronises the whole block.
     pub fn decode_message_params<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
-        Self::decode_with_u8_types(r, U8_VALUE_PARAMETER_TYPES)
+        Self::decode_with_value_types(
+            r,
+            U8_VALUE_PARAMETER_TYPES,
+            TWO_VARINT_VALUE_PARAMETER_TYPES,
+        )
     }
 
     /// Encode a draft-18 §10.2 message-parameter block. Counterpart to
     /// [`decode_message_params`](KeyValuePairs::decode_message_params).
     pub fn encode_message_params<W: bytes::BufMut>(&self, w: &mut W) -> Result<(), EncodeError> {
-        self.encode_with_u8_types(w, U8_VALUE_PARAMETER_TYPES)
+        self.encode_with_value_types(
+            w,
+            U8_VALUE_PARAMETER_TYPES,
+            TWO_VARINT_VALUE_PARAMETER_TYPES,
+        )
     }
 
     pub(crate) fn parameters_allowed_on(&self, message_type: u64) -> bool {
+        if message_type == wire_id::SubscribeTracks {
+            return self.0.iter().all(|parameter| {
+                matches!(
+                    parameter.key,
+                    parameter_type::AUTHORIZATION_TOKEN | parameter_type::FORWARD
+                )
+            });
+        }
         self.0.iter().all(|parameter| {
             MESSAGE_PARAMETER_SCOPES
                 .iter()
@@ -430,6 +448,7 @@ impl KeyValuePairs {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bytes::BytesMut;
 
     #[test]
     fn key_value_pairs_message_parameter_methods_round_trip_typed_values() {
@@ -475,6 +494,27 @@ mod tests {
     #[test]
     fn rendezvous_timeout_absent_is_none() {
         assert_eq!(KeyValuePairs::default().rendezvous_timeout().unwrap(), None);
+    }
+
+    #[test]
+    fn largest_object_uses_two_inline_varints() {
+        let mut params = KeyValuePairs::default();
+        params.set_largest_object(Location::new(4, 5)).unwrap();
+        let mut encoded = BytesMut::new();
+
+        params.encode_message_params(&mut encoded).unwrap();
+
+        assert_eq!(
+            encoded.as_ref(),
+            &[1, parameter_type::LARGEST_OBJECT as u8, 4, 5]
+        );
+        assert_eq!(
+            KeyValuePairs::decode_message_params(&mut encoded)
+                .unwrap()
+                .largest_object()
+                .unwrap(),
+            Some(Location::new(4, 5))
+        );
     }
 
     #[test]

--- a/moq-transport/src/message/publish_blocked.rs
+++ b/moq-transport/src/message/publish_blocked.rs
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2026 Cloudflare Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use crate::coding::{Decode, DecodeError, Encode, EncodeError, TrackName, TrackNamespacePrefix};
+
+/// A track matching SUBSCRIBE_TRACKS that cannot be sent as PUBLISH.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PublishBlocked {
+    pub track_namespace_suffix: TrackNamespacePrefix,
+    pub track_name: TrackName,
+}
+
+impl Decode for PublishBlocked {
+    fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
+        Ok(Self {
+            track_namespace_suffix: TrackNamespacePrefix::decode(r)?,
+            track_name: TrackName::decode(r)?,
+        })
+    }
+}
+
+impl Encode for PublishBlocked {
+    fn encode<W: bytes::BufMut>(&self, w: &mut W) -> Result<(), EncodeError> {
+        self.track_namespace_suffix.encode(w)?;
+        self.track_name.encode(w)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::BytesMut;
+
+    #[test]
+    fn encode_decode() {
+        let message = PublishBlocked {
+            track_namespace_suffix: TrackNamespacePrefix::from_utf8_path("participant/100"),
+            track_name: "video".into(),
+        };
+        let mut buf = BytesMut::new();
+
+        message.encode(&mut buf).unwrap();
+
+        assert_eq!(PublishBlocked::decode(&mut buf).unwrap(), message);
+    }
+}

--- a/moq-transport/src/message/publisher.rs
+++ b/moq-transport/src/message/publisher.rs
@@ -57,6 +57,7 @@ publisher_msgs! {
     // Publisher-initiated subscriptions.
     Publish,
     PublishDone,
+    PublishBlocked,
     // Responses to subscriber-initiated requests.
     SubscribeOk,
     RequestOk,

--- a/moq-transport/src/message/subscribe_tracks.rs
+++ b/moq-transport/src/message/subscribe_tracks.rs
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 Cloudflare Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use crate::coding::{
+    Decode, DecodeError, Encode, EncodeError, KeyValuePairs, TrackNamespacePrefix,
+};
+
+/// Solicit existing and future PUBLISH requests under a namespace prefix.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SubscribeTracks {
+    pub id: u64,
+    pub track_namespace_prefix: TrackNamespacePrefix,
+    pub params: KeyValuePairs,
+}
+
+impl Decode for SubscribeTracks {
+    fn decode<R: bytes::Buf>(r: &mut R) -> Result<Self, DecodeError> {
+        Ok(Self {
+            id: u64::decode(r)?,
+            track_namespace_prefix: TrackNamespacePrefix::decode(r)?,
+            params: KeyValuePairs::decode_message_params(r)?,
+        })
+    }
+}
+
+impl Encode for SubscribeTracks {
+    fn encode<W: bytes::BufMut>(&self, w: &mut W) -> Result<(), EncodeError> {
+        self.id.encode(w)?;
+        self.track_namespace_prefix.encode(w)?;
+        self.params.encode_message_params(w)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::BytesMut;
+
+    #[test]
+    fn encode_decode() {
+        let mut params = KeyValuePairs::default();
+        params.set_forward(false);
+        let message = SubscribeTracks {
+            id: 42,
+            track_namespace_prefix: TrackNamespacePrefix::from_utf8_path("room/123"),
+            params,
+        };
+        let mut buf = BytesMut::new();
+
+        message.encode(&mut buf).unwrap();
+
+        assert_eq!(SubscribeTracks::decode(&mut buf).unwrap(), message);
+    }
+}

--- a/moq-transport/src/message/subscriber.rs
+++ b/moq-transport/src/message/subscriber.rs
@@ -62,6 +62,7 @@ subscriber_msgs! {
     FetchCancel,
     TrackStatus,
     SubscribeNamespace,
+    SubscribeTracks,
     // Responses/control for publisher-initiated requests.
     PublishNamespaceCancel,
     PublishOk,

--- a/moq-transport/src/session/error.rs
+++ b/moq-transport/src/session/error.rs
@@ -157,7 +157,7 @@ impl SessionError {
     /// request stream, and a request that legitimately fails (an unknown track,
     /// say). Collapsing those into "close the session" would let any subscriber
     /// kill the connection by asking for something that does not exist.
-    pub(crate) fn is_session_fatal(&self) -> bool {
+    pub fn is_session_fatal(&self) -> bool {
         if self.is_stream_ended() {
             return false;
         }

--- a/moq-transport/src/session/mod.rs
+++ b/moq-transport/src/session/mod.rs
@@ -16,6 +16,7 @@ mod subscribe;
 mod subscribe_namespace;
 mod subscribed;
 mod subscribed_namespace;
+mod subscribed_tracks;
 mod subscriber;
 mod track_status_requested;
 mod writer;
@@ -35,6 +36,7 @@ pub use subscribe::*;
 pub use subscribe_namespace::*;
 pub use subscribed::*;
 pub use subscribed_namespace::*;
+pub use subscribed_tracks::*;
 pub use subscriber::*;
 pub use track_status_requested::*;
 
@@ -469,6 +471,26 @@ impl Session {
                     msg_type = "SUBSCRIBE_NAMESPACE",
                     request_id = m.id,
                     namespace_prefix = %m.track_namespace_prefix,
+                    "MoQT control message"
+                );
+            }
+            Message::SubscribeTracks(m) => {
+                tracing::debug!(
+                    target: "moq_transport::control",
+                    direction,
+                    msg_type = "SUBSCRIBE_TRACKS",
+                    request_id = m.id,
+                    namespace_prefix = %m.track_namespace_prefix,
+                    "MoQT control message"
+                );
+            }
+            Message::PublishBlocked(m) => {
+                tracing::debug!(
+                    target: "moq_transport::control",
+                    direction,
+                    msg_type = "PUBLISH_BLOCKED",
+                    namespace_suffix = %m.track_namespace_suffix,
+                    track_name = %m.track_name,
                     "MoQT control message"
                 );
             }
@@ -984,7 +1006,7 @@ impl Session {
     /// one-shot request types (TRACK_STATUS, REQUEST_UPDATE).
     ///
     /// Long-lived request types (SUBSCRIBE, PUBLISH_NAMESPACE, PUBLISH,
-    /// SUBSCRIBE_NAMESPACE, FETCH) intentionally keep their bidi stream open
+    /// SUBSCRIBE_NAMESPACE, SUBSCRIBE_TRACKS, FETCH) intentionally keep their bidi stream open
     /// until an explicit terminal message, so they are deliberately NOT bounded
     /// here — bounding them would break the protocol. For those, the QUIC
     /// connection idle timeout (configured by the transport layer; e.g.
@@ -1111,6 +1133,15 @@ impl Session {
                 .as_mut()
                 .ok_or(SessionError::RoleViolation)?
                 .recv_subscribe_namespace(msg)?;
+            return recv.run(writer, reader, mlog).await;
+        }
+
+        if let Message::SubscribeTracks(msg) = msg {
+            request_id.validate_incoming(msg.id)?;
+            let recv = publisher
+                .as_mut()
+                .ok_or(SessionError::RoleViolation)?
+                .recv_subscribe_tracks(msg)?;
             return recv.run(writer, reader, mlog).await;
         }
         let mut writer = ResetOnDropWriter::new(writer);
@@ -1444,6 +1475,10 @@ impl Session {
             Message::NamespaceDone(m) => {
                 m.track_namespace_suffix.encode(&mut payload)?;
             }
+            Message::PublishBlocked(m) => {
+                m.track_namespace_suffix.encode(&mut payload)?;
+                m.track_name.encode(&mut payload)?;
+            }
             Message::PublishOk(m) => {
                 m.params.encode_message_params(&mut payload)?;
             }
@@ -1566,6 +1601,14 @@ impl Session {
                 let track_namespace_suffix = crate::coding::TrackNamespacePrefix::decode(&mut buf)?;
                 Ok(Message::NamespaceDone(message::NamespaceDone {
                     track_namespace_suffix,
+                }))
+            }
+            wire_id::PublishBlocked => {
+                let track_namespace_suffix = crate::coding::TrackNamespacePrefix::decode(&mut buf)?;
+                let track_name = crate::coding::TrackName::decode(&mut buf)?;
+                Ok(Message::PublishBlocked(message::PublishBlocked {
+                    track_namespace_suffix,
+                    track_name,
                 }))
             }
             wire_id::PublishOk => {
@@ -2614,6 +2657,49 @@ mod tests {
 
             assert_eq!(encode_bidi_response_bytes(&msg), plain.to_vec());
         }
+    }
+
+    #[test]
+    fn encode_bidi_publish_blocked_matches_plain_message_encoding() {
+        let msg = Message::PublishBlocked(message::PublishBlocked {
+            track_namespace_suffix: crate::coding::TrackNamespacePrefix::from_utf8_path(
+                "participant=5",
+            ),
+            track_name: "video".into(),
+        });
+        let mut plain = bytes::BytesMut::new();
+        msg.encode(&mut plain).unwrap();
+
+        assert_eq!(encode_bidi_response_bytes(&msg), plain.to_vec());
+    }
+
+    #[tokio::test]
+    async fn decode_bidi_publish_blocked() {
+        let (requester, responder) = test_support::loopback_session_pair().await;
+        let (_request_send, response_recv) = requester.open_bi().await.unwrap();
+        let (response_send, _request_recv) = responder.accept_bi().await.unwrap();
+        let msg = Message::PublishBlocked(message::PublishBlocked {
+            track_namespace_suffix: crate::coding::TrackNamespacePrefix::from_utf8_path(
+                "participant=5",
+            ),
+            track_name: "video".into(),
+        });
+        Session::encode_bidi_response(&mut Writer::new(response_send), &msg)
+            .await
+            .unwrap();
+
+        let Message::PublishBlocked(blocked) =
+            Session::decode_bidi_response(&mut Reader::new(response_recv), 42)
+                .await
+                .unwrap()
+        else {
+            panic!("expected PUBLISH_BLOCKED");
+        };
+        assert_eq!(
+            blocked.track_namespace_suffix,
+            crate::coding::TrackNamespacePrefix::from_utf8_path("participant=5")
+        );
+        assert_eq!(blocked.track_name, crate::coding::TrackName::from("video"));
     }
 
     #[test]

--- a/moq-transport/src/session/publisher.rs
+++ b/moq-transport/src/session/publisher.rs
@@ -22,7 +22,8 @@ use super::{
     split_published_state, BidiResponse, BidiResponseMap, DeliveryError, NameRegistry,
     ObjectForwarderRecv, PublishNamespace, PublishNamespaceRecv, Published, PublishedInfo,
     PublishedRecv, Reader, RequestId, Session, SessionError, Subscribed, SubscribedNamespace,
-    SubscribedNamespaceInfo, SubscribedNamespaceRecv, TrackStatusRequested, Writer,
+    SubscribedNamespaceInfo, SubscribedNamespaceRecv, SubscribedTracks, SubscribedTracksInfo,
+    SubscribedTracksRecv, TrackStatusRequested, Writer,
 };
 use crate::message::RequestErrorCode;
 
@@ -112,6 +113,12 @@ pub struct Publisher {
 
     /// SUBSCRIBE_NAMESPACE requests surfaced to the application.
     unknown_subscribed_namespace: Queue<SubscribedNamespace>,
+
+    /// Active inbound SUBSCRIBE_TRACKS prefixes, including pending requests.
+    subscribed_tracks_prefixes: Arc<Mutex<HashMap<u64, TrackNamespacePrefix>>>,
+
+    /// SUBSCRIBE_TRACKS requests surfaced to the application.
+    unknown_subscribed_tracks: Queue<SubscribedTracks>,
 
     /// Queue for outbound control messages; processed by the session run_send task.
     outgoing: Queue<Message>,
@@ -218,6 +225,8 @@ impl Publisher {
             unknown_track_status_requested: Default::default(),
             subscribed_namespace_prefixes: Default::default(),
             unknown_subscribed_namespace: Default::default(),
+            subscribed_tracks_prefixes: Default::default(),
+            unknown_subscribed_tracks: Default::default(),
             outgoing,
             request_id,
             mlog,
@@ -843,6 +852,11 @@ impl Publisher {
         self.unknown_subscribed_namespace.pop().await
     }
 
+    /// Returns the next inbound SUBSCRIBE_TRACKS request.
+    pub async fn subscribed_tracks(&mut self) -> Option<SubscribedTracks> {
+        self.unknown_subscribed_tracks.pop().await
+    }
+
     /// Accept an inbound SUBSCRIBE_NAMESPACE and surface it to the application.
     ///
     /// Returns the transport-side half, which the caller drives with the
@@ -887,6 +901,48 @@ impl Publisher {
     }
 
     fn has_subscribed_namespace_overlap(
+        prefixes: &HashMap<u64, TrackNamespacePrefix>,
+        prefix: &TrackNamespacePrefix,
+    ) -> bool {
+        prefixes.values().any(|existing| existing.overlaps(prefix))
+    }
+
+    pub(super) fn recv_subscribe_tracks(
+        &mut self,
+        msg: message::SubscribeTracks,
+    ) -> Result<SubscribedTracksRecv, SessionError> {
+        let forward = msg.params.forward()?.unwrap_or(true);
+        {
+            let mut prefixes = self
+                .subscribed_tracks_prefixes
+                .lock()
+                .map_err(|_| SessionError::Internal)?;
+            if Self::has_subscribed_tracks_overlap(&prefixes, &msg.track_namespace_prefix) {
+                return Ok(SubscribedTracksRecv::rejected(
+                    msg.id,
+                    RequestErrorCode::PrefixOverlap as u64,
+                    "prefix overlap",
+                ));
+            }
+            prefixes.insert(msg.id, msg.track_namespace_prefix.clone());
+        }
+
+        let info = SubscribedTracksInfo {
+            request_id: msg.id,
+            namespace_prefix: msg.track_namespace_prefix,
+            forward,
+            params: msg.params,
+        };
+        let (mut request, recv) =
+            SubscribedTracks::new(info, self.subscribed_tracks_prefixes.clone());
+        if let Err(returned) = self.unknown_subscribed_tracks.push(request) {
+            request = returned;
+            request.reject(RequestErrorCode::InternalError as u64, "internal error")?;
+        }
+        Ok(recv)
+    }
+
+    fn has_subscribed_tracks_overlap(
         prefixes: &HashMap<u64, TrackNamespacePrefix>,
         prefix: &TrackNamespacePrefix,
     ) -> bool {
@@ -957,6 +1013,11 @@ impl Publisher {
             // SUBSCRIBE_NAMESPACE not yet implemented — send REQUEST_ERROR NOT_SUPPORTED (§4).
             message::Subscriber::SubscribeNamespace(msg) => {
                 self.send_not_supported(msg.id, "subscribe_namespace");
+            }
+            message::Subscriber::SubscribeTracks(_) => {
+                return Err(SessionError::ProtocolViolation(
+                    "SUBSCRIBE_TRACKS must start a request stream".to_string(),
+                ));
             }
             message::Subscriber::PublishNamespaceCancel(_) => {
                 return Err(SessionError::ProtocolViolation(
@@ -1161,8 +1222,15 @@ impl Publisher {
                 .subscribed_names
                 .lock()
                 .map_err(|_| SessionError::Internal)?;
-            if subscribed_names.contains_name(&full_name) {
+            let published_names = self
+                .published_names
+                .lock()
+                .map_err(|_| SessionError::Internal)?;
+            if subscribed_names.contains_name(&full_name)
+                || published_names.contains_name(&full_name)
+            {
                 let id = msg.id;
+                drop(published_names);
                 drop(subscribed_names);
                 drop(subscribeds);
                 self.send_request_error(
@@ -1176,6 +1244,7 @@ impl Publisher {
                 );
                 return Ok(());
             }
+            drop(published_names);
 
             let (send, recv) = Subscribed::new(self.clone(), msg, self.mlog.clone())?;
             subscribed_names.insert(full_name, send.info.id);
@@ -1361,10 +1430,13 @@ impl Publisher {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, Mutex};
+    use std::{
+        collections::HashMap,
+        sync::{Arc, Mutex},
+    };
 
     use crate::{
-        coding::{KeyValuePairs, ReasonPhrase, TrackName, TrackNamespace},
+        coding::{KeyValuePairs, ReasonPhrase, TrackName, TrackNamespace, TrackNamespacePrefix},
         data,
         message::{self, Message},
         serve::{self, FullTrackName, ServeError, Tracks},
@@ -1383,6 +1455,70 @@ mod tests {
             namespace: TrackNamespace::from_utf8_path(namespace),
             name: TrackName::from(name),
         }
+    }
+
+    #[test]
+    fn subscribe_tracks_pending_prefixes_reserve_overlap_space() {
+        let pending = HashMap::from([(0, TrackNamespacePrefix::from_utf8_path("room/123"))]);
+
+        assert!(Publisher::has_subscribed_tracks_overlap(
+            &pending,
+            &TrackNamespacePrefix::from_utf8_path("room")
+        ));
+        assert!(Publisher::has_subscribed_tracks_overlap(
+            &pending,
+            &TrackNamespacePrefix::from_utf8_path("room/123/video")
+        ));
+        assert!(Publisher::has_subscribed_tracks_overlap(
+            &pending,
+            &TrackNamespacePrefix::from_utf8_path("room/123")
+        ));
+        assert!(Publisher::has_subscribed_tracks_overlap(
+            &pending,
+            &TrackNamespacePrefix::new()
+        ));
+        assert!(!Publisher::has_subscribed_tracks_overlap(
+            &pending,
+            &TrackNamespacePrefix::from_utf8_path("room/456")
+        ));
+    }
+
+    #[tokio::test]
+    async fn subscribe_rejects_name_reserved_by_outbound_publish() {
+        let (publisher_session, _peer_session) = loopback_session_pair().await;
+        let (outgoing, mut outgoing_recv) = Queue::default().split();
+        let (bidi_task_tx, _bidi_task_rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut publisher = Publisher::new(
+            outgoing,
+            publisher_session,
+            None,
+            RequestId::new(0, 1),
+            bidi_task_tx,
+        );
+        let full_name = full_track_name("room/123", "video");
+        publisher
+            .published_names
+            .lock()
+            .unwrap()
+            .insert(full_name.clone(), 1);
+
+        publisher
+            .recv_subscribe(message::Subscribe {
+                id: 2,
+                track_namespace: full_name.namespace,
+                track_name: full_name.name,
+                params: KeyValuePairs::default(),
+            })
+            .unwrap();
+
+        let Some(Message::RequestError(error)) = outgoing_recv.pop().await else {
+            panic!("expected REQUEST_ERROR");
+        };
+        assert_eq!(error.id, 2);
+        assert_eq!(
+            error.error_code,
+            message::RequestErrorCode::DuplicateSubscription as u64
+        );
     }
 
     fn subgroup_track() -> (serve::SubgroupsWriter, serve::TrackReader) {

--- a/moq-transport/src/session/subscribed_tracks.rs
+++ b/moq-transport/src/session/subscribed_tracks.rs
@@ -1,0 +1,491 @@
+// SPDX-FileCopyrightText: 2026 Cloudflare Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::{
+    collections::HashMap,
+    ops,
+    sync::{Arc, Mutex},
+};
+
+use crate::{
+    coding::{KeyValuePairs, ReasonPhrase, TrackName, TrackNamespace, TrackNamespacePrefix},
+    message::{self, Message, RequestErrorCode},
+    mlog,
+    serve::ServeError,
+    watch::State,
+};
+
+use super::{Reader, Session, SessionError, Writer};
+
+const OUTGOING_QUEUE_CAPACITY: usize = 1025;
+
+enum SubscribedTracksOutput {
+    Message(Message),
+    Reset(u32),
+}
+
+#[derive(Debug, Clone)]
+pub struct SubscribedTracksInfo {
+    pub request_id: u64,
+    pub namespace_prefix: TrackNamespacePrefix,
+    pub forward: bool,
+    pub params: KeyValuePairs,
+}
+
+struct SubscribedTracksState {
+    responded: bool,
+    closed: Result<(), ServeError>,
+}
+
+impl Default for SubscribedTracksState {
+    fn default() -> Self {
+        Self {
+            responded: false,
+            closed: Ok(()),
+        }
+    }
+}
+
+#[must_use = "rejects SUBSCRIBE_TRACKS on drop if not accepted"]
+pub struct SubscribedTracks {
+    state: State<SubscribedTracksState>,
+    outgoing: tokio::sync::mpsc::Sender<SubscribedTracksOutput>,
+    pub info: SubscribedTracksInfo,
+}
+
+impl SubscribedTracks {
+    pub(super) fn new(
+        info: SubscribedTracksInfo,
+        active_prefixes: Arc<Mutex<HashMap<u64, TrackNamespacePrefix>>>,
+    ) -> (Self, SubscribedTracksRecv) {
+        let (send_state, recv_state) = State::default().split();
+        let (outgoing, incoming) = tokio::sync::mpsc::channel(OUTGOING_QUEUE_CAPACITY);
+        let request_id = info.request_id;
+        (
+            Self {
+                state: send_state,
+                outgoing,
+                info,
+            },
+            SubscribedTracksRecv {
+                state: recv_state,
+                outgoing: incoming,
+                active_prefixes,
+                request_id,
+            },
+        )
+    }
+
+    pub fn ok(&mut self) -> Result<(), ServeError> {
+        self.responded()?;
+        self.outgoing
+            .try_send(SubscribedTracksOutput::Message(
+                message::RequestOk {
+                    id: self.request_id,
+                    params: Default::default(),
+                }
+                .into(),
+            ))
+            .map_err(|_| ServeError::Cancel)
+    }
+
+    pub fn reject(mut self, error_code: u64, reason: &str) -> Result<(), ServeError> {
+        self.responded()?;
+        self.send_error(error_code, reason)
+    }
+
+    pub fn terminate(&mut self, error_code: u32) -> Result<(), ServeError> {
+        {
+            let state = self.state.lock();
+            if !state.responded {
+                return Err(ServeError::internal_ctx(
+                    "SUBSCRIBE_TRACKS terminated before a response",
+                ));
+            }
+            state.closed.clone()?;
+        }
+        self.outgoing
+            .try_send(SubscribedTracksOutput::Reset(error_code))
+            .map_err(|_| ServeError::Cancel)
+    }
+
+    pub fn publish_blocked(
+        &mut self,
+        namespace: &TrackNamespace,
+        track_name: &TrackName,
+    ) -> Result<(), ServeError> {
+        let suffix = namespace
+            .strip_prefix(&self.namespace_prefix)
+            .ok_or_else(|| ServeError::internal_ctx("track does not match subscribed prefix"))?;
+        {
+            let state = self.state.lock();
+            state.closed.clone()?;
+            if !state.responded {
+                return Err(ServeError::internal_ctx(
+                    "PUBLISH_BLOCKED before SUBSCRIBE_TRACKS accepted",
+                ));
+            }
+        }
+        self.outgoing
+            .try_send(SubscribedTracksOutput::Message(
+                message::PublishBlocked {
+                    track_namespace_suffix: suffix,
+                    track_name: track_name.clone(),
+                }
+                .into(),
+            ))
+            .map_err(|_| ServeError::Cancel)
+    }
+
+    pub async fn closed(&self) -> Result<(), ServeError> {
+        loop {
+            {
+                let state = self.state.lock();
+                state.closed.clone()?;
+                match state.modified() {
+                    Some(modified) => modified,
+                    None => return Ok(()),
+                }
+            }
+            .await;
+        }
+    }
+
+    fn responded(&mut self) -> Result<(), ServeError> {
+        let state = self.state.lock();
+        if state.responded {
+            return Err(ServeError::Duplicate);
+        }
+        state.closed.clone()?;
+        let mut state = state.into_mut().ok_or(ServeError::Cancel)?;
+        state.responded = true;
+        Ok(())
+    }
+
+    fn send_error(&self, error_code: u64, reason: &str) -> Result<(), ServeError> {
+        self.outgoing
+            .try_send(SubscribedTracksOutput::Message(request_error(
+                self.request_id,
+                error_code,
+                reason,
+            )))
+            .map_err(|_| ServeError::Cancel)
+    }
+}
+
+impl Drop for SubscribedTracks {
+    fn drop(&mut self) {
+        let should_reject = {
+            let state = self.state.lock();
+            !state.responded && state.closed.is_ok()
+        };
+        if should_reject {
+            let _ = self
+                .outgoing
+                .try_send(SubscribedTracksOutput::Message(request_error(
+                    self.request_id,
+                    RequestErrorCode::DoesNotExist as u64,
+                    "not handled",
+                )));
+        }
+    }
+}
+
+impl ops::Deref for SubscribedTracks {
+    type Target = SubscribedTracksInfo;
+
+    fn deref(&self) -> &Self::Target {
+        &self.info
+    }
+}
+
+pub(super) struct SubscribedTracksRecv {
+    state: State<SubscribedTracksState>,
+    outgoing: tokio::sync::mpsc::Receiver<SubscribedTracksOutput>,
+    active_prefixes: Arc<Mutex<HashMap<u64, TrackNamespacePrefix>>>,
+    request_id: u64,
+}
+
+impl SubscribedTracksRecv {
+    pub(super) fn rejected(request_id: u64, error_code: u64, reason: &str) -> Self {
+        let (outgoing, incoming) = tokio::sync::mpsc::channel(1);
+        let _ = outgoing.try_send(SubscribedTracksOutput::Message(request_error(
+            request_id, error_code, reason,
+        )));
+        Self {
+            state: State::default(),
+            outgoing: incoming,
+            active_prefixes: Default::default(),
+            request_id,
+        }
+    }
+
+    pub async fn run(
+        mut self,
+        mut writer: Writer,
+        mut reader: Reader,
+        _mlog: Option<Arc<Mutex<mlog::MlogWriter>>>,
+    ) -> Result<(), SessionError> {
+        loop {
+            tokio::select! {
+                output = self.outgoing.recv() => {
+                    let Some(output) = output else {
+                        return finish_response(&mut writer);
+                    };
+                    match output {
+                        SubscribedTracksOutput::Reset(code) => {
+                            writer.reset(code);
+                            reader.stop(code);
+                            self.recv_cancel();
+                            return Ok(());
+                        }
+                        SubscribedTracksOutput::Message(message) => {
+                            let terminal = matches!(message, Message::RequestError(_));
+                            match Session::encode_bidi_response(&mut writer, &message).await {
+                                Ok(()) if terminal => return finish_response(&mut writer),
+                                Ok(()) => {}
+                                Err(error) if error.is_stream_error() => {
+                                    self.recv_cancel();
+                                    return Ok(());
+                                }
+                                Err(error) => return Err(error),
+                            }
+                        }
+                    }
+                }
+                done = reader.done() => {
+                    match done {
+                        Ok(true) => {
+                            self.recv_cancel();
+                            return finish_response(&mut writer);
+                        }
+                        Ok(false) => return Err(SessionError::ProtocolViolation(
+                            "unexpected data after SUBSCRIBE_TRACKS request".to_string(),
+                        )),
+                        Err(error) if error.is_stream_error() => {
+                            self.recv_cancel();
+                            return Ok(());
+                        }
+                        Err(error) => return Err(error),
+                    }
+                }
+                stopped = writer.closed() => {
+                    let _ = stopped?;
+                    reader.stop(super::CANCELLED_STREAM_CODE);
+                    self.recv_cancel();
+                    return Ok(());
+                }
+            }
+        }
+    }
+
+    fn recv_cancel(&mut self) {
+        if let Some(mut state) = self.state.lock_mut() {
+            state.closed = Err(ServeError::Cancel);
+        }
+        self.outgoing.close();
+    }
+}
+
+impl Drop for SubscribedTracksRecv {
+    fn drop(&mut self) {
+        if let Ok(mut prefixes) = self.active_prefixes.lock() {
+            prefixes.remove(&self.request_id);
+        }
+    }
+}
+
+fn request_error(id: u64, error_code: u64, reason: &str) -> Message {
+    message::RequestError {
+        id,
+        error_code,
+        retry_interval: 0,
+        reason: ReasonPhrase(reason.to_string()),
+    }
+    .into()
+}
+
+fn finish_response(writer: &mut Writer) -> Result<(), SessionError> {
+    match writer.finish() {
+        Ok(()) => Ok(()),
+        Err(error) if error.is_stream_error() => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::test_support::loopback_session_pair;
+
+    fn make() -> (
+        SubscribedTracks,
+        SubscribedTracksRecv,
+        Arc<Mutex<HashMap<u64, TrackNamespacePrefix>>>,
+    ) {
+        let prefix = TrackNamespacePrefix::from_utf8_path("room/123");
+        let active = Arc::new(Mutex::new(HashMap::from([(0, prefix.clone())])));
+        let (send, recv) = SubscribedTracks::new(
+            SubscribedTracksInfo {
+                request_id: 0,
+                namespace_prefix: prefix,
+                forward: true,
+                params: KeyValuePairs::default(),
+            },
+            active.clone(),
+        );
+        (send, recv, active)
+    }
+
+    #[tokio::test]
+    async fn ok_queues_request_ok() {
+        let (mut request, mut recv, _) = make();
+        request.ok().unwrap();
+        assert!(matches!(
+            recv.outgoing.recv().await,
+            Some(SubscribedTracksOutput::Message(Message::RequestOk(_)))
+        ));
+    }
+
+    #[test]
+    fn duplicate_response_is_rejected() {
+        let (mut request, _recv, _) = make();
+        request.ok().unwrap();
+        assert!(matches!(request.ok(), Err(ServeError::Duplicate)));
+    }
+
+    #[tokio::test]
+    async fn rejection_queues_request_error() {
+        let (request, mut recv, _) = make();
+        request
+            .reject(RequestErrorCode::Unauthorized as u64, "denied")
+            .unwrap();
+        let Some(SubscribedTracksOutput::Message(Message::RequestError(error))) =
+            recv.outgoing.recv().await
+        else {
+            panic!("expected REQUEST_ERROR");
+        };
+        assert_eq!(error.error_code, RequestErrorCode::Unauthorized as u64);
+    }
+
+    #[test]
+    fn receiver_drop_releases_pending_prefix() {
+        let (_request, recv, active) = make();
+        drop(recv);
+        assert!(active.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn accepted_request_termination_queues_stream_reset() {
+        let (mut request, mut recv, _) = make();
+        request.ok().unwrap();
+        let _ = recv.outgoing.recv().await;
+
+        request
+            .terminate(RequestErrorCode::ExcessiveLoad as u32)
+            .unwrap();
+
+        assert!(matches!(
+            recv.outgoing.recv().await,
+            Some(SubscribedTracksOutput::Reset(code))
+                if code == RequestErrorCode::ExcessiveLoad as u32
+        ));
+    }
+
+    #[tokio::test]
+    async fn blocked_uses_relative_namespace() {
+        let (mut request, mut recv, _) = make();
+        request.ok().unwrap();
+        let _ = recv.outgoing.recv().await;
+        request
+            .publish_blocked(
+                &TrackNamespace::from_utf8_path("room/123/participant/5"),
+                &TrackName::from("video"),
+            )
+            .unwrap();
+        let Some(SubscribedTracksOutput::Message(Message::PublishBlocked(blocked))) =
+            recv.outgoing.recv().await
+        else {
+            panic!("expected PUBLISH_BLOCKED");
+        };
+        assert_eq!(
+            blocked.track_namespace_suffix.to_utf8_path(),
+            "/participant/5"
+        );
+        assert_eq!(blocked.track_name, TrackName::from("video"));
+    }
+
+    #[tokio::test]
+    async fn requester_fin_cancels_and_releases_prefix() {
+        let (request_session, response_session) = loopback_session_pair().await;
+        let (request_send, request_recv) = request_session.open_bi().await.unwrap();
+        let (response_send, response_recv) = response_session.accept_bi().await.unwrap();
+        let mut request_writer = Writer::new(request_send);
+        let mut response_reader = Reader::new(request_recv);
+        let (mut request, recv, active) = make();
+        let driver =
+            tokio::spawn(recv.run(Writer::new(response_send), Reader::new(response_recv), None));
+
+        request.ok().unwrap();
+        assert!(matches!(
+            Session::decode_bidi_response(&mut response_reader, request.request_id)
+                .await
+                .unwrap(),
+            Message::RequestOk(_)
+        ));
+
+        request_writer.finish().unwrap();
+        assert!(matches!(request.closed().await, Err(ServeError::Cancel)));
+        driver.await.unwrap().unwrap();
+        assert!(active.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn requester_reset_cancels_and_releases_prefix() {
+        let (request_session, response_session) = loopback_session_pair().await;
+        let (request_send, request_recv) = request_session.open_bi().await.unwrap();
+        let (response_send, response_recv) = response_session.accept_bi().await.unwrap();
+        let mut request_writer = Writer::new(request_send);
+        let mut response_reader = Reader::new(request_recv);
+        let (mut request, recv, active) = make();
+        let driver =
+            tokio::spawn(recv.run(Writer::new(response_send), Reader::new(response_recv), None));
+
+        request.ok().unwrap();
+        assert!(matches!(
+            Session::decode_bidi_response(&mut response_reader, request.request_id)
+                .await
+                .unwrap(),
+            Message::RequestOk(_)
+        ));
+
+        request_writer.reset(super::super::CANCELLED_STREAM_CODE);
+        assert!(matches!(request.closed().await, Err(ServeError::Cancel)));
+        driver.await.unwrap().unwrap();
+        assert!(active.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn requester_stop_sending_cancels_and_releases_prefix() {
+        let (request_session, response_session) = loopback_session_pair().await;
+        let (_request_send, request_recv) = request_session.open_bi().await.unwrap();
+        let (response_send, response_recv) = response_session.accept_bi().await.unwrap();
+        let mut response_reader = Reader::new(request_recv);
+        let (mut request, recv, active) = make();
+        let driver =
+            tokio::spawn(recv.run(Writer::new(response_send), Reader::new(response_recv), None));
+
+        request.ok().unwrap();
+        assert!(matches!(
+            Session::decode_bidi_response(&mut response_reader, request.request_id)
+                .await
+                .unwrap(),
+            Message::RequestOk(_)
+        ));
+
+        response_reader.stop(super::super::CANCELLED_STREAM_CODE);
+        assert!(matches!(request.closed().await, Err(ServeError::Cancel)));
+        driver.await.unwrap().unwrap();
+        assert!(active.lock().unwrap().is_empty());
+    }
+}

--- a/moq-transport/src/session/subscriber.rs
+++ b/moq-transport/src/session/subscriber.rs
@@ -897,6 +897,11 @@ impl Subscriber {
             }
             message::Publisher::Publish(msg) => self.recv_publish(msg)?,
             message::Publisher::PublishDone(msg) => self.recv_publish_done(msg)?,
+            message::Publisher::PublishBlocked(_) => {
+                return Err(SessionError::ProtocolViolation(
+                    "PUBLISH_BLOCKED is only valid on a SUBSCRIBE_TRACKS stream".to_string(),
+                ));
+            }
             message::Publisher::SubscribeOk(msg) => self.recv_subscribe_ok(msg)?,
             // Draft-16 shared responses (REQUEST_OK / REQUEST_ERROR).
             message::Publisher::RequestOk(msg) => self.recv_request_ok(msg)?,


### PR DESCRIPTION
## Summary

Add the inbound draft-18 `SUBSCRIBE_TRACKS` path to `moq-transport` and `moq-relay-ietf`, including `PUBLISH_BLOCKED` support.

The relay takes a bounded snapshot of matching local publications, generates `PUBLISH` requests for them, and follows later additions and removals under the requested namespace prefix. Tracks originating from the requesting session are excluded, and the subscriber's `FORWARD` preference is applied to generated publishes.

The implementation limits each session to 1,024 retained track slots and 128 active generated publishes. A track that cannot start because the child limit is exhausted receives `PUBLISH_BLOCKED` and retains a request-owned tombstone until the parent request ends. Per-track failures do not tear down the rest of the fanout, and a lagged change receiver rebuilds its state from a bounded snapshot.

The transport layer also reserves overlapping namespace prefixes and track names across inbound requests and locally generated publishes, validates parameter and namespace bounds, and releases those reservations on cancellation.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --no-deps` (pre-existing `module_inception` warning only)
- `cargo test`
- `cargo machete`
- transport request/response, duplicate arbitration, cancellation, and wire-layout tests
- relay snapshot, same-session exclusion, generation replacement, overload, lag resync, `PUBLISH_BLOCKED`, and cancellation tests

## Limitations

This is the inbound relay slice. It does not add an outbound `SUBSCRIBE_TRACKS` API. `REQUEST_UPDATE`, legacy message cleanup, multi-publisher support, FETCH/FILL behavior, and unrelated draft-18 work are unchanged.