### PR TITLE
feat(moq-test-client): add moq-test generator and scoreboard verifier

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
 
 - This repository targets MoQT `draft-ietf-moq-transport-18`.
 - Core protocol code lives in `moq-transport`; relay behavior lives in `moq-relay-ietf`.
+- `moq-test-client` is the interop test harness: it runs TAP-emitting scenarios against a relay. The `moq-test-*` scenarios implement the moq-test protocol (draft-afrind-moq-test) as self-publishing scoreboard tests that need no relay-side moq-test support.
 - `moq-relay-ietf` is production critical, so prefer small, tested changes over broad refactors.
 - Avoid breaking public APIs, wire behavior, CLI flags, and operator workflows unless explicitly requested.
 - Do not add `unsafe` code unless there is a clear performance or FFI need and the safety invariant is documented at the call site.
@@ -17,6 +18,9 @@
 - Run `cargo test -p moq-relay-ietf` or `cargo build -p moq-relay-ietf` for relay-only changes.
 - Run `cargo build --workspace` when shared APIs, relay behavior, or test-client behavior changes.
 - Consider `cargo clippy --workspace --all-targets` before larger changes or when review asks for lint coverage.
+- List interop scenarios with `cargo run -p moq-test-client -- --list`.
+- Run a scenario against a local relay with `cargo run -p moq-test-client -- --relay https://localhost:4443 --tls-disable-verify --test moq-test-datagram` (any `--list` name works; omit `--test` to run them all).
+- Run an ad-hoc moq-test tuple with `cargo run -p moq-test-client -- --relay https://localhost:4443 --tls-disable-verify --moq-test-tuple "moq-test-00/0/0/0/2/4/5/64/32/2/1/1/0/-1/-1/0"` (16 `/`-separated fields; blanks select defaults).
 - When tests fail, diagnose from compiler/test output first and keep fixes scoped to the failing behavior.
 
 ## Draft-18 Terminology

--- a/moq-test-client/src/main.rs
+++ b/moq-test-client/src/main.rs
@@ -235,7 +235,7 @@ async fn run_moqtest_scenario(
 
 /// Run a named moq-test scenario.
 async fn run_moqtest(args: &Args, test_case: TestCase) -> Result<scenarios::TestConnectionIds> {
-    let scenario = moqtest::scenario(test_case.name())
+    let scenario = moqtest::scenario(test_case.name())?
         .ok_or_else(|| anyhow::anyhow!("unregistered moq-test scenario"))?;
     run_moqtest_scenario(args, scenario).await
 }

--- a/moq-test-client/src/main.rs
+++ b/moq-test-client/src/main.rs
@@ -18,15 +18,25 @@
 //!
 //! # List available tests
 //! moq-test-client --list
+//!
+//! # Run an ad-hoc moq-test scenario from a 16-field tuple
+//! moq-test-client --relay https://localhost:4443 \
+//!   --moq-test-tuple "moq-test-00/0/0/0/2/4/5/64/32/2/1/1/0/-1/-1/0"
 //! ```
+//!
+//! The `moq-test-*` tests implement the moq-test protocol
+//! (draft-afrind-moq-test) as a self-publishing scoreboard test: the client
+//! generates a deterministic object set from the tuple, publishes it through
+//! the relay, subscribes, and verifies the exact set plus terminal signals.
 
 use std::net;
 use std::time::{Duration, Instant};
 
-use anyhow::Result;
+use anyhow::{bail, Context, Result};
 use clap::{Parser, ValueEnum};
 use url::Url;
 
+mod moqtest;
 mod scenarios;
 
 /// MoQT Interop Test Client
@@ -46,6 +56,12 @@ pub struct Args {
     /// Specific test to run (runs all if not specified)
     #[arg(short, long, env = "TESTCASE")]
     pub test: Option<TestCase>,
+
+    /// Run an ad-hoc moq-test scenario from a tuple: 16 '/'-separated
+    /// namespace fields (e.g. "moq-test-00/0/0/0/2/4/5/64/32/2/1/1/0///"),
+    /// subscribe-first choreography. Blank fields select defaults.
+    #[arg(long, value_name = "TUPLE", conflicts_with_all = ["test", "list"])]
+    pub moq_test_tuple: Option<String>,
 
     /// List available test cases and exit
     #[arg(short, long)]
@@ -85,6 +101,24 @@ pub enum TestCase {
     PublishTrackSubscribe,
     /// T0.9: SUBSCRIBE with RENDEZVOUS_TIMEOUT expires with TIMEOUT
     RendezvousTimeout,
+    /// moq-test: one subgroup per group, scoreboard-verified
+    MoqTestSubgroupPerGroup,
+    /// moq-test: one subgroup per group with End of Group markers
+    MoqTestSubgroupPerGroupEog,
+    /// moq-test: one subgroup per object
+    MoqTestSubgroupPerObject,
+    /// moq-test: two subgroups per group (parity) with End of Group markers
+    MoqTestTwoSubgroupsEog,
+    /// moq-test: datagram forwarding
+    MoqTestDatagram,
+    /// moq-test: datagram forwarding with End of Group markers
+    MoqTestDatagramEog,
+    /// moq-test: integer and variable extensions on every object
+    MoqTestExtensions,
+    /// moq-test: non-default start/increment arithmetic
+    MoqTestIncrements,
+    /// moq-test: SUBSCRIBE with FORWARD=0 (setup and PUBLISH_DONE, no data)
+    MoqTestForwardZero,
 }
 
 impl TestCase {
@@ -99,6 +133,15 @@ impl TestCase {
             TestCase::PublishTrackOnly,
             TestCase::PublishTrackSubscribe,
             TestCase::RendezvousTimeout,
+            TestCase::MoqTestSubgroupPerGroup,
+            TestCase::MoqTestSubgroupPerGroupEog,
+            TestCase::MoqTestSubgroupPerObject,
+            TestCase::MoqTestTwoSubgroupsEog,
+            TestCase::MoqTestDatagram,
+            TestCase::MoqTestDatagramEog,
+            TestCase::MoqTestExtensions,
+            TestCase::MoqTestIncrements,
+            TestCase::MoqTestForwardZero,
         ]
     }
 
@@ -113,6 +156,15 @@ impl TestCase {
             TestCase::PublishTrackOnly => "publish-track-only",
             TestCase::PublishTrackSubscribe => "publish-track-subscribe",
             TestCase::RendezvousTimeout => "rendezvous-timeout",
+            TestCase::MoqTestSubgroupPerGroup => "moq-test-subgroup-per-group",
+            TestCase::MoqTestSubgroupPerGroupEog => "moq-test-subgroup-per-group-eog",
+            TestCase::MoqTestSubgroupPerObject => "moq-test-subgroup-per-object",
+            TestCase::MoqTestTwoSubgroupsEog => "moq-test-two-subgroups-eog",
+            TestCase::MoqTestDatagram => "moq-test-datagram",
+            TestCase::MoqTestDatagramEog => "moq-test-datagram-eog",
+            TestCase::MoqTestExtensions => "moq-test-extensions",
+            TestCase::MoqTestIncrements => "moq-test-increments",
+            TestCase::MoqTestForwardZero => "moq-test-forward-zero",
         }
     }
 }
@@ -120,33 +172,72 @@ impl TestCase {
 /// Result of running a test case
 #[derive(Debug)]
 pub struct TestResult {
-    pub test_case: TestCase,
+    pub name: String,
     pub passed: bool,
     pub duration: Duration,
     pub message: Option<String>,
     pub cids: Vec<String>,
+    /// Multi-connection tests where the subscriber connected first (affects
+    /// CID labeling only).
+    subscriber_first: bool,
 }
 
 impl TestResult {
-    fn success(test_case: TestCase, duration: Duration, cids: Vec<String>) -> Self {
+    fn success(
+        name: String,
+        duration: Duration,
+        cids: Vec<String>,
+        subscriber_first: bool,
+    ) -> Self {
         Self {
-            test_case,
+            name,
             passed: true,
             duration,
             message: None,
             cids,
+            subscriber_first,
         }
     }
 
-    fn failure(test_case: TestCase, duration: Duration, message: String) -> Self {
+    fn failure(name: String, duration: Duration, message: String) -> Self {
         Self {
-            test_case,
+            name,
             passed: false,
             duration,
             message: Some(message),
             cids: Vec::new(),
+            subscriber_first: false,
         }
     }
+}
+
+/// Run a moq-test scenario under the shared timeout and translate the
+/// verification report into connection IDs or an error.
+async fn run_moqtest_scenario(
+    args: &Args,
+    scenario: &moqtest::Scenario,
+) -> Result<scenarios::TestConnectionIds> {
+    let (cids, report) =
+        tokio::time::timeout(scenarios::TEST_TIMEOUT, moqtest::run(args, scenario))
+            .await
+            .context("test timed out")??;
+
+    if report.passed() {
+        tracing::info!("moq-test passed: {}", report.summary());
+        Ok(cids)
+    } else {
+        bail!(
+            "moq-test verification failed: {}",
+            report.failures.join("; ")
+        )
+    }
+}
+
+/// Run a named moq-test scenario.
+async fn run_moqtest(args: &Args, test_case: TestCase) -> Result<scenarios::TestConnectionIds> {
+    let scenario = moqtest::scenario(test_case.name())
+        .ok_or_else(|| anyhow::anyhow!("unregistered moq-test scenario"))?;
+    run_moqtest_scenario(args, scenario).await
 }
 
 /// Run a single test case
@@ -167,20 +258,36 @@ async fn run_test(args: &Args, test_case: TestCase) -> TestResult {
         TestCase::PublishTrackOnly => scenarios::test_publish_track_only(args).await,
         TestCase::PublishTrackSubscribe => scenarios::test_publish_track_subscribe(args).await,
         TestCase::RendezvousTimeout => scenarios::test_rendezvous_timeout(args).await,
+        TestCase::MoqTestSubgroupPerGroup
+        | TestCase::MoqTestSubgroupPerGroupEog
+        | TestCase::MoqTestSubgroupPerObject
+        | TestCase::MoqTestTwoSubgroupsEog
+        | TestCase::MoqTestDatagram
+        | TestCase::MoqTestDatagramEog
+        | TestCase::MoqTestExtensions
+        | TestCase::MoqTestIncrements
+        | TestCase::MoqTestForwardZero => run_moqtest(args, test_case).await,
     };
 
     let duration = start.elapsed();
 
+    // T0.5 and every moq-test scenario connect the subscriber first.
+    let subscriber_first = test_case == TestCase::SubscribeBeforePublishNamespace
+        || test_case.name().starts_with("moq-test-");
     match result {
-        Ok(cids) => TestResult::success(test_case, duration, cids.cids),
-        Err(e) => TestResult::failure(test_case, duration, format!("{:#}", e)),
+        Ok(cids) => TestResult::success(
+            test_case.name().to_string(),
+            duration,
+            cids.cids,
+            subscriber_first,
+        ),
+        Err(e) => TestResult::failure(test_case.name().to_string(), duration, format!("{:#}", e)),
     }
 }
 
 fn print_tap_result(test_number: usize, result: &TestResult, verbose: bool) {
     let status = if result.passed { "ok" } else { "not ok" };
-    let name = result.test_case.name();
-    println!("{} {} - {}", status, test_number, name);
+    println!("{} {} - {}", status, test_number, result.name);
 
     // YAML diagnostic block
     println!("  ---");
@@ -192,8 +299,8 @@ fn print_tap_result(test_number: usize, result: &TestResult, verbose: bool) {
         1 => println!("  connection_id: {}", result.cids[0]),
         2 => {
             // Multi-connection tests: first is publisher, second is subscriber
-            // (except subscribe-before-announce where subscriber connects first)
-            if result.test_case == TestCase::SubscribeBeforePublishNamespace {
+            // (except subscribe-first choreographies)
+            if result.subscriber_first {
                 println!("  subscriber_connection_id: {}", result.cids[0]);
                 println!("  publisher_connection_id: {}", result.cids[1]);
             } else {
@@ -254,6 +361,41 @@ async fn main() -> Result<()> {
             println!("{}", tc.name());
         }
         return Ok(());
+    }
+
+    // Ad-hoc moq-test tuple: parse, run, report as a single TAP line.
+    if let Some(tuple) = &args.moq_test_tuple {
+        let fields: Vec<String> = tuple.split('/').map(str::to_string).collect();
+        let start = Instant::now();
+        let result = async {
+            let params = moqtest::MoqTestParams::from_namespace_fields(&fields)
+                .context("invalid moq-test tuple")?;
+            let scenario = moqtest::Scenario {
+                params,
+                forward_zero: false,
+            };
+            run_moqtest_scenario(&args, &scenario).await
+        }
+        .await;
+        let duration = start.elapsed();
+        let result = match result {
+            Ok(cids) => {
+                TestResult::success("moq-test-adhoc".to_string(), duration, cids.cids, true)
+            }
+            Err(e) => {
+                TestResult::failure("moq-test-adhoc".to_string(), duration, format!("{:#}", e))
+            }
+        };
+        println!("TAP version 14");
+        println!("# moq-test-client v{}", env!("CARGO_PKG_VERSION"));
+        println!("# Relay: {}", args.relay);
+        println!("1..1");
+        print_tap_result(1, &result, args.verbose);
+        return if result.passed {
+            Ok(())
+        } else {
+            std::process::exit(1);
+        };
     }
 
     let tests_to_run = match args.test {

--- a/moq-test-client/src/moqtest.rs
+++ b/moq-test-client/src/moqtest.rs
@@ -1068,10 +1068,11 @@ fn base() -> MoqTestParams {
     }
 }
 
-/// The built-in scenarios, built and validated once. Small and finite:
-/// every run is well under a second of object pacing plus round-trips.
+/// The built-in scenarios. Small and finite: every run is well under a
+/// second of object pacing plus round-trips. Validated at lookup (see
+/// [`scenario`]) and by the all-scenarios unit test.
 static SCENARIOS: LazyLock<Vec<(&'static str, Scenario)>> = LazyLock::new(|| {
-    let table = vec![
+    vec![
         (
             "moq-test-subgroup-per-group",
             Scenario {
@@ -1201,19 +1202,22 @@ static SCENARIOS: LazyLock<Vec<(&'static str, Scenario)>> = LazyLock::new(|| {
                 forward_zero: true,
             },
         ),
-    ];
-    for (name, scenario) in &table {
-        scenario
-            .params
-            .validate()
-            .unwrap_or_else(|e| panic!("built-in scenario {name} is invalid: {e}"));
-    }
-    table
+    ]
 });
 
-/// Look up a built-in scenario by name.
-pub fn scenario(name: &str) -> Option<&'static Scenario> {
-    SCENARIOS.iter().find(|(n, _)| *n == name).map(|(_, s)| s)
+/// Look up a built-in scenario by name, validating its parameters first.
+/// An invalid built-in entry is a programmer error, but it is surfaced as an
+/// ordinary error rather than a panic (the all-scenarios unit test fails
+/// first); `Ok(None)` means no scenario is registered under `name`.
+pub fn scenario(name: &str) -> Result<Option<&'static Scenario>> {
+    let Some((_, scenario)) = SCENARIOS.iter().find(|(n, _)| *n == name) else {
+        return Ok(None);
+    };
+    scenario
+        .params
+        .validate()
+        .with_context(|| format!("built-in scenario {name} is invalid"))?;
+    Ok(Some(scenario))
 }
 
 async fn connect(
@@ -1793,5 +1797,21 @@ mod tests {
         let sb = Scoreboard::new(p);
         let report = sb.finish(Some(&done(PublishDoneCode::TrackEnded as u64, 3)), true);
         assert!(report.failures.iter().any(|f| f.contains("stream count 3")));
+    }
+
+    #[test]
+    fn all_builtin_scenarios_are_valid() {
+        // An invalid built-in entry is a programmer error; fail here rather
+        // than at lookup (which surfaces it as an ordinary error, not a
+        // panic).
+        let invalid: Vec<&str> = SCENARIOS
+            .iter()
+            .filter(|(_, s)| s.params.validate().is_err())
+            .map(|(n, _)| *n)
+            .collect();
+        assert!(
+            invalid.is_empty(),
+            "invalid built-in scenarios: {invalid:?}"
+        );
     }
 }

--- a/moq-test-client/src/moqtest.rs
+++ b/moq-test-client/src/moqtest.rs
@@ -819,6 +819,27 @@ impl Scoreboard {
         }
     }
 
+    /// Relay-transparent metadata: the generator sets a constant priority
+    /// on every subgroup and datagram, so a deviation is a relay rewrite.
+    fn check_priority(&mut self, priority: u8, what: String) {
+        if priority != PRIORITY {
+            self.fail(format!(
+                "{what} carried priority {priority}, expected {PRIORITY}"
+            ));
+        }
+    }
+
+    /// The generator never sets the datagram end-of-group type bit (status
+    /// datagrams carry the marker instead), so a set bit is a relay
+    /// rewrite.
+    fn check_datagram_flags(&mut self, group: u64, object: u64, end_of_group: bool) {
+        if end_of_group {
+            self.fail(format!(
+                "datagram ({group}, {object}) carried an unexpected end-of-group type bit"
+            ));
+        }
+    }
+
     fn check_extensions(&mut self, group: u64, object: u64, extensions: &ExtensionHeaders) {
         let mut expected = 0;
         if let Some(id) = self.params.int_extension_id() {
@@ -1036,6 +1057,10 @@ pub async fn verify(
                     streams_received += 1;
                     let group = subgroup.info.group_id;
                     let subgroup_id = subgroup.info.subgroup_id;
+                    scoreboard.check_priority(
+                        subgroup.info.priority,
+                        format!("subgroup ({group}, {subgroup_id})"),
+                    );
                     loop {
                         match subgroup.next().await {
                             Ok(Some(mut object)) => {
@@ -1073,6 +1098,15 @@ pub async fn verify(
         TrackReaderMode::Datagrams(mut datagrams) => loop {
             match datagrams.read().await {
                 Ok(Some(datagram)) => {
+                    scoreboard.check_priority(
+                        datagram.priority,
+                        format!("datagram ({}, {})", datagram.group_id, datagram.object_id),
+                    );
+                    scoreboard.check_datagram_flags(
+                        datagram.group_id,
+                        datagram.object_id,
+                        datagram.end_of_group,
+                    );
                     if datagram.status == ObjectStatus::NormalObject {
                         scoreboard.record_data(
                             datagram.group_id,
@@ -1971,6 +2005,26 @@ mod tests {
         let sb = full_scoreboard();
         let report = sb.finish(None, false);
         assert!(report.failures.iter().any(|f| f.contains("never arrived")));
+    }
+
+    #[test]
+    fn scoreboard_checks_priority_and_datagram_flags() {
+        let mut sb = full_scoreboard();
+        // Correct values record no failure.
+        sb.check_priority(PRIORITY, "subgroup (0, 0)".to_string());
+        sb.check_datagram_flags(0, 1, false);
+        assert!(sb.failures.is_empty());
+        // A relay rewrite of either is a verification failure.
+        sb.check_priority(64, "subgroup (0, 0)".to_string());
+        sb.check_datagram_flags(0, 1, true);
+        assert!(sb
+            .failures
+            .iter()
+            .any(|f| f.contains("priority 64, expected 128")));
+        assert!(sb
+            .failures
+            .iter()
+            .any(|f| f.contains("end-of-group type bit")));
     }
 
     #[test]

--- a/moq-test-client/src/moqtest.rs
+++ b/moq-test-client/src/moqtest.rs
@@ -1,0 +1,1797 @@
+// SPDX-FileCopyrightText: 2026 Cloudflare Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! moq-test protocol implementation: generator plus scoreboard verifier.
+//!
+//! The client is both the original publisher and the end subscriber of the
+//! same track: it derives a deterministic object set from a moq-test tuple
+//! (the "scoreboard"), publishes it through the relay under test, subscribes
+//! to the same track, and verifies that exactly the expected set arrives,
+//! with correct metadata and terminal signals. The relay under test needs no
+//! moq-test implementation; it sees an ordinary PUBLISH and SUBSCRIBE.
+//!
+//! The tuple semantics of draft-afrind-moq-test, made precise:
+//!
+//! - Groups: `start_group + k*group_increment` while `<= last_group`.
+//! - Objects per group: `start_object + k*object_increment` while
+//!   `<= last_object`. Field 6 (`objects_per_group`) constrains the valid
+//!   range of `last_object` but does not drive generation.
+//! - When end-of-group markers are enabled, the final slot (`object_id ==
+//!   last_object`) of each group is an End of Group status object instead of
+//!   a data object.
+//! - A data object's size is `size_object_zero` when `object_id ==
+//!   start_object`, otherwise `size_object_rest`.
+//! - Payload is the byte `b't'` repeated.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::LazyLock;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::{anyhow, bail, Context, Result};
+use bytes::Bytes;
+use tokio::time::sleep;
+
+use moq_transport::coding::{KeyValuePairs, TrackNamespace, TupleField};
+use moq_transport::data::{ExtensionHeaders, ObjectStatus};
+use moq_transport::message::PublishDoneCode;
+use moq_transport::serve::{Datagram, Subgroup, Track, TrackReader, TrackReaderMode, TrackWriter};
+use moq_transport::session::{PublishDoneInfo, Session, Subscribe};
+
+use crate::scenarios::{is_normal_subscription_end, TestConnectionIds};
+use crate::Args;
+
+/// Tuple field 0: identifies the moq-test protocol version.
+pub const TUPLE_FIELD_0: &str = "moq-test-00";
+
+/// moq-test namespaces carry exactly this many tuple fields.
+pub const NUM_TUPLE_FIELDS: usize = 16;
+
+/// Publisher priority used for every subgroup and datagram.
+const PRIORITY: u8 = 128;
+
+/// Rendezvous window requested on SUBSCRIBE so the relay holds the
+/// subscription pending until the publisher appears (subscribe-first
+/// choreography).
+const RENDEZVOUS_TIMEOUT_MS: u64 = 10_000;
+
+/// Worst-case datagram payload budget; larger datagram-mode objects are a
+/// test-declaration error.
+const MAX_DATAGRAM_PAYLOAD: usize = 1200;
+
+/// moq-test forwarding preference (tuple field 1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Forwarding {
+    /// 0: one subgroup stream per group, Subgroup ID 0.
+    SubgroupPerGroup,
+    /// 1: one subgroup stream per object, Subgroup ID == Object ID.
+    SubgroupPerObject,
+    /// 2: two subgroup streams per group; even objects on Subgroup 0, odd on
+    /// Subgroup 1.
+    TwoSubgroupsPerGroup,
+    /// 3: one datagram per object.
+    Datagram,
+}
+
+impl Forwarding {
+    fn from_u64(value: u64) -> Result<Self> {
+        match value {
+            0 => Ok(Self::SubgroupPerGroup),
+            1 => Ok(Self::SubgroupPerObject),
+            2 => Ok(Self::TwoSubgroupsPerGroup),
+            3 => Ok(Self::Datagram),
+            _ => bail!("invalid forwarding preference: {value}"),
+        }
+    }
+
+    fn to_u64(self) -> u64 {
+        match self {
+            Self::SubgroupPerGroup => 0,
+            Self::SubgroupPerObject => 1,
+            Self::TwoSubgroupsPerGroup => 2,
+            Self::Datagram => 3,
+        }
+    }
+}
+
+/// A parsed moq-test tuple: the test declaration shared by the generator and
+/// the verifier.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MoqTestParams {
+    pub forwarding: Forwarding,
+    pub start_group: u64,
+    pub start_object: u64,
+    pub last_group: u64,
+    pub last_object: u64,
+    pub objects_per_group: u64,
+    pub size_object_zero: u64,
+    pub size_object_rest: u64,
+    pub frequency_ms: u64,
+    pub group_increment: u64,
+    pub object_increment: u64,
+    pub eog_markers: bool,
+    /// Tuple field 13 value; the extension ID is `2 * value`.
+    pub int_extension: Option<u64>,
+    /// Tuple field 14 value; the extension ID is `2 * value + 1`.
+    pub var_extension: Option<u64>,
+    pub delivery_timeout_ms: Option<u64>,
+}
+
+impl MoqTestParams {
+    /// Parse the 16 namespace tuple fields. Fields 1-15 may be blank, which
+    /// selects the default (matching draft-afrind-moq-test).
+    pub fn from_namespace_fields(fields: &[String]) -> Result<Self> {
+        if fields.len() != NUM_TUPLE_FIELDS {
+            bail!(
+                "moq-test namespace must have {} fields, got {}",
+                NUM_TUPLE_FIELDS,
+                fields.len()
+            );
+        }
+        if fields[0] != TUPLE_FIELD_0 {
+            bail!(
+                "tuple field 0 must be {TUPLE_FIELD_0:?}, got {:?}",
+                fields[0]
+            );
+        }
+
+        let mut rest = fields[1..].iter().map(String::as_str);
+
+        let forwarding = Forwarding::from_u64(next_u64(&mut rest, 0)?)?;
+        let start_group = next_u64(&mut rest, 0)?;
+        let start_object = next_u64(&mut rest, 0)?;
+        let last_group = next_u64(&mut rest, (1u64 << 62) - 1)?;
+        // Field 5's default is "the maximum value" (draft): computed once the
+        // other fields are known, below.
+        let last_object = optional_u64(&mut rest)?;
+        let objects_per_group = next_u64(&mut rest, 10)?;
+        let size_object_zero = next_u64(&mut rest, 1024)?;
+        let size_object_rest = next_u64(&mut rest, 100)?;
+        let frequency_ms = next_u64(&mut rest, 1000)?;
+        let group_increment = next_u64(&mut rest, 1)?;
+        let object_increment = next_u64(&mut rest, 1)?;
+        let eog_markers = match next_u64(&mut rest, 0)? {
+            0 => false,
+            1 => true,
+            other => bail!("end-of-group marker field must be 0 or 1, got {other}"),
+        };
+        let int_extension = optional_extension(&mut rest)?;
+        let var_extension = optional_extension(&mut rest)?;
+        let delivery_timeout_ms = optional_timeout(&mut rest)?;
+
+        let last_object = match last_object {
+            Some(value) => value,
+            None => default_last_object(
+                start_object,
+                objects_per_group,
+                eog_markers,
+                object_increment,
+            )?,
+        };
+
+        let params = Self {
+            forwarding,
+            start_group,
+            start_object,
+            last_group,
+            last_object,
+            objects_per_group,
+            size_object_zero,
+            size_object_rest,
+            frequency_ms,
+            group_increment,
+            object_increment,
+            eog_markers,
+            int_extension,
+            var_extension,
+            delivery_timeout_ms,
+        };
+        params.validate()?;
+        Ok(params)
+    }
+
+    /// Serialize as the 16 namespace tuple fields.
+    ///
+    /// moq-transport cannot encode empty namespace fields, so "no extension"
+    /// is written as `-1` (the de-facto wire encoding of a disabled test
+    /// extension) and "no delivery timeout" as `0`. The parser accepts
+    /// blank for all three as well (the draft's spelling of "default").
+    pub fn to_namespace_fields(&self) -> Vec<String> {
+        vec![
+            TUPLE_FIELD_0.to_string(),
+            self.forwarding.to_u64().to_string(),
+            self.start_group.to_string(),
+            self.start_object.to_string(),
+            self.last_group.to_string(),
+            self.last_object.to_string(),
+            self.objects_per_group.to_string(),
+            self.size_object_zero.to_string(),
+            self.size_object_rest.to_string(),
+            self.frequency_ms.to_string(),
+            self.group_increment.to_string(),
+            self.object_increment.to_string(),
+            (self.eog_markers as u64).to_string(),
+            self.int_extension
+                .map_or_else(|| "-1".to_string(), |v| v.to_string()),
+            self.var_extension
+                .map_or_else(|| "-1".to_string(), |v| v.to_string()),
+            self.delivery_timeout_ms
+                .map_or_else(|| "0".to_string(), |v| v.to_string()),
+        ]
+    }
+
+    /// Build the track namespace for this tuple. Serialization never emits
+    /// empty fields (moq-transport cannot encode them); see
+    /// [`Self::to_namespace_fields`].
+    pub fn to_namespace(&self) -> TrackNamespace {
+        let mut ns = TrackNamespace::new();
+        for field in self.to_namespace_fields() {
+            ns.add(TupleField::from_utf8(&field));
+        }
+        ns
+    }
+
+    fn validate(&self) -> Result<()> {
+        if self.start_group > self.last_group {
+            bail!(
+                "start group {} exceeds last group {}",
+                self.start_group,
+                self.last_group
+            );
+        }
+        if self.start_object > self.last_object {
+            bail!(
+                "start object {} exceeds last object {}",
+                self.start_object,
+                self.last_object
+            );
+        }
+        if self.group_increment == 0 {
+            bail!("group increment cannot be zero");
+        }
+        if self.object_increment == 0 {
+            bail!("object increment cannot be zero");
+        }
+        if self.objects_per_group == 0 {
+            bail!("objects per group cannot be zero");
+        }
+
+        // Field 6 constrains how far `last_object` may reach: the object
+        // series may contain at most `objects_per_group` data objects plus
+        // one EOG marker slot. (the naive formula assumes start_object == 0;
+        // this is the same rule offset by start_object.)
+        let max_last = default_last_object(
+            self.start_object,
+            self.objects_per_group,
+            self.eog_markers,
+            self.object_increment,
+        )?;
+        if self.last_object > max_last {
+            bail!(
+                "last object {} exceeds maximum {} for {} objects per group",
+                self.last_object,
+                max_last,
+                self.objects_per_group
+            );
+        }
+
+        if self.forwarding == Forwarding::Datagram {
+            let max_size = self.size_object_zero.max(self.size_object_rest) as usize;
+            if max_size > MAX_DATAGRAM_PAYLOAD {
+                bail!("datagram-mode object size {max_size} exceeds budget {MAX_DATAGRAM_PAYLOAD}");
+            }
+        }
+
+        // Bound the materialized ranges: the scoreboard eagerly allocates one
+        // entry per group and object, so unbounded tuple fields (a blank
+        // last_group defaults to (1<<62)-1) would exhaust memory before any
+        // network I/O. Generous test-scale limits. u128 arithmetic: an
+        // explicit last_group/last_object near u64::MAX must not wrap the
+        // +1 into passing the check.
+        const MAX_GROUPS: u128 = 100_000;
+        const MAX_DATA_OBJECTS: u128 = 1_000_000;
+        let group_count =
+            u128::from(self.last_group - self.start_group) / u128::from(self.group_increment) + 1;
+        if group_count > MAX_GROUPS {
+            bail!("group series of {group_count} groups exceeds the {MAX_GROUPS} group limit");
+        }
+        let per_group = u128::from(self.last_object - self.start_object)
+            / u128::from(self.object_increment)
+            + 1;
+        let total_objects = group_count * per_group;
+        if total_objects > MAX_DATA_OBJECTS {
+            bail!(
+                "track would carry {total_objects} objects, exceeding the {MAX_DATA_OBJECTS} object limit"
+            );
+        }
+        Ok(())
+    }
+
+    /// The group ID series, ascending.
+    pub fn groups(&self) -> Vec<u64> {
+        series(self.start_group, self.last_group, self.group_increment)
+    }
+
+    /// The per-group object ID series, ascending. When EOG markers are
+    /// enabled the final entry is the EOG marker slot.
+    pub fn objects(&self) -> Vec<u64> {
+        series(self.start_object, self.last_object, self.object_increment)
+    }
+
+    /// Object IDs that carry data (i.e. excluding the EOG marker slot).
+    pub fn data_objects(&self) -> Vec<u64> {
+        let mut objects = self.objects();
+        if self.eog_markers {
+            objects.pop();
+        }
+        objects
+    }
+
+    pub fn object_size(&self, object_id: u64) -> u64 {
+        if object_id == self.start_object {
+            self.size_object_zero
+        } else {
+            self.size_object_rest
+        }
+    }
+
+    pub fn int_extension_id(&self) -> Option<u64> {
+        self.int_extension.map(|v| 2 * v)
+    }
+
+    pub fn var_extension_id(&self) -> Option<u64> {
+        self.var_extension.map(|v| 2 * v + 1)
+    }
+
+    /// Number of data objects expected across the whole track.
+    pub fn expected_data_objects(&self) -> u64 {
+        self.groups().len() as u64 * self.data_objects().len() as u64
+    }
+
+    /// Number of data streams the subscription should receive (PUBLISH_DONE
+    /// Stream Count).
+    pub fn expected_stream_count(&self) -> u64 {
+        let groups = self.groups().len() as u64;
+        match self.forwarding {
+            Forwarding::SubgroupPerGroup => groups,
+            Forwarding::SubgroupPerObject => groups * self.objects().len() as u64,
+            Forwarding::TwoSubgroupsPerGroup => 2 * groups,
+            Forwarding::Datagram => 0,
+        }
+    }
+
+    /// Subgroup ID an object belongs to (subgroup modes only).
+    fn subgroup_for(&self, object_id: u64) -> Option<u64> {
+        match self.forwarding {
+            Forwarding::SubgroupPerGroup => Some(0),
+            Forwarding::SubgroupPerObject => Some(object_id),
+            // Parity of the offset from start_object:
+            // (object_id - start_object) % 2 — with start_object == 0 this
+            // is plain parity.
+            Forwarding::TwoSubgroupsPerGroup => Some((object_id - self.start_object) % 2),
+            Forwarding::Datagram => None,
+        }
+    }
+}
+
+fn series(start: u64, last: u64, increment: u64) -> Vec<u64> {
+    let mut values = Vec::new();
+    let mut current = start;
+    while current <= last {
+        values.push(current);
+        let Some(next) = current.checked_add(increment) else {
+            break;
+        };
+        current = next;
+    }
+    values
+}
+
+/// The largest valid `last_object`: `objects_per_group` data objects plus
+/// one EOG marker slot, offset by `start_object`. Also the field-5 default.
+fn default_last_object(
+    start_object: u64,
+    objects_per_group: u64,
+    eog_markers: bool,
+    object_increment: u64,
+) -> Result<u64> {
+    let slots = objects_per_group
+        .checked_add(u64::from(eog_markers))
+        .context("object series overflow")?;
+    start_object
+        .checked_add(
+            slots
+                .saturating_sub(1)
+                .checked_mul(object_increment)
+                .context("object series overflow")?,
+        )
+        .context("object series overflow")
+}
+
+fn next_u64<'a>(rest: &mut impl Iterator<Item = &'a str>, default: u64) -> Result<u64> {
+    match rest.next() {
+        Some("") => Ok(default),
+        Some(field) => field
+            .parse()
+            .with_context(|| format!("invalid tuple integer: {field:?}")),
+        None => bail!("namespace ended early"),
+    }
+}
+
+fn optional_u64<'a>(rest: &mut impl Iterator<Item = &'a str>) -> Result<Option<u64>> {
+    match rest.next() {
+        Some("") | None => Ok(None),
+        Some(field) => field
+            .parse()
+            .map(Some)
+            .with_context(|| format!("invalid tuple integer: {field:?}")),
+    }
+}
+
+/// Fields 13/14: blank or a negative value (the de-facto wire encoding of
+/// a disabled extension) both mean "no extension".
+fn optional_extension<'a>(rest: &mut impl Iterator<Item = &'a str>) -> Result<Option<u64>> {
+    match rest.next() {
+        Some("") | None => Ok(None),
+        Some(field) => {
+            let value: i64 = field
+                .parse()
+                .with_context(|| format!("invalid tuple integer: {field:?}"))?;
+            Ok((value >= 0).then_some(value as u64))
+        }
+    }
+}
+
+/// Field 15: blank or 0 means "no delivery timeout".
+fn optional_timeout<'a>(rest: &mut impl Iterator<Item = &'a str>) -> Result<Option<u64>> {
+    match rest.next() {
+        Some("") | None => Ok(None),
+        Some(field) => {
+            let value: u64 = field
+                .parse()
+                .with_context(|| format!("invalid tuple integer: {field:?}"))?;
+            Ok((value != 0).then_some(value))
+        }
+    }
+}
+
+/// xorshift64* PRNG: deterministic-quality random values for extension
+/// payloads without taking a dependency on a rand crate.
+struct Prng(u64);
+
+impl Prng {
+    fn from_entropy() -> Self {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos() as u64)
+            .unwrap_or(0x9e3779b97f4a7c15);
+        // Avoid the all-zero fixed point; mix in the process ID so parallel
+        // runs differ even at equal clock readings.
+        Self(nanos ^ (u64::from(std::process::id()) << 32) | 1)
+    }
+
+    fn next(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        self.0 = x;
+        x.wrapping_mul(0x2545F4914F6CDD1D)
+    }
+
+    fn bytes(&mut self, len: usize) -> Vec<u8> {
+        (0..len).map(|_| (self.next() >> 32) as u8).collect()
+    }
+}
+
+/// A per-run unique track name. Any unique name is valid for the same
+/// tuple-derived content, so a fresh name per run acts as a cache buster:
+/// the relay cannot serve stale objects from an earlier run.
+pub fn run_track_name() -> String {
+    let mut prng = Prng::from_entropy();
+    format!("moq-test-{:016x}", prng.next())
+}
+
+/// Build the extension headers for one object, per tuple fields 13/14.
+fn object_extensions(params: &MoqTestParams, prng: &mut Prng) -> Option<ExtensionHeaders> {
+    let mut extensions = ExtensionHeaders::new();
+    if let Some(id) = params.int_extension_id() {
+        extensions.set_intvalue(id, prng.next());
+    }
+    if let Some(id) = params.var_extension_id() {
+        let len = (prng.next() % 20 + 1) as usize;
+        extensions.set_bytesvalue(id, prng.bytes(len));
+    }
+    if extensions.is_empty() {
+        None
+    } else {
+        Some(extensions)
+    }
+}
+
+fn object_payload(params: &MoqTestParams, object_id: u64) -> Bytes {
+    Bytes::from(vec![b't'; params.object_size(object_id) as usize])
+}
+
+/// Generate the object set into the track, per the tuple.
+///
+/// Returns when every object has been handed to the transport; the caller
+/// then completes the publish (PUBLISH_DONE) via `Published::serve`.
+pub async fn generate(params: &MoqTestParams, track: TrackWriter) -> Result<()> {
+    let mut prng = Prng::from_entropy();
+    match params.forwarding {
+        Forwarding::SubgroupPerGroup => {
+            let mut subgroups = track.subgroups().context("failed to enter subgroup mode")?;
+            for group in params.groups() {
+                let mut subgroup = subgroups
+                    .create(Subgroup {
+                        group_id: group,
+                        subgroup_id: 0,
+                        priority: PRIORITY,
+                    })
+                    .context("failed to create subgroup")?;
+                write_group_objects(params, &mut subgroup, &mut prng).await?;
+                subgroup.finish().context("failed to finish subgroup")?;
+            }
+        }
+        Forwarding::SubgroupPerObject => {
+            let mut subgroups = track.subgroups().context("failed to enter subgroup mode")?;
+            for group in params.groups() {
+                for object in params.objects() {
+                    let mut subgroup = subgroups
+                        .create(Subgroup {
+                            group_id: group,
+                            subgroup_id: object,
+                            priority: PRIORITY,
+                        })
+                        .context("failed to create subgroup")?;
+                    write_object(params, &mut subgroup, object, &mut prng)?;
+                    subgroup.finish().context("failed to finish subgroup")?;
+                    pace(params).await;
+                }
+            }
+        }
+        Forwarding::TwoSubgroupsPerGroup => {
+            let mut subgroups = track.subgroups().context("failed to enter subgroup mode")?;
+            for group in params.groups() {
+                let mut even = subgroups
+                    .create(Subgroup {
+                        group_id: group,
+                        subgroup_id: 0,
+                        priority: PRIORITY,
+                    })
+                    .context("failed to create subgroup 0")?;
+                let mut odd = subgroups
+                    .create(Subgroup {
+                        group_id: group,
+                        subgroup_id: 1,
+                        priority: PRIORITY,
+                    })
+                    .context("failed to create subgroup 1")?;
+                for object in params.objects() {
+                    let subgroup = if (object - params.start_object) % 2 == 0 {
+                        &mut even
+                    } else {
+                        &mut odd
+                    };
+                    write_object(params, subgroup, object, &mut prng)?;
+                    pace(params).await;
+                }
+                even.finish().context("failed to finish subgroup 0")?;
+                odd.finish().context("failed to finish subgroup 1")?;
+            }
+        }
+        Forwarding::Datagram => {
+            let mut datagrams = track.datagrams().context("failed to enter datagram mode")?;
+            for group in params.groups() {
+                for object in params.objects() {
+                    let datagram = if params.eog_markers && object == params.last_object {
+                        // Status datagram: the EndOfGroup status conveys the
+                        // marker; the end-of-group type bit is only valid on
+                        // payload datagrams.
+                        Datagram {
+                            group_id: group,
+                            object_id: object,
+                            priority: PRIORITY,
+                            status: ObjectStatus::EndOfGroup,
+                            end_of_group: false,
+                            payload: Bytes::new(),
+                            extension_headers: ExtensionHeaders::new(),
+                        }
+                    } else {
+                        Datagram {
+                            group_id: group,
+                            object_id: object,
+                            priority: PRIORITY,
+                            status: ObjectStatus::NormalObject,
+                            end_of_group: false,
+                            payload: object_payload(params, object),
+                            extension_headers: object_extensions(params, &mut prng)
+                                .unwrap_or_default(),
+                        }
+                    };
+                    datagrams
+                        .write(datagram)
+                        .context("failed to write datagram")?;
+                    pace(params).await;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Write every object of one group to a single subgroup (mode 0).
+async fn write_group_objects(
+    params: &MoqTestParams,
+    subgroup: &mut moq_transport::serve::SubgroupWriter,
+    prng: &mut Prng,
+) -> Result<()> {
+    for object in params.objects() {
+        write_object(params, subgroup, object, prng)?;
+        pace(params).await;
+    }
+    Ok(())
+}
+
+/// Write one object (data or EOG marker) to a subgroup.
+fn write_object(
+    params: &MoqTestParams,
+    subgroup: &mut moq_transport::serve::SubgroupWriter,
+    object: u64,
+    prng: &mut Prng,
+) -> Result<()> {
+    if params.eog_markers && object == params.last_object {
+        let marker = subgroup
+            .create_with_id_and_status(object, 0, ObjectStatus::EndOfGroup, None)
+            .context("failed to create EOG marker")?;
+        drop(marker);
+        return Ok(());
+    }
+
+    let payload = object_payload(params, object);
+    let mut writer = subgroup
+        .create_with_id(object, payload.len(), object_extensions(params, prng))
+        .context("failed to create object")?;
+    writer.write(payload).context("failed to write object")?;
+    Ok(())
+}
+
+async fn pace(params: &MoqTestParams) {
+    if params.frequency_ms > 0 {
+        sleep(Duration::from_millis(params.frequency_ms)).await;
+    }
+}
+
+/// What the verifier observed, in a form suitable for TAP diagnostics.
+#[derive(Debug, Default)]
+pub struct Report {
+    pub failures: Vec<String>,
+    pub data_objects_received: u64,
+    pub data_objects_expected: u64,
+    pub eog_markers_received: u64,
+    pub eog_markers_expected: u64,
+    pub streams_received: u64,
+    pub publish_done: Option<String>,
+}
+
+impl Report {
+    pub fn passed(&self) -> bool {
+        self.failures.is_empty()
+    }
+
+    /// One-line summary for TAP diagnostics.
+    pub fn summary(&self) -> String {
+        if self.passed() {
+            format!(
+                "objects {}/{}, eog {}/{}, streams {}, publish_done {}",
+                self.data_objects_received,
+                self.data_objects_expected,
+                self.eog_markers_received,
+                self.eog_markers_expected,
+                self.streams_received,
+                self.publish_done.as_deref().unwrap_or("none"),
+            )
+        } else {
+            format!(
+                "{} failure(s); first: {}",
+                self.failures.len(),
+                self.failures[0]
+            )
+        }
+    }
+}
+
+/// The expected object set derived from the tuple, checked off as objects
+/// arrive. Any deviation is recorded as a failure string immediately.
+struct Scoreboard {
+    params: MoqTestParams,
+    expected_data: HashSet<(u64, u64)>,
+    expected_eog: HashSet<(u64, u64)>,
+    received: HashSet<(u64, u64)>,
+    received_eog: HashSet<(u64, u64)>,
+    last_object_per_stream: HashMap<(u64, u64), u64>,
+    failures: Vec<String>,
+    data_received: u64,
+    eog_received: u64,
+}
+
+impl Scoreboard {
+    fn new(params: MoqTestParams) -> Self {
+        let mut expected_data = HashSet::new();
+        let mut expected_eog = HashSet::new();
+        for group in params.groups() {
+            for object in params.data_objects() {
+                expected_data.insert((group, object));
+            }
+            if params.eog_markers {
+                expected_eog.insert((group, params.last_object));
+            }
+        }
+        Self {
+            params,
+            expected_data,
+            expected_eog,
+            received: HashSet::new(),
+            received_eog: HashSet::new(),
+            last_object_per_stream: HashMap::new(),
+            failures: Vec::new(),
+            data_received: 0,
+            eog_received: 0,
+        }
+    }
+
+    fn fail(&mut self, message: String) {
+        const MAX_FAILURES: usize = 50;
+        if self.failures.len() < MAX_FAILURES {
+            self.failures.push(message);
+        }
+    }
+
+    fn check_subgroup(&mut self, group: u64, object: u64, subgroup: Option<u64>) {
+        let Some(subgroup) = subgroup else {
+            return; // datagram mode: no subgroup mapping to check
+        };
+        match self.params.subgroup_for(object) {
+            Some(expected) if expected != subgroup => self.fail(format!(
+                "object ({group}, {object}) arrived on subgroup {subgroup}, expected {expected}"
+            )),
+            None => self.fail(format!(
+                "object ({group}, {object}) arrived on subgroup {subgroup} in datagram mode"
+            )),
+            _ => {}
+        }
+
+        // Per-stream ordering only; relays may reorder streams freely.
+        let key = (group, subgroup);
+        if let Some(last) = self.last_object_per_stream.insert(key, object) {
+            if object <= last {
+                self.fail(format!(
+                    "object ({group}, {object}) arrived out of order within subgroup {subgroup} (after {last})"
+                ));
+            }
+        }
+    }
+
+    fn check_extensions(&mut self, group: u64, object: u64, extensions: &ExtensionHeaders) {
+        let mut expected = 0;
+        if let Some(id) = self.params.int_extension_id() {
+            expected += 1;
+            if !extensions.has(id) {
+                self.fail(format!(
+                    "object ({group}, {object}) missing integer extension {id}"
+                ));
+            }
+        }
+        if let Some(id) = self.params.var_extension_id() {
+            expected += 1;
+            if !extensions.has(id) {
+                self.fail(format!(
+                    "object ({group}, {object}) missing variable extension {id}"
+                ));
+            }
+        }
+        // Exactly the configured set, no more, no less.
+        if extensions.0.len() != expected {
+            self.fail(format!(
+                "object ({group}, {object}) carried {} extensions, expected {expected}",
+                extensions.0.len()
+            ));
+        }
+    }
+
+    fn record_data(
+        &mut self,
+        group: u64,
+        object: u64,
+        subgroup: Option<u64>,
+        payload: &[u8],
+        extensions: &ExtensionHeaders,
+    ) {
+        if self.expected_eog.contains(&(group, object)) {
+            self.fail(format!(
+                "data object at ({group}, {object}) where an EOG marker was expected"
+            ));
+            return;
+        }
+        if !self.expected_data.contains(&(group, object)) {
+            self.fail(format!("unexpected object ({group}, {object})"));
+            return;
+        }
+        if !self.received.insert((group, object)) {
+            self.fail(format!("duplicate object ({group}, {object})"));
+            return;
+        }
+        self.data_received += 1;
+
+        let expected_size = self.params.object_size(object) as usize;
+        if payload.len() != expected_size {
+            self.fail(format!(
+                "object ({group}, {object}) size {} != expected {expected_size}",
+                payload.len()
+            ));
+        } else if !payload.iter().all(|b| *b == b't') {
+            self.fail(format!("object ({group}, {object}) payload corrupted"));
+        }
+
+        self.check_subgroup(group, object, subgroup);
+        self.check_extensions(group, object, extensions);
+    }
+
+    fn record_eog(&mut self, group: u64, object: u64, subgroup: Option<u64>) {
+        if !self.params.eog_markers {
+            self.fail(format!("unexpected EOG marker at ({group}, {object})"));
+            return;
+        }
+        if !self.expected_eog.contains(&(group, object)) {
+            self.fail(format!(
+                "EOG marker at ({group}, {object}), expected only at object {}",
+                self.params.last_object
+            ));
+            return;
+        }
+        if !self.received_eog.insert((group, object)) {
+            self.fail(format!("duplicate EOG marker at ({group}, {object})"));
+            return;
+        }
+        self.eog_received += 1;
+        self.check_subgroup(group, object, subgroup);
+    }
+
+    fn finish(mut self, publish_done: Option<&PublishDoneInfo>, forward_zero: bool) -> Report {
+        let mut report = Report {
+            data_objects_expected: if forward_zero {
+                0
+            } else {
+                self.expected_data.len() as u64
+            },
+            data_objects_received: self.data_received,
+            eog_markers_expected: if forward_zero {
+                0
+            } else {
+                self.expected_eog.len() as u64
+            },
+            eog_markers_received: self.eog_received,
+            failures: std::mem::take(&mut self.failures),
+            ..Report::default()
+        };
+
+        if !forward_zero {
+            let missing_count = self.expected_data.difference(&self.received).count();
+            let mut missing: Vec<_> = self
+                .expected_data
+                .difference(&self.received)
+                .map(|(g, o)| format!("({g}, {o})"))
+                .collect();
+            missing.sort();
+            missing.truncate(5);
+            if missing_count > 0 {
+                report.failures.push(format!(
+                    "missing {missing_count} objects (first 5): {}",
+                    missing.join(", ")
+                ));
+            }
+            for (group, object) in self.expected_eog.difference(&self.received_eog) {
+                report
+                    .failures
+                    .push(format!("missing EOG marker at ({group}, {object})"));
+            }
+        }
+
+        match publish_done {
+            Some(done) => {
+                report.publish_done = Some(format!(
+                    "status={} stream_count={} reason={:?}",
+                    done.status_code, done.stream_count, done.reason
+                ));
+                let expected_status = PublishDoneCode::TrackEnded as u64;
+                if done.status_code != expected_status {
+                    report.failures.push(format!(
+                        "PUBLISH_DONE status {} != TRACK_ENDED ({expected_status})",
+                        done.status_code
+                    ));
+                }
+                let expected_streams = if forward_zero {
+                    0
+                } else {
+                    self.params.expected_stream_count()
+                };
+                if done.stream_count != expected_streams {
+                    report.failures.push(format!(
+                        "PUBLISH_DONE stream count {} != expected {expected_streams}",
+                        done.stream_count
+                    ));
+                }
+            }
+            None => report
+                .failures
+                .push("PUBLISH_DONE never arrived".to_string()),
+        }
+
+        report
+    }
+}
+
+/// Verify a subscription against the scoreboard derived from the tuple.
+///
+/// Consumes the track until the publisher ends it, then checks the object
+/// set, structure, and the PUBLISH_DONE terminal signal.
+pub async fn verify(
+    params: MoqTestParams,
+    track: TrackReader,
+    subscribe: Subscribe,
+    forward_zero: bool,
+) -> Result<Report> {
+    let mut scoreboard = Scoreboard::new(params.clone());
+
+    if forward_zero {
+        // FORWARD=0: no data plane at all. Setup completing, PUBLISH_DONE
+        // with stream count 0, and zero objects is the pass condition.
+        match subscribe.closed().await {
+            Err(err) if is_normal_subscription_end(&err) => {}
+            Err(err) => bail!("subscription ended abnormally: {err}"),
+            Ok(()) => {}
+        }
+        let mut report = scoreboard.finish(subscribe.publish_done().as_ref(), true);
+        // If the relay forwarded data anyway, the session would already have
+        // resolved the track mode; a resolved mode here is a failure. A
+        // no-data track leaves mode() pending or closed.
+        if let Ok(Ok(_mode)) = tokio::time::timeout(Duration::from_millis(10), track.mode()).await {
+            report
+                .failures
+                .push("FORWARD=0 but the relay forwarded data".to_string());
+        }
+        return Ok(report);
+    }
+
+    let mode = track.mode().await.context("track mode never resolved")?;
+    let mut streams_received = 0u64;
+
+    match mode {
+        TrackReaderMode::Subgroups(mut subgroups) => loop {
+            match subgroups.next().await {
+                Ok(Some(mut subgroup)) => {
+                    streams_received += 1;
+                    let group = subgroup.info.group_id;
+                    let subgroup_id = subgroup.info.subgroup_id;
+                    loop {
+                        match subgroup.next().await {
+                            Ok(Some(mut object)) => {
+                                let object_id = object.info.object_id;
+                                if object.info.status == ObjectStatus::NormalObject {
+                                    let payload =
+                                        object.read_all().await.context("object read failed")?;
+                                    scoreboard.record_data(
+                                        group,
+                                        object_id,
+                                        Some(subgroup_id),
+                                        &payload,
+                                        &object.info.extension_headers,
+                                    );
+                                } else {
+                                    scoreboard.record_eog(group, object_id, Some(subgroup_id));
+                                }
+                            }
+                            Ok(None) => break,
+                            Err(err) if is_normal_subscription_end(&err) => break,
+                            Err(err) => bail!("subgroup read failed: {err}"),
+                        }
+                    }
+                }
+                Ok(None) => break,
+                Err(err) if is_normal_subscription_end(&err) => break,
+                Err(err) => bail!("subgroup stream failed: {err}"),
+            }
+        },
+        TrackReaderMode::Datagrams(mut datagrams) => loop {
+            match datagrams.read().await {
+                Ok(Some(datagram)) => {
+                    if datagram.status == ObjectStatus::NormalObject {
+                        scoreboard.record_data(
+                            datagram.group_id,
+                            datagram.object_id,
+                            None,
+                            &datagram.payload,
+                            &datagram.extension_headers,
+                        );
+                    } else {
+                        scoreboard.record_eog(datagram.group_id, datagram.object_id, None);
+                    }
+                }
+                Ok(None) => break,
+                Err(err) if is_normal_subscription_end(&err) => break,
+                Err(err) => bail!("datagram read failed: {err}"),
+            }
+        },
+        _ => bail!("unexpected track mode (expected subgroups or datagrams)"),
+    }
+
+    // Wait for the terminal signal; the data plane draining first is normal.
+    match subscribe.closed().await {
+        Err(err) if is_normal_subscription_end(&err) => {}
+        Err(err) => bail!("subscription ended abnormally: {err}"),
+        Ok(()) => {}
+    }
+
+    let mut report = scoreboard.finish(subscribe.publish_done().as_ref(), false);
+    report.streams_received = streams_received;
+    Ok(report)
+}
+
+/// A named moq-test scenario: a tuple plus choreography flags.
+pub struct Scenario {
+    pub params: MoqTestParams,
+    /// Run the SUBSCRIBE with FORWARD=0 (expect setup + PUBLISH_DONE, no data).
+    pub forward_zero: bool,
+}
+
+/// Base tuple for the built-in scenarios: subgroup-per-group, group 0 / object
+/// 0 starts, unit increments, 2ms pacing, no EOG, no extensions. Scenarios
+/// override fields with struct-update syntax and are validated once when the
+/// built-in table is first used.
+fn base() -> MoqTestParams {
+    MoqTestParams {
+        forwarding: Forwarding::SubgroupPerGroup,
+        start_group: 0,
+        start_object: 0,
+        last_group: 0,
+        last_object: 0,
+        objects_per_group: 1,
+        size_object_zero: 64,
+        size_object_rest: 32,
+        frequency_ms: 2,
+        group_increment: 1,
+        object_increment: 1,
+        eog_markers: false,
+        int_extension: None,
+        var_extension: None,
+        delivery_timeout_ms: None,
+    }
+}
+
+/// The built-in scenarios, built and validated once. Small and finite:
+/// every run is well under a second of object pacing plus round-trips.
+static SCENARIOS: LazyLock<Vec<(&'static str, Scenario)>> = LazyLock::new(|| {
+    let table = vec![
+        (
+            "moq-test-subgroup-per-group",
+            Scenario {
+                params: MoqTestParams {
+                    last_group: 2,
+                    last_object: 4,
+                    objects_per_group: 5,
+                    ..base()
+                },
+                forward_zero: false,
+            },
+        ),
+        (
+            "moq-test-subgroup-per-group-eog",
+            Scenario {
+                params: MoqTestParams {
+                    last_group: 2,
+                    last_object: 5,
+                    objects_per_group: 5,
+                    eog_markers: true,
+                    ..base()
+                },
+                forward_zero: false,
+            },
+        ),
+        (
+            "moq-test-subgroup-per-object",
+            Scenario {
+                params: MoqTestParams {
+                    forwarding: Forwarding::SubgroupPerObject,
+                    last_group: 1,
+                    last_object: 3,
+                    objects_per_group: 4,
+                    ..base()
+                },
+                forward_zero: false,
+            },
+        ),
+        (
+            "moq-test-two-subgroups-eog",
+            Scenario {
+                params: MoqTestParams {
+                    forwarding: Forwarding::TwoSubgroupsPerGroup,
+                    last_group: 2,
+                    last_object: 6,
+                    objects_per_group: 6,
+                    eog_markers: true,
+                    ..base()
+                },
+                forward_zero: false,
+            },
+        ),
+        (
+            "moq-test-datagram",
+            Scenario {
+                // Datagram delivery through the serve API is latest-value,
+                // not a queue: a receiver that falls behind loses objects.
+                // 20ms pacing keeps every hop's reader ahead of the writer.
+                params: MoqTestParams {
+                    forwarding: Forwarding::Datagram,
+                    last_group: 2,
+                    last_object: 4,
+                    objects_per_group: 5,
+                    frequency_ms: 20,
+                    ..base()
+                },
+                forward_zero: false,
+            },
+        ),
+        (
+            "moq-test-datagram-eog",
+            Scenario {
+                params: MoqTestParams {
+                    forwarding: Forwarding::Datagram,
+                    last_group: 2,
+                    last_object: 5,
+                    objects_per_group: 5,
+                    frequency_ms: 20,
+                    eog_markers: true,
+                    ..base()
+                },
+                forward_zero: false,
+            },
+        ),
+        (
+            "moq-test-extensions",
+            Scenario {
+                params: MoqTestParams {
+                    last_group: 2,
+                    last_object: 5,
+                    objects_per_group: 5,
+                    eog_markers: true,
+                    int_extension: Some(1),
+                    var_extension: Some(2),
+                    ..base()
+                },
+                forward_zero: false,
+            },
+        ),
+        (
+            "moq-test-increments",
+            Scenario {
+                params: MoqTestParams {
+                    start_group: 10,
+                    start_object: 3,
+                    last_group: 24,
+                    last_object: 7,
+                    objects_per_group: 3,
+                    size_object_zero: 40,
+                    size_object_rest: 24,
+                    group_increment: 7,
+                    object_increment: 2,
+                    ..base()
+                },
+                forward_zero: false,
+            },
+        ),
+        (
+            "moq-test-forward-zero",
+            Scenario {
+                params: MoqTestParams {
+                    last_group: 1,
+                    last_object: 2,
+                    objects_per_group: 3,
+                    ..base()
+                },
+                forward_zero: true,
+            },
+        ),
+    ];
+    for (name, scenario) in &table {
+        scenario
+            .params
+            .validate()
+            .unwrap_or_else(|e| panic!("built-in scenario {name} is invalid: {e}"));
+    }
+    table
+});
+
+/// Look up a built-in scenario by name.
+pub fn scenario(name: &str) -> Option<&'static Scenario> {
+    SCENARIOS.iter().find(|(n, _)| *n == name).map(|(_, s)| s)
+}
+
+async fn connect(
+    args: &Args,
+) -> Result<(
+    web_transport::Session,
+    String,
+    moq_transport::session::Transport,
+)> {
+    let tls = args.tls.load()?;
+    let quic = moq_native_ietf::quic::Endpoint::new(moq_native_ietf::quic::Config::new(
+        args.bind, None, tls,
+    )?)?;
+    let (session, connection_id, transport) = quic.client.connect(&args.relay, None).await?;
+    Ok((session, connection_id, transport))
+}
+
+/// Run a moq-test scenario with the subscribe-first choreography and return
+/// the verification report.
+pub async fn run(args: &Args, scenario: &Scenario) -> Result<(TestConnectionIds, Report)> {
+    let mut cids = TestConnectionIds::default();
+    let namespace = scenario.params.to_namespace();
+    let track_name = run_track_name();
+
+    // 1. Subscriber session: subscribe first; the relay holds the
+    //    subscription pending (RENDEZVOUS_TIMEOUT) until the publisher
+    //    appears.
+    let (sub_session, sub_cid, sub_transport) = connect(args)
+        .await
+        .context("subscriber failed to connect")?;
+    cids.add(sub_cid);
+    let (sub_session, _sub_publisher, mut subscriber) =
+        Session::connect(sub_session, None, sub_transport)
+            .await
+            .context("subscriber SETUP failed")?;
+
+    let (sub_writer, sub_reader) = Track::new(namespace.clone(), track_name.clone()).produce();
+
+    let mut sub_params = KeyValuePairs::default();
+    sub_params.set_rendezvous_timeout(RENDEZVOUS_TIMEOUT_MS);
+    if scenario.forward_zero {
+        sub_params.set_forward(false);
+    }
+
+    // Datagrams are fire-and-forget: objects the publisher sends before the
+    // relay has bound the subscription have nowhere to go and are silently
+    // dropped (the serve API's datagram delivery is latest-value, not a
+    // queue). The publisher therefore waits until the subscriber's SUBSCRIBE
+    // has been answered — at that point the relay has bound the pair and
+    // forwarding is live. The channel also fails the publisher promptly if
+    // the subscriber's setup errors.
+    let (setup_tx, setup_rx) = tokio::sync::oneshot::channel::<()>();
+
+    let params = scenario.params.clone();
+    let forward_zero = scenario.forward_zero;
+    let sub_handle = tokio::spawn(async move {
+        let work = async move {
+            let subscribe = subscriber
+                .subscribe_open_with_params(sub_writer, sub_params)
+                .await
+                .context("SUBSCRIBE failed")?;
+            let _ = setup_tx.send(());
+            verify(params, sub_reader, subscribe, forward_zero).await
+        };
+        tokio::select! {
+            res = work => res,
+            res = sub_session.run() => {
+                res.context("subscriber session error")?;
+                Err(anyhow!("subscriber session ended before verification completed"))
+            }
+        }
+    });
+
+    // Give the subscriber a head start so the SUBSCRIBE genuinely arrives
+    // first at the relay. This is a bias, not a guarantee: if the publisher
+    // wins the race under load the relay simply runs a publish-first
+    // choreography, which passes identically for the data scenarios (the
+    // scoreboard is order-agnostic across the two connection roles). The one
+    // scenario where ordering is semantic — FORWARD=0 — fails loudly on
+    // inversion, because the relay then grants forward=1 and data flows.
+    sleep(Duration::from_millis(200)).await;
+
+    // 2. Publisher session: direct PUBLISH of the same track, then generate.
+    let (pub_session, pub_cid, pub_transport) =
+        connect(args).await.context("publisher failed to connect")?;
+    cids.add(pub_cid);
+    let (pub_session, mut publisher, _pub_subscriber) =
+        Session::connect(pub_session, None, pub_transport)
+            .await
+            .context("publisher SETUP failed")?;
+
+    let (pub_writer, pub_reader) = Track::new(namespace.clone(), track_name.clone()).produce();
+
+    let mut pub_params = KeyValuePairs::default();
+    if let Some(timeout_ms) = scenario.params.delivery_timeout_ms {
+        pub_params.set_delivery_timeout(timeout_ms);
+    }
+
+    let publish = async move {
+        let mut published = publisher
+            .publish(pub_reader, pub_params)
+            .await
+            .context("failed to send PUBLISH")?;
+        published.ok().await.context("PUBLISH was rejected")?;
+        setup_rx
+            .await
+            .map_err(|_| anyhow!("subscriber setup failed before generation started"))?;
+        tracing::info!(
+            objects = scenario.params.expected_data_objects(),
+            streams = scenario.params.expected_stream_count(),
+            "PUBLISH accepted and subscription bound; generating objects"
+        );
+        // Generation and serving must run concurrently: the session reads
+        // datagrams from the track through the serve API's latest-value
+        // reader, so anything written before `serve` starts is coalesced
+        // away. (Subgroup streams buffer and would survive sequential
+        // ordering, but datagrams do not.)
+        let params = &scenario.params;
+        let generate = async move { generate(params, pub_writer).await };
+        let serve = async move { published.serve().await };
+        let (gen_result, serve_result) = tokio::join!(generate, serve);
+        gen_result?;
+        serve_result.context("failed serving PUBLISH track")?;
+        tracing::info!("PUBLISH completed");
+        Ok::<_, anyhow::Error>(())
+    };
+
+    tokio::select! {
+        res = publish => res?,
+        res = pub_session.run() => {
+            res.context("publisher session error")?;
+            bail!("publisher session ended before generation completed");
+        }
+    }
+
+    let report = sub_handle
+        .await
+        .context("subscriber task panicked")?
+        .context("subscriber verification failed")?;
+
+    Ok((cids, report))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(fields: &[&str]) -> Result<MoqTestParams> {
+        let fields: Vec<String> = fields.iter().map(|s| s.to_string()).collect();
+        MoqTestParams::from_namespace_fields(&fields)
+    }
+
+    #[test]
+    fn round_trip_explicit_tuple() {
+        let p = MoqTestParams {
+            forwarding: Forwarding::TwoSubgroupsPerGroup,
+            last_group: 2,
+            last_object: 6,
+            objects_per_group: 6,
+            eog_markers: true,
+            int_extension: Some(1),
+            var_extension: Some(2),
+            ..base()
+        };
+        let fields = p.to_namespace_fields();
+        assert_eq!(fields.len(), NUM_TUPLE_FIELDS);
+        let parsed = MoqTestParams::from_namespace_fields(&fields).unwrap();
+        assert_eq!(parsed, p);
+    }
+
+    #[test]
+    fn blank_fields_select_defaults() {
+        // Only fields 4 (last group) and 5 (last object) are explicit.
+        let p = parse(&[
+            "moq-test-00",
+            "",
+            "",
+            "",
+            "3",
+            "4",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+        ])
+        .unwrap();
+        assert_eq!(p.forwarding, Forwarding::SubgroupPerGroup);
+        assert_eq!(p.start_group, 0);
+        assert_eq!(p.start_object, 0);
+        assert_eq!(p.last_group, 3);
+        assert_eq!(p.last_object, 4);
+        assert_eq!(p.objects_per_group, 10); // default: cap check only (max 9 >= 4)
+        assert_eq!(p.int_extension, None);
+
+        // Field 5 blank: defaults to the computed maximum.
+        let p = parse(&[
+            "moq-test-00",
+            "",
+            "",
+            "",
+            "3",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+        ])
+        .unwrap();
+        assert_eq!(p.last_object, 9); // 0 + (10-1)*1
+    }
+
+    #[test]
+    fn rejects_wrong_field_count_and_tag() {
+        assert!(parse(&["moq-test-00", "0"]).is_err());
+        let mut fields = vec!["wrong-00".to_string()];
+        fields.extend((0..15).map(|_| "0".to_string()));
+        assert!(MoqTestParams::from_namespace_fields(&fields).is_err());
+    }
+
+    #[test]
+    fn rejects_unbounded_default_last_group() {
+        // A blank field 4 defaults last_group to (1<<62)-1; validation must
+        // reject the tuple before the scoreboard materializes the series.
+        let fields: Vec<String> = "moq-test-00/1/0/0//4/10/64/32/100/1/1/0///"
+            .split('/')
+            .map(str::to_string)
+            .collect();
+        assert_eq!(
+            MoqTestParams::from_namespace_fields(&fields)
+                .unwrap_err()
+                .to_string(),
+            "group series of 4611686018427387904 groups exceeds the 100000 group limit"
+        );
+
+        // An explicit last_group at u64::MAX must be rejected by the same
+        // bound, not wrap the count arithmetic.
+        let fields: Vec<String> = "moq-test-00/1/0/0/18446744073709551615/0/1/64/32/100/1/1/0///"
+            .split('/')
+            .map(str::to_string)
+            .collect();
+        assert_eq!(
+            MoqTestParams::from_namespace_fields(&fields)
+                .unwrap_err()
+                .to_string(),
+            "group series of 18446744073709551616 groups exceeds the 100000 group limit"
+        );
+    }
+
+    #[test]
+    fn rejects_excessive_total_object_count() {
+        // 1000 groups of 1100 objects = 1.1M objects, over the cap.
+        let params = MoqTestParams {
+            last_group: 999,
+            last_object: 1099,
+            objects_per_group: 1100,
+            ..base()
+        };
+        assert!(params.validate().is_err());
+
+        // 999 groups of 1000 objects = 999k objects, just under the cap.
+        let params = MoqTestParams {
+            last_group: 998,
+            last_object: 999,
+            objects_per_group: 1000,
+            ..base()
+        };
+        assert!(params.validate().is_ok());
+    }
+
+    #[test]
+    fn object_series_and_eog_slot() {
+        // 3 groups (0,1,2), objects 0..=5, EOG at 5: data objects 0..=4.
+        let p = MoqTestParams {
+            last_group: 2,
+            last_object: 5,
+            objects_per_group: 5,
+            eog_markers: true,
+            ..base()
+        };
+        assert_eq!(p.groups(), vec![0, 1, 2]);
+        assert_eq!(p.objects(), vec![0, 1, 2, 3, 4, 5]);
+        assert_eq!(p.data_objects(), vec![0, 1, 2, 3, 4]);
+        assert_eq!(p.expected_data_objects(), 15);
+        assert_eq!(p.expected_stream_count(), 3);
+    }
+
+    #[test]
+    fn increments_scenario_math() {
+        let p = MoqTestParams {
+            start_group: 10,
+            start_object: 3,
+            last_group: 24,
+            last_object: 7,
+            objects_per_group: 3,
+            size_object_zero: 40,
+            size_object_rest: 24,
+            group_increment: 7,
+            object_increment: 2,
+            ..base()
+        };
+        p.validate().unwrap();
+        assert_eq!(p.groups(), vec![10, 17, 24]);
+        assert_eq!(p.objects(), vec![3, 5, 7]);
+        assert_eq!(p.expected_data_objects(), 9);
+        assert_eq!(p.object_size(3), 40);
+        assert_eq!(p.object_size(5), 24);
+    }
+
+    #[test]
+    fn field5_cap_offsets_by_start_object() {
+        // The naive formula (objects_per_group + eog) * object_increment
+        // assumes start_object == 0; ours offsets. 3 objects starting at 3
+        // with increment 2: last valid slot is 3 + 2*2 = 7.
+        let p = MoqTestParams {
+            start_object: 3,
+            last_object: 7,
+            objects_per_group: 3,
+            object_increment: 2,
+            ..base()
+        };
+        p.validate().unwrap();
+
+        // 8 would require a fourth object slot: invalid.
+        let mut bad = p.clone();
+        bad.last_object = 8;
+        assert!(bad.validate().is_err());
+    }
+
+    #[test]
+    fn stream_counts_by_mode() {
+        assert_eq!(
+            MoqTestParams {
+                last_group: 2,
+                last_object: 4,
+                objects_per_group: 5,
+                ..base()
+            }
+            .expected_stream_count(),
+            3
+        );
+        assert_eq!(
+            MoqTestParams {
+                forwarding: Forwarding::SubgroupPerObject,
+                last_group: 1,
+                last_object: 3,
+                objects_per_group: 4,
+                ..base()
+            }
+            .expected_stream_count(),
+            8
+        );
+        assert_eq!(
+            MoqTestParams {
+                forwarding: Forwarding::TwoSubgroupsPerGroup,
+                last_group: 2,
+                last_object: 6,
+                objects_per_group: 6,
+                eog_markers: true,
+                ..base()
+            }
+            .expected_stream_count(),
+            6
+        );
+        assert_eq!(
+            MoqTestParams {
+                forwarding: Forwarding::Datagram,
+                last_group: 2,
+                last_object: 4,
+                objects_per_group: 5,
+                ..base()
+            }
+            .expected_stream_count(),
+            0
+        );
+    }
+
+    #[test]
+    fn extension_ids() {
+        let p = MoqTestParams {
+            int_extension: Some(1),
+            var_extension: Some(2),
+            ..base()
+        };
+        assert_eq!(p.int_extension_id(), Some(2));
+        assert_eq!(p.var_extension_id(), Some(5));
+    }
+
+    #[test]
+    fn datagram_size_budget() {
+        assert!(MoqTestParams {
+            forwarding: Forwarding::Datagram,
+            last_object: 4,
+            objects_per_group: 5,
+            ..base()
+        }
+        .validate()
+        .is_ok());
+        assert!(MoqTestParams {
+            forwarding: Forwarding::Datagram,
+            last_object: 4,
+            objects_per_group: 5,
+            size_object_zero: 2000,
+            ..base()
+        }
+        .validate()
+        .is_err());
+    }
+
+    fn full_scoreboard() -> Scoreboard {
+        // One group, objects 0,1 data + EOG at 2.
+        let p = MoqTestParams {
+            last_object: 2,
+            objects_per_group: 2,
+            size_object_zero: 4,
+            size_object_rest: 2,
+            eog_markers: true,
+            ..base()
+        };
+        Scoreboard::new(p)
+    }
+
+    fn done(status_code: u64, stream_count: u64) -> PublishDoneInfo {
+        PublishDoneInfo {
+            status_code,
+            stream_count,
+            reason: moq_transport::coding::ReasonPhrase("publish ended".to_string()),
+        }
+    }
+
+    #[test]
+    fn scoreboard_passes_on_exact_delivery() {
+        let mut sb = full_scoreboard();
+        // Group 0: data at 0,1; EOG at 2.
+        sb.record_data(0, 0, Some(0), b"tttt", &ExtensionHeaders::new());
+        sb.record_data(0, 1, Some(0), b"tt", &ExtensionHeaders::new());
+        sb.record_eog(0, 2, Some(0));
+        let report = sb.finish(Some(&done(PublishDoneCode::TrackEnded as u64, 1)), false);
+        assert!(report.passed(), "failures: {:?}", report.failures);
+    }
+
+    #[test]
+    fn scoreboard_catches_missing_object() {
+        let mut sb = full_scoreboard();
+        sb.record_data(0, 0, Some(0), b"tttt", &ExtensionHeaders::new());
+        sb.record_eog(0, 2, Some(0));
+        let report = sb.finish(Some(&done(PublishDoneCode::TrackEnded as u64, 1)), false);
+        assert!(!report.passed());
+        assert!(report.failures.iter().any(|f| f.contains("missing")));
+    }
+
+    #[test]
+    fn scoreboard_catches_extra_and_duplicate() {
+        let mut sb = full_scoreboard();
+        sb.record_data(0, 0, Some(0), b"tttt", &ExtensionHeaders::new());
+        sb.record_data(0, 1, Some(0), b"tt", &ExtensionHeaders::new());
+        sb.record_eog(0, 2, Some(0));
+        sb.record_data(0, 1, Some(0), b"tt", &ExtensionHeaders::new()); // duplicate
+        sb.record_data(0, 9, Some(0), b"tt", &ExtensionHeaders::new()); // unexpected
+        let report = sb.finish(Some(&done(PublishDoneCode::TrackEnded as u64, 1)), false);
+        assert!(report.failures.iter().any(|f| f.contains("duplicate")));
+        assert!(report.failures.iter().any(|f| f.contains("unexpected")));
+    }
+
+    #[test]
+    fn scoreboard_catches_corruption_and_size() {
+        let mut sb = full_scoreboard();
+        sb.record_data(0, 0, Some(0), b"txtt", &ExtensionHeaders::new());
+        sb.record_data(0, 1, Some(0), b"t", &ExtensionHeaders::new());
+        sb.record_eog(0, 2, Some(0));
+        let report = sb.finish(Some(&done(PublishDoneCode::TrackEnded as u64, 1)), false);
+        assert!(report.failures.iter().any(|f| f.contains("size")));
+        assert!(report.failures.iter().any(|f| f.contains("corrupted")));
+    }
+
+    #[test]
+    fn subgroup_mapping_is_offset_parity() {
+        // Two-subgroup mode maps (object_id - start_object) % 2: with
+        // start_object = 3, object 3 lands on subgroup 0 even though its
+        // raw ID is odd.
+        let p = MoqTestParams {
+            forwarding: Forwarding::TwoSubgroupsPerGroup,
+            start_object: 3,
+            last_object: 6,
+            objects_per_group: 4,
+            size_object_zero: 2,
+            size_object_rest: 2,
+            ..base()
+        };
+        let mut sb = Scoreboard::new(p);
+        sb.record_data(0, 3, Some(1), b"tt", &ExtensionHeaders::new()); // raw parity would allow this
+        sb.record_data(0, 4, Some(1), b"tt", &ExtensionHeaders::new());
+        sb.record_data(0, 5, Some(0), b"tt", &ExtensionHeaders::new());
+        sb.record_data(0, 6, Some(1), b"tt", &ExtensionHeaders::new());
+        let report = sb.finish(Some(&done(PublishDoneCode::TrackEnded as u64, 2)), false);
+        assert!(report
+            .failures
+            .iter()
+            .any(|f| f.contains("arrived on subgroup 1, expected 0")));
+    }
+
+    #[test]
+    fn scoreboard_catches_wrong_subgroup_and_order() {
+        // Objects 0..=3 in one group; sizes: object 0 -> 4 bytes, rest -> 2.
+        let p = MoqTestParams {
+            forwarding: Forwarding::TwoSubgroupsPerGroup,
+            last_object: 3,
+            objects_per_group: 4,
+            size_object_zero: 4,
+            size_object_rest: 2,
+            ..base()
+        };
+        let mut sb = Scoreboard::new(p);
+        sb.record_data(0, 0, Some(1), b"tttt", &ExtensionHeaders::new()); // even on odd subgroup
+        sb.record_data(0, 2, Some(0), b"tt", &ExtensionHeaders::new());
+        sb.record_data(0, 1, Some(1), b"tt", &ExtensionHeaders::new());
+        sb.record_data(0, 3, Some(1), b"tt", &ExtensionHeaders::new());
+        let report = sb.finish(Some(&done(PublishDoneCode::TrackEnded as u64, 2)), false);
+        assert!(report
+            .failures
+            .iter()
+            .any(|f| f.contains("arrived on subgroup 1, expected 0")));
+
+        // Out-of-order within a stream: object 0 after object 2 on subgroup 0.
+        let p = MoqTestParams {
+            last_object: 3,
+            objects_per_group: 4,
+            size_object_zero: 4,
+            size_object_rest: 2,
+            ..base()
+        };
+        let mut sb = Scoreboard::new(p);
+        sb.record_data(0, 2, Some(0), b"tt", &ExtensionHeaders::new());
+        sb.record_data(0, 0, Some(0), b"tttt", &ExtensionHeaders::new());
+        let report = sb.finish(Some(&done(PublishDoneCode::TrackEnded as u64, 1)), false);
+        assert!(report.failures.iter().any(|f| f.contains("out of order")));
+    }
+
+    #[test]
+    fn scoreboard_checks_publish_done() {
+        let mut sb = full_scoreboard();
+        sb.record_data(0, 0, Some(0), b"tttt", &ExtensionHeaders::new());
+        sb.record_data(0, 1, Some(0), b"tt", &ExtensionHeaders::new());
+        sb.record_eog(0, 2, Some(0));
+
+        let report = sb.finish(Some(&done(PublishDoneCode::TrackEnded as u64, 7)), false);
+        assert!(report.failures.iter().any(|f| f.contains("stream count 7")));
+
+        let sb = full_scoreboard();
+        let report = sb.finish(None, false);
+        assert!(report.failures.iter().any(|f| f.contains("never arrived")));
+    }
+
+    #[test]
+    fn scoreboard_forward_zero_expects_nothing() {
+        let p = MoqTestParams {
+            last_object: 2,
+            objects_per_group: 2,
+            eog_markers: true,
+            ..base()
+        };
+        let sb = Scoreboard::new(p.clone());
+        let report = sb.finish(Some(&done(PublishDoneCode::TrackEnded as u64, 0)), true);
+        assert!(report.passed(), "failures: {:?}", report.failures);
+
+        let sb = Scoreboard::new(p);
+        let report = sb.finish(Some(&done(PublishDoneCode::TrackEnded as u64, 3)), true);
+        assert!(report.failures.iter().any(|f| f.contains("stream count 3")));
+    }
+}

--- a/moq-test-client/src/moqtest.rs
+++ b/moq-test-client/src/moqtest.rs
@@ -58,6 +58,12 @@ const RENDEZVOUS_TIMEOUT_MS: u64 = 10_000;
 /// test-declaration error.
 const MAX_DATAGRAM_PAYLOAD: usize = 1200;
 
+/// Worst-case object size in any mode. Payloads are materialized as
+/// `vec![b't'; size]` during generation, so an absurd operator-supplied
+/// size must be a clean validation error, not an allocator failure.
+/// Generous test-scale limit; the datagram budget is much tighter.
+const MAX_OBJECT_SIZE: u64 = 16 * 1024 * 1024;
+
 /// moq-test forwarding preference (tuple field 1).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Forwarding {
@@ -274,11 +280,13 @@ impl MoqTestParams {
             );
         }
 
-        if self.forwarding == Forwarding::Datagram {
-            let max_size = self.size_object_zero.max(self.size_object_rest) as usize;
-            if max_size > MAX_DATAGRAM_PAYLOAD {
-                bail!("datagram-mode object size {max_size} exceeds budget {MAX_DATAGRAM_PAYLOAD}");
-            }
+        let max_size = self.size_object_zero.max(self.size_object_rest);
+        if max_size > MAX_OBJECT_SIZE {
+            bail!("object size {max_size} exceeds the {MAX_OBJECT_SIZE} byte limit");
+        }
+
+        if self.forwarding == Forwarding::Datagram && max_size as usize > MAX_DATAGRAM_PAYLOAD {
+            bail!("datagram-mode object size {max_size} exceeds budget {MAX_DATAGRAM_PAYLOAD}");
         }
 
         // Bound the materialized ranges: the scoreboard eagerly allocates one
@@ -837,7 +845,17 @@ impl Scoreboard {
         self.check_extensions(group, object, extensions);
     }
 
-    fn record_eog(&mut self, group: u64, object: u64, subgroup: Option<u64>) {
+    /// Record a status object. Only `EndOfGroup` is an EOG marker: the
+    /// generator never emits any other status, so a relay that injected
+    /// e.g. `EndOfTrack` at the EOG slot must fail verification rather
+    /// than silently pass.
+    fn record_eog(&mut self, status: ObjectStatus, group: u64, object: u64, subgroup: Option<u64>) {
+        if status != ObjectStatus::EndOfGroup {
+            self.fail(format!(
+                "unexpected status {status:?} at ({group}, {object}), expected EndOfGroup"
+            ));
+            return;
+        }
         if !self.params.eog_markers {
             self.fail(format!("unexpected EOG marker at ({group}, {object})"));
             return;
@@ -988,7 +1006,12 @@ pub async fn verify(
                                         &object.info.extension_headers,
                                     );
                                 } else {
-                                    scoreboard.record_eog(group, object_id, Some(subgroup_id));
+                                    scoreboard.record_eog(
+                                        object.info.status,
+                                        group,
+                                        object_id,
+                                        Some(subgroup_id),
+                                    );
                                 }
                             }
                             Ok(None) => break,
@@ -1014,7 +1037,12 @@ pub async fn verify(
                             &datagram.extension_headers,
                         );
                     } else {
-                        scoreboard.record_eog(datagram.group_id, datagram.object_id, None);
+                        scoreboard.record_eog(
+                            datagram.status,
+                            datagram.group_id,
+                            datagram.object_id,
+                            None,
+                        );
                     }
                 }
                 Ok(None) => break,
@@ -1638,6 +1666,30 @@ mod tests {
         .is_err());
     }
 
+    #[test]
+    fn subgroup_size_bound() {
+        // Subgroup modes stream over QUIC, so the tight datagram budget
+        // does not apply — but payloads are still materialized eagerly, so
+        // an absurd operator-supplied size is a validation error rather
+        // than an allocator failure.
+        assert!(MoqTestParams {
+            last_object: 4,
+            objects_per_group: 5,
+            size_object_rest: MAX_OBJECT_SIZE,
+            ..base()
+        }
+        .validate()
+        .is_ok());
+        assert!(MoqTestParams {
+            last_object: 4,
+            objects_per_group: 5,
+            size_object_zero: u64::MAX,
+            ..base()
+        }
+        .validate()
+        .is_err());
+    }
+
     fn full_scoreboard() -> Scoreboard {
         // One group, objects 0,1 data + EOG at 2.
         let p = MoqTestParams {
@@ -1665,7 +1717,7 @@ mod tests {
         // Group 0: data at 0,1; EOG at 2.
         sb.record_data(0, 0, Some(0), b"tttt", &ExtensionHeaders::new());
         sb.record_data(0, 1, Some(0), b"tt", &ExtensionHeaders::new());
-        sb.record_eog(0, 2, Some(0));
+        sb.record_eog(ObjectStatus::EndOfGroup, 0, 2, Some(0));
         let report = sb.finish(Some(&done(PublishDoneCode::TrackEnded as u64, 1)), false);
         assert!(report.passed(), "failures: {:?}", report.failures);
     }
@@ -1674,10 +1726,30 @@ mod tests {
     fn scoreboard_catches_missing_object() {
         let mut sb = full_scoreboard();
         sb.record_data(0, 0, Some(0), b"tttt", &ExtensionHeaders::new());
-        sb.record_eog(0, 2, Some(0));
+        sb.record_eog(ObjectStatus::EndOfGroup, 0, 2, Some(0));
         let report = sb.finish(Some(&done(PublishDoneCode::TrackEnded as u64, 1)), false);
         assert!(!report.passed());
         assert!(report.failures.iter().any(|f| f.contains("missing")));
+    }
+
+    #[test]
+    fn scoreboard_rejects_non_eog_status() {
+        // A relay that injects e.g. EndOfTrack at the EOG slot must not
+        // pass as an EOG marker.
+        let mut sb = full_scoreboard();
+        sb.record_data(0, 0, Some(0), b"tttt", &ExtensionHeaders::new());
+        sb.record_data(0, 1, Some(0), b"tt", &ExtensionHeaders::new());
+        sb.record_eog(ObjectStatus::EndOfTrack, 0, 2, Some(0));
+        let report = sb.finish(Some(&done(PublishDoneCode::TrackEnded as u64, 1)), false);
+        assert!(!report.passed());
+        assert!(
+            report
+                .failures
+                .iter()
+                .any(|f| f.contains("unexpected status")),
+            "failures: {:?}",
+            report.failures
+        );
     }
 
     #[test]
@@ -1685,7 +1757,7 @@ mod tests {
         let mut sb = full_scoreboard();
         sb.record_data(0, 0, Some(0), b"tttt", &ExtensionHeaders::new());
         sb.record_data(0, 1, Some(0), b"tt", &ExtensionHeaders::new());
-        sb.record_eog(0, 2, Some(0));
+        sb.record_eog(ObjectStatus::EndOfGroup, 0, 2, Some(0));
         sb.record_data(0, 1, Some(0), b"tt", &ExtensionHeaders::new()); // duplicate
         sb.record_data(0, 9, Some(0), b"tt", &ExtensionHeaders::new()); // unexpected
         let report = sb.finish(Some(&done(PublishDoneCode::TrackEnded as u64, 1)), false);
@@ -1698,7 +1770,7 @@ mod tests {
         let mut sb = full_scoreboard();
         sb.record_data(0, 0, Some(0), b"txtt", &ExtensionHeaders::new());
         sb.record_data(0, 1, Some(0), b"t", &ExtensionHeaders::new());
-        sb.record_eog(0, 2, Some(0));
+        sb.record_eog(ObjectStatus::EndOfGroup, 0, 2, Some(0));
         let report = sb.finish(Some(&done(PublishDoneCode::TrackEnded as u64, 1)), false);
         assert!(report.failures.iter().any(|f| f.contains("size")));
         assert!(report.failures.iter().any(|f| f.contains("corrupted")));
@@ -1772,7 +1844,7 @@ mod tests {
         let mut sb = full_scoreboard();
         sb.record_data(0, 0, Some(0), b"tttt", &ExtensionHeaders::new());
         sb.record_data(0, 1, Some(0), b"tt", &ExtensionHeaders::new());
-        sb.record_eog(0, 2, Some(0));
+        sb.record_eog(ObjectStatus::EndOfGroup, 0, 2, Some(0));
 
         let report = sb.finish(Some(&done(PublishDoneCode::TrackEnded as u64, 7)), false);
         assert!(report.failures.iter().any(|f| f.contains("stream count 7")));

--- a/moq-test-client/src/moqtest.rs
+++ b/moq-test-client/src/moqtest.rs
@@ -71,8 +71,8 @@ pub enum Forwarding {
     SubgroupPerGroup,
     /// 1: one subgroup stream per object, Subgroup ID == Object ID.
     SubgroupPerObject,
-    /// 2: two subgroup streams per group; even objects on Subgroup 0, odd on
-    /// Subgroup 1.
+    /// 2: two subgroup streams per group; objects alternate by offset from
+    /// start_object: `(object_id - start_object) % 2` is the Subgroup ID.
     TwoSubgroupsPerGroup,
     /// 3: one datagram per object.
     Datagram,

--- a/moq-test-client/src/moqtest.rs
+++ b/moq-test-client/src/moqtest.rs
@@ -51,8 +51,10 @@ const PRIORITY: u8 = 128;
 
 /// Rendezvous window requested on SUBSCRIBE so the relay holds the
 /// subscription pending until the publisher appears (subscribe-first
-/// choreography).
-const RENDEZVOUS_TIMEOUT_MS: u64 = 10_000;
+/// choreography). Deliberately half the outer TEST_TIMEOUT (10s): if a
+/// relay never binds the pair, the specific rendezvous TIMEOUT error
+/// surfaces before the generic scenario timeout masks it.
+const RENDEZVOUS_TIMEOUT_MS: u64 = 5_000;
 
 /// Worst-case datagram payload budget; larger datagram-mode objects are a
 /// test-declaration error.

--- a/moq-test-client/src/moqtest.rs
+++ b/moq-test-client/src/moqtest.rs
@@ -22,6 +22,26 @@
 //! - A data object's size is `size_object_zero` when `object_id ==
 //!   start_object`, otherwise `size_object_rest`.
 //! - Payload is the byte `b't'` repeated.
+//!
+//! ## Verification contract
+//!
+//! The scoreboard checks, per track: the exact `(group, object)` set with
+//! payload length and content; EOG markers iff configured, and only with
+//! `EndOfGroup` status; extension IDs and exact count on every data
+//! object; subgroup mapping and per-stream ordering (no cross-stream
+//! ordering); relay-transparent metadata (constant publisher priority on
+//! every subgroup and datagram; absence of the datagram end-of-group type
+//! bit); and the PUBLISH_DONE terminal signal (TRACK_ENDED status and the
+//! §10.11 Stream Count for the forwarding mode).
+//!
+//! Deliberately not checked: extension *values* (tuple fields 13/14
+//! specify random values, so presence, ID, and exact count are the
+//! contract) and cross-stream/cross-group ordering (MoQ multiplexing
+//! makes it non-deterministic; per-stream order is still asserted).
+//!
+//! FORWARD=0 scenarios invert the contract: no data plane at all — pass
+//! is setup completing, PUBLISH_DONE with Stream Count 0, and zero
+//! objects received.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::LazyLock;

--- a/moq-test-client/src/moqtest.rs
+++ b/moq-test-client/src/moqtest.rs
@@ -64,6 +64,11 @@ const MAX_DATAGRAM_PAYLOAD: usize = 1200;
 /// Generous test-scale limit; the datagram budget is much tighter.
 const MAX_OBJECT_SIZE: u64 = 16 * 1024 * 1024;
 
+/// Worst-case cumulative payload volume for a track. The per-object and
+/// object-count caps are independent, so without this a tuple like 1,000
+/// objects x 16 MiB still validates. Generous test-scale limit.
+const MAX_TOTAL_PAYLOAD: u128 = 256 * 1024 * 1024;
+
 /// moq-test forwarding preference (tuple field 1).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Forwarding {
@@ -280,6 +285,21 @@ impl MoqTestParams {
             );
         }
 
+        // With EOG markers, last_object must land on the object series:
+        // the generator marks the object whose ID equals last_object, and
+        // the scoreboard expects the marker there. A misaligned tuple
+        // (e.g. start 0, last 5, increment 2) would emit no marker at all
+        // and trip its own verifier. Without EOG a short series is
+        // self-consistent, so no alignment requirement applies.
+        if self.eog_markers && (self.last_object - self.start_object) % self.object_increment != 0 {
+            bail!(
+                "last object {} is unreachable from start object {} by increment {}; the EOG marker would never be generated",
+                self.last_object,
+                self.start_object,
+                self.object_increment
+            );
+        }
+
         let max_size = self.size_object_zero.max(self.size_object_rest);
         if max_size > MAX_OBJECT_SIZE {
             bail!("object size {max_size} exceeds the {MAX_OBJECT_SIZE} byte limit");
@@ -309,6 +329,17 @@ impl MoqTestParams {
         if total_objects > MAX_DATA_OBJECTS {
             bail!(
                 "track would carry {total_objects} objects, exceeding the {MAX_DATA_OBJECTS} object limit"
+            );
+        }
+
+        // Bound cumulative payload volume too: generation materializes
+        // every payload and the track buffers them until served, so
+        // per-object and per-track caps alone still permit e.g. 1,000 x
+        // 16 MiB.
+        let total_payload = total_objects * u128::from(max_size);
+        if total_payload > MAX_TOTAL_PAYLOAD {
+            bail!(
+                "track would carry {total_payload} bytes of payload, exceeding the {MAX_TOTAL_PAYLOAD} byte limit"
             );
         }
         Ok(())
@@ -667,6 +698,12 @@ fn write_object(
 async fn pace(params: &MoqTestParams) {
     if params.frequency_ms > 0 {
         sleep(Duration::from_millis(params.frequency_ms)).await;
+    } else {
+        // Zero frequency must still yield: every other call in the
+        // generation loop is synchronous, so without this the whole track
+        // is emitted in a single poll — Published::serve never drains it
+        // and the scenario timeout cannot fire.
+        tokio::task::yield_now().await;
     }
 }
 
@@ -972,8 +1009,14 @@ pub async fn verify(
         let mut report = scoreboard.finish(subscribe.publish_done().as_ref(), true);
         // If the relay forwarded data anyway, the session would already have
         // resolved the track mode; a resolved mode here is a failure. A
-        // no-data track leaves mode() pending or closed.
-        if let Ok(Ok(_mode)) = tokio::time::timeout(Duration::from_millis(10), track.mode()).await {
+        // no-data track leaves mode() pending or closed. Data and control
+        // travel on independent QUIC paths, so a violating stream could in
+        // theory arrive just after PUBLISH_DONE; sample well past the DONE
+        // rather than for a token instant. A violating relay forwards during
+        // generation (hundreds of ms of pacing), so in practice the mode has
+        // long resolved by this point.
+        if let Ok(Ok(_mode)) = tokio::time::timeout(Duration::from_millis(250), track.mode()).await
+        {
             report
                 .failures
                 .push("FORWARD=0 but the relay forwarded data".to_string());
@@ -1263,6 +1306,20 @@ async fn connect(
     Ok((session, connection_id, transport))
 }
 
+/// Aborts the spawned subscriber task if `run` exits without awaiting it
+/// (early publisher error, or the outer scenario timeout dropping the
+/// future). A bare `JoinHandle` detaches on drop, which would leave the
+/// subscriber session running for the rest of the process.
+struct AbortOnDrop<T>(tokio::task::JoinHandle<T>);
+
+impl<T> Drop for AbortOnDrop<T> {
+    fn drop(&mut self) {
+        // No-op if the task already finished (the happy path awaits it
+        // first).
+        self.0.abort();
+    }
+}
+
 /// Run a moq-test scenario with the subscribe-first choreography and return
 /// the verification report.
 pub async fn run(args: &Args, scenario: &Scenario) -> Result<(TestConnectionIds, Report)> {
@@ -1301,7 +1358,7 @@ pub async fn run(args: &Args, scenario: &Scenario) -> Result<(TestConnectionIds,
 
     let params = scenario.params.clone();
     let forward_zero = scenario.forward_zero;
-    let sub_handle = tokio::spawn(async move {
+    let mut sub_handle = AbortOnDrop(tokio::spawn(async move {
         let work = async move {
             let subscribe = subscriber
                 .subscribe_open_with_params(sub_writer, sub_params)
@@ -1317,7 +1374,7 @@ pub async fn run(args: &Args, scenario: &Scenario) -> Result<(TestConnectionIds,
                 Err(anyhow!("subscriber session ended before verification completed"))
             }
         }
-    });
+    }));
 
     // Give the subscriber a head start so the SUBSCRIBE genuinely arrives
     // first at the relay. This is a bias, not a guarantee: if the publisher
@@ -1381,7 +1438,7 @@ pub async fn run(args: &Args, scenario: &Scenario) -> Result<(TestConnectionIds,
         }
     }
 
-    let report = sub_handle
+    let report = (&mut sub_handle.0)
         .await
         .context("subscriber task panicked")?
         .context("subscriber verification failed")?;
@@ -1684,6 +1741,66 @@ mod tests {
             last_object: 4,
             objects_per_group: 5,
             size_object_zero: u64::MAX,
+            ..base()
+        }
+        .validate()
+        .is_err());
+    }
+
+    #[test]
+    fn eog_last_object_must_land_on_the_series() {
+        // Series 0,2,4 never reaches 5: no marker would be generated, and
+        // the verifier would fail against its own generator. Reject up
+        // front.
+        assert!(MoqTestParams {
+            last_object: 5,
+            objects_per_group: 3,
+            object_increment: 2,
+            eog_markers: true,
+            ..base()
+        }
+        .validate()
+        .is_err());
+        // Aligned: the marker lands at 4.
+        assert!(MoqTestParams {
+            last_object: 4,
+            objects_per_group: 3,
+            object_increment: 2,
+            eog_markers: true,
+            ..base()
+        }
+        .validate()
+        .is_ok());
+        // Without EOG a last_object off the series is self-consistent.
+        assert!(MoqTestParams {
+            last_object: 3,
+            objects_per_group: 3,
+            object_increment: 2,
+            ..base()
+        }
+        .validate()
+        .is_ok());
+    }
+
+    #[test]
+    fn total_payload_bound() {
+        // 10 objects x 16 MiB = 160 MiB: within the 256 MiB track budget.
+        assert!(MoqTestParams {
+            last_object: 9,
+            objects_per_group: 10,
+            size_object_zero: MAX_OBJECT_SIZE,
+            size_object_rest: MAX_OBJECT_SIZE,
+            ..base()
+        }
+        .validate()
+        .is_ok());
+        // 20 x 16 MiB = 320 MiB: each object is individually legal, but
+        // the cumulative volume is not.
+        assert!(MoqTestParams {
+            last_object: 19,
+            objects_per_group: 20,
+            size_object_zero: MAX_OBJECT_SIZE,
+            size_object_rest: MAX_OBJECT_SIZE,
             ..base()
         }
         .validate()

--- a/moq-test-client/src/scenarios.rs
+++ b/moq-test-client/src/scenarios.rs
@@ -24,7 +24,7 @@ use moq_transport::{
 use crate::Args;
 
 /// Overall test timeout - individual operations should complete faster
-const TEST_TIMEOUT: Duration = Duration::from_secs(10);
+pub(crate) const TEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Namespace used for test operations
 const TEST_NAMESPACE: &str = "moq-test/interop";
@@ -94,7 +94,7 @@ fn write_test_subgroup(track: TrackWriter, payload: &'static [u8]) -> Result<()>
 /// PUBLISH_DONE / TRACK_ENDED (draft-18 §10.11), which surfaces here as
 /// `Closed(0x2)`. Treating that as a failure would fail every test that
 /// subscribes to a finite track.
-fn is_normal_subscription_end(err: &ServeError) -> bool {
+pub(crate) fn is_normal_subscription_end(err: &ServeError) -> bool {
     match err {
         ServeError::Done | ServeError::Cancel => true,
         ServeError::Closed(code) => *code == PublishDoneCode::TrackEnded as u64,

--- a/moq-transport/src/serve/subgroup.rs
+++ b/moq-transport/src/serve/subgroup.rs
@@ -737,7 +737,13 @@ impl SubgroupWriter {
         )
     }
 
-    pub(crate) fn create_with_id_and_status(
+    /// Write an object with an explicit absolute Object ID and status.
+    ///
+    /// This is how End of Group / End of Track markers (draft-18 §10.2.1.1)
+    /// are published on a subgroup stream: a status other than
+    /// [`ObjectStatus::NormalObject`] requires `size == 0` and no extension
+    /// headers, matching the wire encoding.
+    pub fn create_with_id_and_status(
         &mut self,
         object_id: u64,
         size: usize,
@@ -1645,6 +1651,38 @@ mod tests {
             reader.next().await.unwrap().is_none(),
             "the stream ends cleanly after the final object"
         );
+    }
+
+    /// Status objects (EOG/EOT markers) carry no payload and no extensions;
+    /// the reader observes the status and an immediate end of the (empty) body.
+    #[tokio::test]
+    async fn status_object_delivers_status_with_empty_body() {
+        let (mut writer, mut reader) = subgroup();
+        let object = writer
+            .create_with_id_and_status(7, 0, ObjectStatus::EndOfGroup, None)
+            .unwrap();
+        drop(object);
+
+        let mut object = reader.next().await.unwrap().unwrap();
+        assert_eq!(object.info.object_id, 7);
+        assert_eq!(object.info.status, ObjectStatus::EndOfGroup);
+        assert_eq!(object.read_all().await.unwrap(), Bytes::new());
+    }
+
+    #[tokio::test]
+    async fn status_object_rejects_payload_or_extensions() {
+        let (mut writer, _reader) = subgroup();
+        assert!(matches!(
+            writer.create_with_id_and_status(0, 1, ObjectStatus::EndOfGroup, None),
+            Err(ServeError::Size)
+        ));
+
+        let mut extensions = crate::data::ExtensionHeaders::new();
+        extensions.set_intvalue(2, 42);
+        assert!(matches!(
+            writer.create_with_id_and_status(0, 0, ObjectStatus::EndOfTrack, Some(extensions)),
+            Err(ServeError::Size)
+        ));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Implements the moq-test protocol (draft-afrind-moq-test tuple format) in the test client, as a self-publishing test: the client derives a deterministic object set from a 16-field moq-test tuple, publishes it through the relay under test via direct PUBLISH, subscribes to the same track, and verifies that exactly the expected set arrives, with correct metadata and terminal signals. The relay needs no moq-test implementation; it sees an ordinary PUBLISH and SUBSCRIBE, and the scoreboard checks its relaying function rather than a relay-side generator.

Commit stack:

1. `feat(moq-transport)`: `SubgroupWriter::create_with_id_and_status` made public — End of Group / End of Track markers (draft-18 §10.2.1.1) were unpublishable on subgroup streams; datagrams already exposed status publicly, so the modes are now symmetric.
2. `feat(moq-test-client)`: the generator, scoreboard verifier, nine named TAP scenarios (`moq-test-*`), and an ad-hoc `--moq-test-tuple` flag.
3. Review follow-ups: AGENTS.md coverage of the harness; fallible built-in-scenario validation (no `panic!`); the scoreboard now requires `EndOfGroup` status for EOG markers; a 16 MiB object-size bound in `validate()`; doc-comment corrections.
4. Robustness follow-ups from external review: `validate()` rejects EOG tuples whose `last_object` is unreachable by the object increment (previously the verifier failed against the client's own generator); `validate()` also bounds cumulative payload volume (256 MiB) and `pace()` yields at zero frequency, so an ad-hoc tuple cannot synchronously out-allocate the process; the subscriber task aborts rather than detaches on early exit; the FORWARD=0 no-data window is widened; the rendezvous window sits below the outer scenario timeout so the specific error surfaces.
5. Metadata-coverage follow-up: the scoreboard now also checks relay-transparent metadata — publisher priority on every subgroup stream and datagram, and the datagram end-of-group type bit — so a relay that rewrites either fails verification.

## How

- Generation follows draft-afrind-moq-test tuple semantics, made precise: inclusive group/object ID series from start/last/increment fields, `size_object_zero` iff `object_id == start_object`, offset-parity subgroups in two-subgroup mode (`(object_id - start_object) % 2`), subgroup ID == object ID in subgroup-per-object mode, EOG status object in each group's final slot when enabled (status datagram in datagram mode), random per-object extensions per tuple fields 13/14.
- The verifier checks: exact `(group, object)` set with payload length/content; EOG markers iff configured, and only with `EndOfGroup` status; relay-transparent metadata (constant publisher priority on every subgroup and datagram; absence of the datagram end-of-group type bit); extension IDs and exact count on every data object; subgroup mapping and per-stream ordering (no cross-stream ordering); PUBLISH_DONE TRACK_ENDED status and §10.11 Stream Count (groups / objects / 2×groups / 0 by mode, or 0 for the FORWARD=0 choreography).
- Extension **values** are deliberately not verified: tuple fields 13/14 specify random values, so the contract is presence, ID, and exact count only.
- Track names are per-run unique tokens so relay caches cannot leak between runs.

## Behavior findings that shaped the design

- The serve API's datagram delivery is latest-value, not a queue: the publishing session itself reads the track through that reader, so generation must run concurrently with `Published::serve()` or only the final datagram survives (streams buffer and are unaffected).
- Datagrams sent before the relay binds the pending subscription have no forwarding path and are dropped, so the publisher gates on the subscriber's SUBSCRIBE_OK. Datagram scenarios pace at 20ms so every reader in the chain outpaces the writer.
- Status datagrams must not set the end-of-group type bit (the encoder rejects it); the EndOfGroup status conveys the marker.

## Verification

No GitHub checks run on this PR: `pr.yml` only triggers for `main`-targeted PRs, so verification for the draft-18-dev lane is the full local CI gate plus the GitLab mirror pipeline (build/test and AI code review — approved with zero findings), same as #233:

- Self-test against a local `moq-relay-ietf`: **all 18 scenarios (9 existing + 9 new) pass**, repeatedly across the review rounds.
- `cargo fmt --all`, `cargo clippy --workspace --all-targets --no-deps` (only pre-existing warnings in untouched files), `cargo build --workspace`, `cargo test --workspace` (all suites green), `cargo machete` — all clean.
- Unit tests cover tuple parsing/serialization/validation, series math, stream-count derivation, and scoreboard acceptance/rejection paths.
