### PR TITLE
feat(auth): add scope-configured CAT bearer authorization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024-2026 Cloudflare Inc., Luke Curley, Mike English and contributors
+SPDX-FileCopyrightText: 2026 Cloudflare Inc.
 SPDX-License-Identifier: MIT OR Apache-2.0
 -->
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,129 @@
+<!--
+SPDX-FileCopyrightText: 2024-2026 Cloudflare Inc., Luke Curley, Mike English and contributors
+SPDX-License-Identifier: MIT OR Apache-2.0
+-->
+
+# Working in this repository
+
+Media over QUIC Transport (MoQT) in Rust. Targets
+[draft-ietf-moq-transport-16](https://datatracker.ietf.org/doc/draft-ietf-moq-transport/16/).
+
+## CI must pass
+
+CI (`.github/workflows/pr.yml`) runs these at the **workspace root**. Run them
+before pushing; they are the whole gate.
+
+```sh
+cargo test --verbose      # every crate, default features
+cargo clippy --no-deps    # warnings are not denied, but keep it clean
+cargo fmt --check
+cargo machete             # unused dependencies
+```
+
+REUSE compliance is also checked: every new file needs an
+`SPDX-FileCopyrightText` and `SPDX-License-Identifier` header. Match the header
+on a neighbouring file in the same crate.
+
+Optional features are **not** covered by the default CI run. If you touch code
+behind one, test it explicitly:
+
+```sh
+cargo test -p moq-relay-ietf --features auth-cat
+cargo clippy --no-deps --all-targets -p moq-relay-ietf --features auth-cat
+```
+
+A feature-gated module still has to compile and behave correctly with the
+feature *off* — that is usually where the bugs are.
+
+## Workspace layout
+
+| Crate | Responsibility |
+|---|---|
+| `moq-transport` | The protocol. Wire encoding, control messages, session state machine, `serve` model. No policy, no I/O beyond the QUIC/WebTransport handle. |
+| `moq-relay-ietf` | The relay. Routing, caching, namespace/track registration, authorization. Both a library and the `moq-relay-ietf` binary. |
+| `moq-native-ietf` | QUIC/TLS setup shared by the native binaries (endpoints, certificates, ALPN). |
+| `moq-api` | HTTP API server for cluster-wide origin registration. |
+| `moq-pub` / `moq-sub` | Reference publisher and subscriber CLIs. |
+| `moq-clock-ietf` | Minimal publisher/subscriber used as a smoke test. |
+| `moq-catalog` | Catalog format types. |
+| `moq-test-client` | Interop test client. |
+
+Dependencies point one way: `moq-transport` knows nothing about the relay.
+Keep it that way — if the relay needs something from the transport, add an
+accessor rather than moving policy down.
+
+## Protocol references
+
+Cite the section, not just the document, when a decision follows from the spec.
+
+- **[draft-ietf-moq-transport-16](https://datatracker.ietf.org/doc/draft-ietf-moq-transport/16/)** —
+  the transport. Frequently needed: §9.2.2.1 (AUTHORIZATION TOKEN), §9.3.1
+  (setup parameters), §13.1 (auth token alias types), §13.4.1 (session
+  termination codes), §13.4.2 (REQUEST_ERROR codes).
+- **[draft-ietf-moq-c4m-01](https://datatracker.ietf.org/doc/draft-ietf-moq-c4m/)** —
+  Common Access Token authorization. §2 (the `moqt` claim and its matching
+  rules), §3.1.1 (DPoP), §7.1 (token type registry).
+- **RFC 9052 / 8392 / 8747** — COSE, CWT, and CWT proof-of-possession, for
+  anything touching token encoding.
+
+The drafts are the authority. Where this implementation knowingly diverges, the
+divergence is documented at the site — search for "Known gap".
+
+## Conventions
+
+**Comments explain why.** The what is in the code. A comment earns its place by
+recording a constraint, a spec requirement, or a decision someone would
+otherwise undo. Prefer citing a draft section over restating the line below.
+
+**Fail closed.** Anything on an authorization or admission path treats an error
+as a denial, never as a pass. `Result` in that code is not an escape hatch:
+`unwrap_or_default`, `.ok()` and a permissive `_ =>` arm are how these bugs get
+written.
+
+**Tests should fail when the behaviour breaks.** For a security control, check
+that: remove the control, confirm a test goes red, put it back. A test that
+still passes without the thing it is testing is worse than no test, because it
+implies coverage that does not exist.
+
+**Errors sent to a peer carry a code and a fixed phrase.** Diagnostic detail
+goes to logs. Never put validation internals, claim contents, or token bytes in
+a wire message — or in a `Debug` impl that might reach one.
+
+## Authorization
+
+Lives in `moq-relay-ietf/src/auth/`. Read `auth/mod.rs` first; it states the
+model and the fail-closed contract.
+
+Keys and policy come from the coordinator per scope
+(`Coordinator::get_scope_config`), never from CLI flags — a relay serves
+multiple tenants and rotates keys without restarting. A scope that returns no
+policy is unauthenticated by design and must keep working exactly as before.
+
+Enforcement points are `AuthHook::on_setup` (once, before either session half
+exists) and `AuthHook::on_request` (before SUBSCRIBE, SUBSCRIBE_NAMESPACE,
+TRACK_STATUS, PUBLISH_NAMESPACE, PUBLISH). Each runs *before* the corresponding
+lookup or registration; for SUBSCRIBE and TRACK_STATUS that ordering is a
+correctness property, since deciding afterwards turns them into existence
+oracles.
+
+Adding an enforcement point means adding an `AuthzOperation` variant, which is
+deliberately a compile error everywhere it must be handled.
+
+## Gotchas
+
+- `moq-transport`'s `Publisher`/`Subscriber` cannot be constructed outside that
+  crate, so relay code holding one is not unit-testable. Extract the decision
+  into a free function and test that.
+- `KeyValuePairs::get` returns only the first match. Parameters that may
+  legitimately repeat (AUTHORIZATION TOKEN, §9.2.2.1) must be read by iterating
+  `.0`.
+- `ReasonPhrase` is capped at 1024 bytes and *fails to encode* above it. An
+  encode failure on the control stream propagates out of `Session::run` and
+  ends the session, so it is not merely a lost message. Build one with
+  `ReasonPhrase::new`, which truncates on a character boundary; the tuple
+  constructor is only safe for string literals.
+- Dropping a request handle (`Subscribed`, `PublishedNamespace`,
+  `PublishReceived`) sends a rejection to the peer. Check the `Drop` impl
+  before assuming a code or reason reaches the wire.
+- `cargo fmt` reformats the whole workspace. Check `git diff --stat` and revert
+  unrelated churn before committing.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1673,6 +1673,7 @@ name = "moq-clock-ietf"
 version = "0.6.21"
 dependencies = [
  "anyhow",
+ "base64",
  "chrono",
  "clap",
  "moq-native-ietf",
@@ -1733,7 +1734,6 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
- "base64",
  "bytes",
  "cat-token",
  "ciborium",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,6 +72,12 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android-tzdata"
@@ -112,10 +153,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "async-trait"
@@ -243,10 +299,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bindgen"
@@ -278,6 +346,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,6 +371,35 @@ name = "bytes"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+
+[[package]]
+name = "cat-token"
+version = "0.4.3"
+source = "git+https://github.com/Quicr/cat-token?rev=df4905bad7ba24a2713746ed9907691eae7bc61b#df4905bad7ba24a2713746ed9907691eae7bc61b"
+dependencies = [
+ "aes-gcm",
+ "base64",
+ "chrono",
+ "ciborium",
+ "der",
+ "geohash",
+ "hex",
+ "hmac",
+ "lru",
+ "p256",
+ "regex",
+ "ring",
+ "rsa",
+ "serde",
+ "serde_cbor",
+ "serde_json",
+ "sfv 0.9.4",
+ "sha2",
+ "thiserror 1.0.61",
+ "uuid",
+ "x509-cert",
+ "zeroize",
+]
 
 [[package]]
 name = "cc"
@@ -347,6 +453,43 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half 2.7.1",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -430,6 +573,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,6 +605,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,6 +627,44 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "darling"
@@ -506,6 +702,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "der_derive",
+ "flagset",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -513,6 +739,18 @@ checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -528,10 +766,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "either"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "equivalent"
@@ -568,10 +840,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0399f9d26e5191ce32c498bebd31e7a3ceabc2745f0ac54af3f335126c3f24b3"
+
+[[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "fnv"
@@ -584,6 +872,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -706,6 +1000,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+dependencies = [
+ "typenum",
+ "version_check",
+ "zeroize",
+]
+
+[[package]]
+name = "geo-types"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94776032c45f950d30a13af6113c2ad5625316c9abfbccee4dd5a6695f8fe0f5"
+dependencies = [
+ "approx",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "geohash"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f58890382f70caccc5fa388981f7ac80c913795042afce9f3e065695d8f7464"
+dependencies = [
+ "geo-types",
+ "libm",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -733,6 +1059,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -743,6 +1079,17 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "h2"
@@ -764,6 +1111,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,7 +1139,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -783,6 +1147,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -795,6 +1164,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "home"
@@ -1013,6 +1391,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1087,6 +1474,9 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "lazycell"
@@ -1137,6 +1527,15 @@ name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+
+[[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
+]
 
 [[package]]
 name = "lru-slab"
@@ -1334,6 +1733,10 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
+ "base64",
+ "bytes",
+ "cat-token",
+ "ciborium",
  "clap",
  "fs2",
  "futures",
@@ -1344,6 +1747,8 @@ dependencies = [
  "moq-api",
  "moq-native-ietf",
  "moq-transport",
+ "p256",
+ "secrecy",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
@@ -1467,6 +1872,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1478,6 +1899,16 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
  "num-traits",
 ]
 
@@ -1500,6 +1931,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1518,6 +1950,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1528,6 +1966,18 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1557,6 +2007,15 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1597,6 +2056,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1622,6 +2114,15 @@ checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -1673,7 +2174,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.0.0",
  "rustls 0.23.31",
- "socket2 0.5.7",
+ "socket2 0.6.0",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -1714,7 +2215,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.7",
+ "socket2 0.6.0",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -1964,6 +2465,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1975,6 +2486,37 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sha2",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7653272e75dcac41dc199fbea6f5797633994fafd339943c06c9af16bf29cd3a"
+dependencies = [
+ "arrayvec",
+ "num-traits",
 ]
 
 [[package]]
@@ -2194,6 +2736,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2237,6 +2802,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half 1.8.3",
+ "serde",
 ]
 
 [[package]]
@@ -2329,6 +2904,17 @@ dependencies = [
 
 [[package]]
 name = "sfv"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27daf6ed3fc7ffd5ea3ce9f684fe351c47e50f2fdbb6236e2bad0b440dbe408"
+dependencies = [
+ "data-encoding",
+ "indexmap 2.13.0",
+ "rust_decimal",
+]
+
+[[package]]
+name = "sfv"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d471eaefb14f4b30032525bdb124b36e55ba9cb1292080e06f1a236cd10fe87"
@@ -2343,6 +2929,17 @@ name = "sha1_smol"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
 
 [[package]]
 name = "sharded-slab"
@@ -2366,6 +2963,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2416,6 +3023,22 @@ checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -2548,6 +3171,27 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tls_codec"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e78c9c330f8c85b2bae7c8368f2739157db9991235123aa1b15ef9502bfb6a"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d9ef545650e79f30233c0003bcc2504d7efac6dad25fca40744de773fe2049c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tokio"
@@ -2725,6 +3369,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2743,6 +3393,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
+]
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -2777,6 +3437,7 @@ checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
  "getrandom 0.3.3",
  "js-sys",
+ "serde",
  "wasm-bindgen",
 ]
 
@@ -2945,7 +3606,7 @@ checksum = "0225d295c8ac00a2e9a498aefeaf3f3c6186da12a251c938189b15b82ea22808"
 dependencies = [
  "bytes",
  "http",
- "sfv",
+ "sfv 0.14.0",
  "thiserror 2.0.17",
  "tokio",
  "url",
@@ -3322,6 +3983,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid",
+ "der",
+ "spki",
+ "tls_codec",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3346,3 +4019,17 @@ name = "zeroize"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/moq-clock-ietf/Cargo.toml
+++ b/moq-clock-ietf/Cargo.toml
@@ -28,6 +28,7 @@ tokio = { version = "1", features = ["full"] }
 
 # CLI, logging, error handling
 clap = { version = "4", features = ["derive"] }
+base64 = "0.22"
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 anyhow = { version = "1", features = ["backtrace"] }

--- a/moq-clock-ietf/src/cli.rs
+++ b/moq-clock-ietf/src/cli.rs
@@ -2,10 +2,43 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use clap::Parser;
-use std::net;
+use std::{net, str::FromStr};
 use url::Url;
 
-#[derive(Parser, Clone)]
+use base64::{engine::general_purpose, Engine};
+
+#[derive(Clone)]
+pub struct AuthorizationTokenArg {
+    pub token_type: u64,
+    pub value: Vec<u8>,
+}
+
+impl FromStr for AuthorizationTokenArg {
+    type Err = String;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let (token_type, value) = input
+            .split_once(':')
+            .ok_or_else(|| "expected TYPE:BASE64URL".to_string())?;
+        let token_type = if let Some(hex) = token_type.strip_prefix("0x") {
+            u64::from_str_radix(hex, 16)
+        } else {
+            token_type.parse()
+        }
+        .map_err(|_| "token type must be a decimal or 0x-prefixed integer".to_string())?;
+        if token_type > (1 << 62) - 1 {
+            return Err("token type exceeds the QUIC varint range".to_string());
+        }
+        let value = general_purpose::URL_SAFE_NO_PAD
+            .decode(value)
+            .or_else(|_| general_purpose::URL_SAFE.decode(value))
+            .map_err(|_| "token value must be base64url encoded".to_string())?;
+
+        Ok(Self { token_type, value })
+    }
+}
+
+#[derive(Parser)]
 pub struct Cli {
     /// Listen for UDP packets on the given address.
     #[arg(long, default_value = "[::]:0")]
@@ -39,4 +72,53 @@ pub struct Cli {
     /// Use datagrams instead of streams for the clock publisher.
     #[arg(long)]
     pub datagrams: bool,
+
+    /// Authorization token as TYPE:BASE64URL. May be repeated. Testing only:
+    /// the token is visible in the process arguments.
+    #[arg(long = "auth-token", value_name = "TYPE:BASE64URL")]
+    pub authorization_tokens: Vec<AuthorizationTokenArg>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_generic_authorization_tokens() {
+        let decimal: AuthorizationTokenArg = "1:AQI".parse().unwrap();
+        assert_eq!(decimal.token_type, 1);
+        assert_eq!(decimal.value, [1, 2]);
+
+        let hex: AuthorizationTokenArg = "0x63346d:c2VjcmV0".parse().unwrap();
+        assert_eq!(hex.token_type, 0x63346d);
+        assert_eq!(hex.value, b"secret");
+    }
+
+    #[test]
+    fn parses_repeated_authorization_token_flags() {
+        let cli = Cli::try_parse_from([
+            "moq-clock-ietf",
+            "https://example.com",
+            "--auth-token",
+            "1:AQI",
+            "--auth-token",
+            "0x40:AQI=",
+        ])
+        .unwrap();
+
+        assert_eq!(cli.authorization_tokens.len(), 2);
+        assert_eq!(cli.authorization_tokens[0].token_type, 1);
+        assert_eq!(cli.authorization_tokens[0].value, [1, 2]);
+        assert_eq!(cli.authorization_tokens[1].token_type, 0x40);
+        assert_eq!(cli.authorization_tokens[1].value, [1, 2]);
+    }
+
+    #[test]
+    fn rejects_malformed_authorization_tokens() {
+        assert!("1".parse::<AuthorizationTokenArg>().is_err());
+        assert!("1:not+base64".parse::<AuthorizationTokenArg>().is_err());
+        assert!("4611686018427387904:AQ"
+            .parse::<AuthorizationTokenArg>()
+            .is_err());
+    }
 }

--- a/moq-clock-ietf/src/main.rs
+++ b/moq-clock-ietf/src/main.rs
@@ -15,6 +15,7 @@ use moq_transport::{
     coding::TrackNamespace,
     serve,
     session::{Publisher, SessionId, Subscriber},
+    setup::AuthorizationToken,
 };
 
 /// The main entry point for the MoQ Clock IETF example.
@@ -33,7 +34,12 @@ async fn main() -> anyhow::Result<()> {
         )
         .init();
 
-    let config = Cli::parse();
+    let mut config = Cli::parse();
+    let authorization_tokens = std::mem::take(&mut config.authorization_tokens)
+        .into_iter()
+        .map(|token| AuthorizationToken::new(token.token_type, token.value))
+        .collect::<Result<Vec<_>, _>>()
+        .context("authorization token type exceeds the QUIC varint range")?;
     let tls = config.tls.load()?;
 
     // Create the QUIC endpoint
@@ -52,12 +58,11 @@ async fn main() -> anyhow::Result<()> {
     // Depending on whether we are publishing or subscribing, create the appropriate session
     if config.publish {
         // Create the publisher session
-        // TODO(itzmanish): When SessionId becomes mandatory in the next breaking API, make
-        // `connect` accept it and remove `connect_with_session_id`.
-        let (session, mut publisher) = Publisher::connect_with_session_id(
+        let (session, mut publisher) = Publisher::connect_with_session_id_and_tokens(
             session,
             SessionId::new(connection_id.clone()),
             transport,
+            authorization_tokens,
         )
         .await
         .context("failed to create MoQ Transport session")?;
@@ -97,12 +102,11 @@ async fn main() -> anyhow::Result<()> {
         }
     } else {
         // Create the subscriber session
-        // TODO(itzmanish): When SessionId becomes mandatory in the next breaking API, make
-        // `connect` accept it and remove `connect_with_session_id`.
-        let (session, mut subscriber) = Subscriber::connect_with_session_id(
+        let (session, mut subscriber) = Subscriber::connect_with_session_id_and_tokens(
             session,
             SessionId::new(connection_id.clone()),
             transport,
+            authorization_tokens,
         )
         .await
         .context("failed to create MoQ Transport session")?;

--- a/moq-relay-ietf/Cargo.toml
+++ b/moq-relay-ietf/Cargo.toml
@@ -27,6 +27,21 @@ moq-transport = { path = "../moq-transport", version = "0.16" }
 moq-native-ietf = { path = "../moq-native-ietf", version = "0.10" }
 moq-api = { path = "../moq-api", version = "0.2" }
 web-transport = { workspace = true }
+bytes = "1"
+
+# Bearer tokens are held in a type that zeroizes on drop and redacts under
+# Debug. Not optional: the enforcement points compile without `auth-cat`, so
+# the type that carries the credential has to as well.
+secrecy = "0.10"
+
+# Authorization: Common Access Tokens (draft-ietf-moq-c4m). Optional because
+# the token library pulls in a substantial cryptography tree that relays
+# without token authorization should not have to build or audit.
+cat-token = { git = "https://github.com/Quicr/cat-token", rev = "df4905bad7ba24a2713746ed9907691eae7bc61b", optional = true }
+# Reading the untrusted `kid` header to select a verification key. Both are
+# already in cat-token's own tree, so the feature adds no new crates.
+base64 = { version = "0.22", optional = true }
+ciborium = { version = "0.2", optional = true }
 
 # QUIC
 url = "2"
@@ -76,7 +91,14 @@ metrics-exporter-prometheus = { version = "0.16", optional = true }
 tokio = { version = "1", features = ["full", "test-util"] }
 # Used to assert that session correlation fields actually reach formatted output.
 tracing-subscriber = { workspace = true }
+# The CAT tests mint their own keypairs; cat-token can load a public key from
+# PEM but cannot export one, so the tests do that conversion themselves.
+p256 = { version = "0.13", features = ["ecdsa", "pem"] }
 
 [features]
 default = []
 metrics-prometheus = ["dep:metrics-exporter-prometheus"]
+# Common Access Token authorization (draft-ietf-moq-c4m). Off by default: the
+# trait, wire decoding and enforcement points are always compiled, so a relay
+# built without this still fails closed for any scope that requires tokens.
+auth-cat = ["dep:cat-token", "dep:base64", "dep:ciborium"]

--- a/moq-relay-ietf/Cargo.toml
+++ b/moq-relay-ietf/Cargo.toml
@@ -27,7 +27,6 @@ moq-transport = { path = "../moq-transport", version = "0.16" }
 moq-native-ietf = { path = "../moq-native-ietf", version = "0.10" }
 moq-api = { path = "../moq-api", version = "0.2" }
 web-transport = { workspace = true }
-bytes = "1"
 
 # Bearer tokens are held in a type that zeroizes on drop and redacts under
 # Debug. Not optional: the enforcement points compile without `auth-cat`, so
@@ -38,9 +37,8 @@ secrecy = "0.10"
 # the token library pulls in a substantial cryptography tree that relays
 # without token authorization should not have to build or audit.
 cat-token = { git = "https://github.com/Quicr/cat-token", rev = "df4905bad7ba24a2713746ed9907691eae7bc61b", optional = true }
-# Reading the untrusted `kid` header to select a verification key. Both are
-# already in cat-token's own tree, so the feature adds no new crates.
-base64 = { version = "0.22", optional = true }
+# Reading the untrusted `kid` header to select a verification key. Already in
+# cat-token's own tree, so the feature adds no new crates.
 ciborium = { version = "0.2", optional = true }
 
 # QUIC
@@ -86,6 +84,7 @@ metrics = "0.24"
 metrics-exporter-prometheus = { version = "0.16", optional = true }
 
 [dev-dependencies]
+bytes = "1"
 # test-util provides the paused-clock runtime used to test idle timeouts without
 # sleeping for real.
 tokio = { version = "1", features = ["full", "test-util"] }
@@ -101,4 +100,4 @@ metrics-prometheus = ["dep:metrics-exporter-prometheus"]
 # Common Access Token authorization (draft-ietf-moq-c4m). Off by default: the
 # trait, wire decoding and enforcement points are always compiled, so a relay
 # built without this still fails closed for any scope that requires tokens.
-auth-cat = ["dep:cat-token", "dep:base64", "dep:ciborium"]
+auth-cat = ["dep:cat-token", "dep:ciborium"]

--- a/moq-relay-ietf/src/auth/cat.rs
+++ b/moq-relay-ietf/src/auth/cat.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 Cloudflare Inc., Luke Curley, Mike English and contributors
+// SPDX-FileCopyrightText: 2026 Cloudflare Inc.
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 //! Common Access Token authorization (draft-ietf-moq-c4m).
@@ -32,7 +32,7 @@ use moq_transport::coding::{TrackNamespace, TrackNamespacePrefix};
 
 use super::{
     AuthDecision, AuthError, AuthHook, AuthRequest, AuthToken, AuthzOperation, DenyReason,
-    Principal, CAT_TOKEN_TYPE,
+    Principal, CAT_TOKEN_TYPE, UNSCOPED,
 };
 use crate::{
     AuthKeyAlgorithm, AuthPublicKey, ScopeAuthConfig, SessionContext, MAX_SCOPE_AUTH_KEYS,
@@ -150,7 +150,7 @@ impl CatAuthHook {
 
         // Duplicate identifiers would make key selection depend on ordering,
         // which turns a rotation into a coin flip.
-        let mut seen = Vec::new();
+        let mut seen = Vec::with_capacity(config.keys.len());
         for key in &config.keys {
             if let Some(kid) = &key.kid {
                 if seen.contains(&kid.as_str()) {
@@ -170,8 +170,7 @@ impl CatAuthHook {
             .collect::<Result<Vec<_>, _>>()?;
 
         // Clamped rather than trusted: a coordinator returning an enormous
-        // skew would otherwise keep expired tokens valid indefinitely, and
-        // would keep expired tokens valid indefinitely.
+        // skew would otherwise keep expired tokens valid indefinitely.
         let clock_skew =
             duration_to_seconds(config.effective_clock_skew()).min(MAX_CLOCK_SKEW_SECS);
 
@@ -193,7 +192,7 @@ impl CatAuthHook {
         let moqt_validator = MoqtValidator::new().without_revalidation_support();
 
         tracing::info!(
-            scope = scope.unwrap_or("<unscoped>"),
+            scope = scope.unwrap_or(UNSCOPED),
             keys = keys.len(),
             issuers = config.issuers.len(),
             audiences = config.audiences.len(),
@@ -243,7 +242,7 @@ impl CatAuthHook {
         for key in self.candidate_keys(kid.as_deref()) {
             if *budget == 0 {
                 tracing::debug!(
-                    scope = self.scope.as_deref().unwrap_or("<unscoped>"),
+                    scope = self.scope.as_deref().unwrap_or(UNSCOPED),
                     "exhausted the signature verification budget for this session"
                 );
                 return Err(DenyReason::TokenInvalid);
@@ -264,7 +263,7 @@ impl CatAuthHook {
             None => {
                 let err = best_error.unwrap_or(CatError::SignatureVerificationFailed);
                 tracing::debug!(
-                    scope = self.scope.as_deref().unwrap_or("<unscoped>"),
+                    scope = self.scope.as_deref().unwrap_or(UNSCOPED),
                     kid = kid.as_deref(),
                     error = %err,
                     "CAT token failed to verify against every configured key"
@@ -279,7 +278,7 @@ impl CatAuthHook {
         // leaked token to its lifetime.
         let Some(expires_at) = verified.claims().core.exp else {
             tracing::debug!(
-                scope = self.scope.as_deref().unwrap_or("<unscoped>"),
+                scope = self.scope.as_deref().unwrap_or(UNSCOPED),
                 subject = verified.claims().informational.sub.as_deref(),
                 "CAT token has no expiry"
             );
@@ -294,7 +293,7 @@ impl CatAuthHook {
 
         if expires_at > horizon {
             tracing::debug!(
-                scope = self.scope.as_deref().unwrap_or("<unscoped>"),
+                scope = self.scope.as_deref().unwrap_or(UNSCOPED),
                 subject = verified.claims().informational.sub.as_deref(),
                 "CAT token expiry is implausibly distant"
             );
@@ -304,9 +303,18 @@ impl CatAuthHook {
         if let Some(not_before) = verified.claims().core.nbf {
             if !(now.saturating_sub(MAX_TOKEN_LIFETIME_SECS)..=horizon).contains(&not_before) {
                 tracing::debug!(
-                    scope = self.scope.as_deref().unwrap_or("<unscoped>"),
+                    scope = self.scope.as_deref().unwrap_or(UNSCOPED),
                     subject = verified.claims().informational.sub.as_deref(),
                     "CAT token not-before is implausibly distant"
+                );
+                return Err(DenyReason::TokenInvalid);
+            }
+
+            if expires_at.saturating_sub(not_before) > MAX_TOKEN_LIFETIME_SECS {
+                tracing::debug!(
+                    scope = self.scope.as_deref().unwrap_or(UNSCOPED),
+                    subject = verified.claims().informational.sub.as_deref(),
+                    "CAT token lifetime exceeds the supported maximum"
                 );
                 return Err(DenyReason::TokenInvalid);
             }
@@ -316,7 +324,7 @@ impl CatAuthHook {
         // verified token into the validated trust state.
         if let Some(claim) = unenforceable_claim(token.expose_value()) {
             tracing::debug!(
-                scope = self.scope.as_deref().unwrap_or("<unscoped>"),
+                scope = self.scope.as_deref().unwrap_or(UNSCOPED),
                 subject = verified.claims().informational.sub.as_deref(),
                 claim,
                 "CAT token carries a restriction this relay cannot enforce"
@@ -329,7 +337,7 @@ impl CatAuthHook {
         // Standard CWT claims: exp, nbf, iss, aud, plus CAT extensions.
         let validated = verified.validate(&self.token_validator).map_err(|err| {
             tracing::debug!(
-                scope = self.scope.as_deref().unwrap_or("<unscoped>"),
+                scope = self.scope.as_deref().unwrap_or(UNSCOPED),
                 error = %err,
                 "CAT token claims rejected"
             );
@@ -341,7 +349,7 @@ impl CatAuthHook {
             .validate_moqt_claims(validated.claims())
             .map_err(|err| {
                 tracing::debug!(
-                    scope = self.scope.as_deref().unwrap_or("<unscoped>"),
+                    scope = self.scope.as_deref().unwrap_or(UNSCOPED),
                     subject = validated.claims().informational.sub.as_deref(),
                     error = %err,
                     "CAT token MOQT claims rejected"
@@ -393,7 +401,7 @@ impl CatAuthHook {
         // setup, so this check always applies.
         let Some(now) = try_now_unix() else {
             tracing::error!(
-                scope = self.scope.as_deref().unwrap_or("<unscoped>"),
+                scope = self.scope.as_deref().unwrap_or(UNSCOPED),
                 "system clock is before the UNIX epoch; cannot evaluate token expiry"
             );
             return AuthDecision::deny(DenyReason::HookFault {
@@ -403,7 +411,7 @@ impl CatAuthHook {
 
         if now > principal.expires_at.saturating_add(principal.clock_skew) {
             tracing::debug!(
-                scope = self.scope.as_deref().unwrap_or("<unscoped>"),
+                scope = self.scope.as_deref().unwrap_or(UNSCOPED),
                 subject = principal.token.informational.sub.as_deref(),
                 operation = operation.label(),
                 "CAT token expired mid-session"
@@ -416,7 +424,7 @@ impl CatAuthHook {
             AuthDecision::allow(established.clone())
         } else {
             tracing::debug!(
-                scope = self.scope.as_deref().unwrap_or("<unscoped>"),
+                scope = self.scope.as_deref().unwrap_or(UNSCOPED),
                 subject = principal.token.informational.sub.as_deref(),
                 operation = operation.label(),
                 "CAT authorization denied: operation outside token scope"
@@ -487,7 +495,7 @@ impl AuthHook for CatAuthHook {
 
         if candidates.peek().is_none() {
             tracing::debug!(
-                scope = session.scope().unwrap_or("<unscoped>"),
+                scope = session.scope().unwrap_or(UNSCOPED),
                 presented = tokens.len(),
                 "no CAT token in CLIENT_SETUP"
             );
@@ -523,7 +531,7 @@ impl AuthHook for CatAuthHook {
         // predicate, as the namespace-level actions are.
         if !scope_authorizes(&decoded, MoqtAction::ClientSetup, None, None) {
             tracing::debug!(
-                scope = session.scope().unwrap_or("<unscoped>"),
+                scope = session.scope().unwrap_or(UNSCOPED),
                 subject = decoded.informational.sub.as_deref(),
                 "CAT token does not authorize CLIENT_SETUP"
             );
@@ -531,7 +539,7 @@ impl AuthHook for CatAuthHook {
         }
 
         tracing::debug!(
-            scope = session.scope().unwrap_or("<unscoped>"),
+            scope = session.scope().unwrap_or(UNSCOPED),
             subject = decoded.informational.sub.as_deref(),
             "CAT token accepted"
         );
@@ -2401,6 +2409,38 @@ mod tests {
                 .unwrap();
             assert!(!decision.is_allowed(), "nbf {nbf} must be refused");
         }
+    }
+
+    #[tokio::test]
+    async fn a_past_not_before_is_valid_but_total_lifetime_is_bounded() {
+        let key = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(key.pem)]);
+        let now = now_unix();
+
+        let mut live = base_token();
+        live.core.nbf = Some(now - 3600);
+        live.core.exp = Some(now + 3600);
+        let encoded = Bytes::from(encode_token(&live, &key.signer).unwrap());
+        assert!(hook
+            .on_setup(&session(), &[auth_token(encoded)])
+            .await
+            .unwrap()
+            .is_allowed());
+
+        let mut token = base_token();
+        token.core.nbf = Some(now - MAX_TOKEN_LIFETIME_SECS + 60);
+        token.core.exp = Some(now + MAX_TOKEN_LIFETIME_SECS - 60);
+
+        let encoded = Bytes::from(encode_token(&token, &key.signer).unwrap());
+        let decision = hook
+            .on_setup(&session(), &[auth_token(encoded)])
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            decision.deny_reason(),
+            Some(DenyReason::TokenInvalid)
+        ));
     }
 
     /// Admission cost must not scale with what the peer chooses to send.

--- a/moq-relay-ietf/src/auth/cat.rs
+++ b/moq-relay-ietf/src/auth/cat.rs
@@ -1,0 +1,2867 @@
+// SPDX-FileCopyrightText: 2024-2026 Cloudflare Inc., Luke Curley, Mike English and contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Common Access Token authorization (draft-ietf-moq-c4m).
+//!
+//! Verification happens once, at session setup: the decoded token is carried
+//! in the session's [`Principal`], and per-request authorization is a pure
+//! claims check with no cryptography. That keeps SUBSCRIBE off the signature
+//! path while still re-checking expiry on every request.
+//!
+//! # What this hook enforces
+//!
+//! The signature, `exp`, `nbf`, `iss`, `aud`, and the `moqt` claim's actions,
+//! namespace matches and track match. A token is required to carry `exp`, and
+//! its lifetime is capped, because the relay has no revocation mechanism.
+//!
+//! Any *other* claim causes the token to be **refused**: honouring a token
+//! while ignoring a constraint its issuer attached would grant more than was
+//! authorized. The check is an allowlist over the claim keys present in the
+//! raw payload, not a walk over the decoded token — see
+//! [`unenforceable_claim`] for why that distinction is load-bearing.
+//!
+//! Composite claims (`and` / `or` / `nor`) are refused by the same rule.
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use async_trait::async_trait;
+use cat_token::{
+    decode_token, CatError, CatToken, CatTokenValidator, Es256Algorithm, MoqtAction, MoqtValidator,
+};
+use moq_transport::coding::{TrackNamespace, TrackNamespacePrefix};
+
+use super::{
+    AuthDecision, AuthError, AuthHook, AuthRequest, AuthToken, AuthzOperation, DenyReason,
+    Principal, CAT_TOKEN_TYPE,
+};
+use crate::{
+    AuthKeyAlgorithm, AuthPublicKey, ScopeAuthConfig, SessionContext, MAX_SCOPE_AUTH_KEYS,
+};
+
+/// Longest token lifetime the relay will honour.
+///
+/// Caps how long a leaked token stays usable, and keeps `exp` far enough from
+/// `i64::MAX` that adding a skew tolerance to it cannot overflow.
+const MAX_TOKEN_LIFETIME_SECS: i64 = 7 * 24 * 60 * 60;
+
+/// Largest clock skew tolerance the relay will honour, whatever a scope asks
+/// for. Bounds both how far an expired token remains usable and the magnitude
+/// of the `exp + skew` arithmetic.
+const MAX_CLOCK_SKEW_SECS: i64 = 300;
+
+/// Signature verifications a single CLIENT_SETUP may cost.
+///
+/// Verification is the expensive part of admission and it runs inline on the
+/// accepting task, while both multipliers — how many tokens are presented and,
+/// by choosing a `kid` that matches nothing, how many keys each is tried
+/// against — are peer-controlled. Bounding the product rather than either
+/// factor keeps the cost of an unauthenticated connection attempt flat as a
+/// scope adds keys.
+///
+/// An ECDSA P-256 verification costs roughly 0.4 ms, so this bounds admission
+/// at about 5 ms of CPU however the peer arranges its tokens — against the
+/// 17 ms an unbounded [`MAX_SETUP_TOKENS`]-by-[`MAX_SCOPE_AUTH_KEYS`] fan-out
+/// would allow.
+///
+/// Sized above the honest worst case rather than as tight as possible: a
+/// client presenting two tokens to a scope mid-rotation, with neither carrying
+/// a `kid`, needs ten. Denying that would be a silent, hard-to-diagnose
+/// failure, and the CPU saved by refusing it is not worth much.
+///
+/// This, not [`MAX_SETUP_TOKENS`], is the operative limit on how many tokens
+/// are usable: with a full key set and no `kid` to narrow the search, roughly
+/// two are reachable before the budget runs out, even though four are decoded.
+/// A `kid` that matches costs one verification per token, so a client whose
+/// issuer labels its tokens is unaffected.
+///
+/// [`MAX_SETUP_TOKENS`]: super::MAX_SETUP_TOKENS
+const MAX_SETUP_VERIFICATIONS: usize = 12;
+
+// The budget only means something if it binds before the per-factor limits do.
+const _: () = assert!(
+    MAX_SETUP_VERIFICATIONS < super::MAX_SETUP_TOKENS * MAX_SCOPE_AUTH_KEYS,
+    "the verification budget must bind before tokens x keys does"
+);
+
+/// Authorizes sessions and requests against Common Access Tokens.
+pub struct CatAuthHook {
+    /// Verification keys in the order the scope configured them, so a rotation
+    /// overlap costs one verification for the common case.
+    keys: Vec<CatKey>,
+
+    /// Validates `exp`, `nbf`, `iss`, `aud` and the CAT-specific claims.
+    token_validator: CatTokenValidator,
+
+    /// Validates and evaluates the `moqt` claim.
+    moqt_validator: MoqtValidator,
+
+    /// Clock skew tolerance, mirrored here for the per-request expiry re-check.
+    clock_skew: i64,
+
+    /// Scope identity, for logging only.
+    scope: Option<String>,
+}
+
+/// One configured verification key.
+///
+/// The token's own `alg` header is checked against the key by
+/// `decode_token` before any signature work, so the key's algorithm does
+/// not need to be tracked separately while ES256 is the only variant.
+struct CatKey {
+    kid: Option<String>,
+    verifier: Es256Algorithm,
+}
+
+/// Session state established at setup and carried in the [`Principal`].
+///
+/// [`Principal`] already stores this behind an `Arc`, so the decoded token is
+/// shared by every request on the session without a second layer of
+/// indirection.
+struct CatPrincipal {
+    token: CatToken,
+
+    /// `exp` snapshot, so the per-request freshness check is an integer
+    /// comparison rather than a re-parse of the token.
+    expires_at: i64,
+
+    clock_skew: i64,
+}
+
+impl CatAuthHook {
+    /// Build a hook from a scope's authorization configuration.
+    ///
+    /// Fails rather than returning a partially usable hook: a scope whose key
+    /// material is wrong must fail closed as a whole, so that a typo in one
+    /// key of a rotating set cannot silently degrade into a working
+    /// single-key configuration.
+    pub fn new(config: &ScopeAuthConfig, scope: Option<&str>) -> Result<Self, AuthError> {
+        if config.keys.is_empty() {
+            return Err(AuthError::Configuration(
+                "no public keys configured".to_string(),
+            ));
+        }
+
+        if config.keys.len() > MAX_SCOPE_AUTH_KEYS {
+            return Err(AuthError::Configuration(format!(
+                "{} public keys configured, at most {MAX_SCOPE_AUTH_KEYS} are allowed",
+                config.keys.len()
+            )));
+        }
+
+        // Duplicate identifiers would make key selection depend on ordering,
+        // which turns a rotation into a coin flip.
+        let mut seen = Vec::new();
+        for key in &config.keys {
+            if let Some(kid) = &key.kid {
+                if seen.contains(&kid.as_str()) {
+                    return Err(AuthError::Configuration(format!(
+                        "duplicate key identifier {kid:?}"
+                    )));
+                }
+                seen.push(kid.as_str());
+            }
+        }
+
+        let keys = config
+            .keys
+            .iter()
+            .enumerate()
+            .map(|(index, key)| CatKey::build(index, key))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        // Clamped rather than trusted: a coordinator returning an enormous
+        // skew would otherwise keep expired tokens valid indefinitely, and
+        // would keep expired tokens valid indefinitely.
+        let clock_skew =
+            duration_to_seconds(config.effective_clock_skew()).min(MAX_CLOCK_SKEW_SECS);
+
+        let mut token_validator = CatTokenValidator::new()
+            .with_clock_skew_tolerance(clock_skew)
+            .map_err(|err| AuthError::Configuration(err.to_string()))?
+            .allow_unencrypted_privacy_claims();
+        if !config.issuers.is_empty() {
+            token_validator = token_validator.with_expected_issuers(config.issuers.clone());
+        }
+        if !config.audiences.is_empty() {
+            token_validator = token_validator.with_expected_audiences(config.audiences.clone());
+        }
+
+        // draft-ietf-moq-c4m: "If a recipient is unable to revalidate tokens,
+        // it MUST reject all tokens with a 'moqt-reval' claim." This relay does
+        // not revalidate mid-session, so saying so makes `validate_moqt_claims`
+        // reject such tokens instead of silently ignoring the requirement.
+        let moqt_validator = MoqtValidator::new().without_revalidation_support();
+
+        tracing::info!(
+            scope = scope.unwrap_or("<unscoped>"),
+            keys = keys.len(),
+            issuers = config.issuers.len(),
+            audiences = config.audiences.len(),
+            clock_skew_secs = clock_skew,
+            "CAT token authorization enabled"
+        );
+
+        Ok(Self {
+            keys,
+            token_validator,
+            moqt_validator,
+            clock_skew,
+            scope: scope.map(str::to_string),
+        })
+    }
+
+    /// Verify a token against the configured keys and validate its claims.
+    ///
+    /// `budget` is the number of signature verifications still available for
+    /// this CLIENT_SETUP; it is decremented as keys are tried. Exhausting it
+    /// denies, so a peer cannot make admission arbitrarily expensive.
+    ///
+    /// Returns the decoded token together with its expiry, which is required
+    /// and therefore known to be present once this succeeds.
+    fn verify(&self, token: &AuthToken, budget: &mut usize) -> Result<(CatToken, i64), DenyReason> {
+        if token.expose_value().is_empty() {
+            return Err(DenyReason::TokenMalformed);
+        }
+
+        // This relay does not implement any application-defined COSE header
+        // extensions. Accepting `crit` would claim otherwise and could ignore
+        // a restriction required by the issuer.
+        if has_critical_header(token.expose_value()) {
+            return Err(DenyReason::TokenInvalid);
+        }
+
+        // The `kid` header, when present and matchable, narrows which keys are
+        // worth trying. It is only a hint; see `header_kid`.
+        let kid = header_kid(token.expose_value());
+
+        // Try each key in turn. `decode_token` compares the header's
+        // `alg` before verifying, so a key of the wrong algorithm costs no
+        // signature operation.
+        let mut best_error: Option<CatError> = None;
+        let mut decoded = None;
+
+        for key in self.candidate_keys(kid.as_deref()) {
+            if *budget == 0 {
+                tracing::debug!(
+                    scope = self.scope.as_deref().unwrap_or("<unscoped>"),
+                    "exhausted the signature verification budget for this session"
+                );
+                return Err(DenyReason::TokenInvalid);
+            }
+            *budget -= 1;
+
+            match decode_token(token.expose_value(), &key.verifier) {
+                Ok(token) => {
+                    decoded = Some(token);
+                    break;
+                }
+                Err(err) => best_error = Some(more_informative(best_error, err)),
+            }
+        }
+
+        let verified = match decoded {
+            Some(token) => token,
+            None => {
+                let err = best_error.unwrap_or(CatError::SignatureVerificationFailed);
+                tracing::debug!(
+                    scope = self.scope.as_deref().unwrap_or("<unscoped>"),
+                    kid = kid.as_deref(),
+                    error = %err,
+                    "CAT token failed to verify against every configured key"
+                );
+                return Err(map_cat_error(err));
+            }
+        };
+
+        // A bearer credential with no expiry is unrevokable: this relay has no
+        // revocation list, and rotating a key only affects sessions
+        // established afterwards. Requiring `exp` bounds the damage from a
+        // leaked token to its lifetime.
+        let Some(expires_at) = verified.claims().core.exp else {
+            tracing::debug!(
+                scope = self.scope.as_deref().unwrap_or("<unscoped>"),
+                subject = verified.claims().informational.sub.as_deref(),
+                "CAT token has no expiry"
+            );
+            return Err(DenyReason::TokenInvalid);
+        };
+
+        // Keep both timestamps inside the relay's supported lifetime horizon.
+        // Bounding `exp` also serves the rule above: an expiry decades away is
+        // the unbounded credential this check exists to prevent.
+        let now = now_unix();
+        let horizon = now.saturating_add(MAX_TOKEN_LIFETIME_SECS);
+
+        if expires_at > horizon {
+            tracing::debug!(
+                scope = self.scope.as_deref().unwrap_or("<unscoped>"),
+                subject = verified.claims().informational.sub.as_deref(),
+                "CAT token expiry is implausibly distant"
+            );
+            return Err(DenyReason::TokenInvalid);
+        }
+
+        if let Some(not_before) = verified.claims().core.nbf {
+            if !(now.saturating_sub(MAX_TOKEN_LIFETIME_SECS)..=horizon).contains(&not_before) {
+                tracing::debug!(
+                    scope = self.scope.as_deref().unwrap_or("<unscoped>"),
+                    subject = verified.claims().informational.sub.as_deref(),
+                    "CAT token not-before is implausibly distant"
+                );
+                return Err(DenyReason::TokenInvalid);
+            }
+        }
+
+        // Reject constraints this relay cannot evaluate before consuming the
+        // verified token into the validated trust state.
+        if let Some(claim) = unenforceable_claim(token.expose_value()) {
+            tracing::debug!(
+                scope = self.scope.as_deref().unwrap_or("<unscoped>"),
+                subject = verified.claims().informational.sub.as_deref(),
+                claim,
+                "CAT token carries a restriction this relay cannot enforce"
+            );
+            return Err(DenyReason::PolicyDenied {
+                message: format!("unenforceable claim: {claim}"),
+            });
+        }
+
+        // Standard CWT claims: exp, nbf, iss, aud, plus CAT extensions.
+        let validated = verified.validate(&self.token_validator).map_err(|err| {
+            tracing::debug!(
+                scope = self.scope.as_deref().unwrap_or("<unscoped>"),
+                error = %err,
+                "CAT token claims rejected"
+            );
+            map_cat_error(err)
+        })?;
+
+        // MOQT claim well-formedness, including the revalidation contract.
+        self.moqt_validator
+            .validate_moqt_claims(validated.claims())
+            .map_err(|err| {
+                tracing::debug!(
+                    scope = self.scope.as_deref().unwrap_or("<unscoped>"),
+                    subject = validated.claims().informational.sub.as_deref(),
+                    error = %err,
+                    "CAT token MOQT claims rejected"
+                );
+                map_cat_error(err)
+            })?;
+
+        Ok((validated.into_inner(), expires_at))
+    }
+
+    /// The configured keys, ordered by how likely each is to verify a token
+    /// bearing `kid`.
+    ///
+    /// `kid` only reorders; it never excludes. The signature is the sole
+    /// authority on whether a token is authentic, and the identifier that
+    /// selects a key is unauthenticated, so treating a mismatch as grounds for
+    /// rejection would let an attacker-controlled label decide the outcome —
+    /// and would turn an issuer relabelling its tokens, or a typo in one
+    /// configured identifier, into an outage. At most
+    /// [`MAX_SCOPE_AUTH_KEYS`] verifications are involved, once per session,
+    /// so exhausting the list costs little.
+    fn candidate_keys(&self, kid: Option<&str>) -> Vec<&CatKey> {
+        match kid {
+            Some(kid) => {
+                let (named, rest): (Vec<_>, Vec<_>) = self
+                    .keys
+                    .iter()
+                    .partition(|key| key.kid.as_deref() == Some(kid));
+                named.into_iter().chain(rest).collect()
+            }
+            None => self.keys.iter().collect(),
+        }
+    }
+
+    /// Evaluate the `moqt` claim for one operation.
+    ///
+    /// `established` is the caller's existing [`Principal`]; on an allow it is
+    /// handed back as-is. Rebuilding one here would deep-clone the whole
+    /// decoded token on every authorized request, which is both the hot path
+    /// and peer-influenced in size, to produce a value the caller discards.
+    fn authorize(
+        &self,
+        established: &Principal,
+        principal: &CatPrincipal,
+        operation: &AuthzOperation<'_>,
+    ) -> AuthDecision {
+        // A session outliving its token must stop being authorized, even
+        // though no fresh signature check happens here. `exp` is required at
+        // setup, so this check always applies.
+        let Some(now) = try_now_unix() else {
+            tracing::error!(
+                scope = self.scope.as_deref().unwrap_or("<unscoped>"),
+                "system clock is before the UNIX epoch; cannot evaluate token expiry"
+            );
+            return AuthDecision::deny(DenyReason::HookFault {
+                message: "clock unavailable".to_string(),
+            });
+        };
+
+        if now > principal.expires_at.saturating_add(principal.clock_skew) {
+            tracing::debug!(
+                scope = self.scope.as_deref().unwrap_or("<unscoped>"),
+                subject = principal.token.informational.sub.as_deref(),
+                operation = operation.label(),
+                "CAT token expired mid-session"
+            );
+            return AuthDecision::deny(DenyReason::TokenExpired);
+        }
+
+        let (action, namespace, track) = map_operation(operation);
+        if scope_authorizes(&principal.token, action, Some(&namespace), track.as_deref()) {
+            AuthDecision::allow(established.clone())
+        } else {
+            tracing::debug!(
+                scope = self.scope.as_deref().unwrap_or("<unscoped>"),
+                subject = principal.token.informational.sub.as_deref(),
+                operation = operation.label(),
+                "CAT authorization denied: operation outside token scope"
+            );
+            AuthDecision::deny(DenyReason::ScopeMismatch)
+        }
+    }
+}
+
+impl std::fmt::Debug for CatAuthHook {
+    /// Reports the shape of the configuration without its key material.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CatAuthHook")
+            .field("scope", &self.scope)
+            .field("keys", &self.keys.len())
+            .field(
+                "kids",
+                &self
+                    .keys
+                    .iter()
+                    .map(|key| key.kid.as_deref().unwrap_or("<none>"))
+                    .collect::<Vec<_>>(),
+            )
+            .field("clock_skew_secs", &self.clock_skew)
+            .finish_non_exhaustive()
+    }
+}
+
+impl CatKey {
+    fn build(index: usize, key: &AuthPublicKey) -> Result<Self, AuthError> {
+        let verifier = match key.algorithm {
+            AuthKeyAlgorithm::Es256 => {
+                Es256Algorithm::from_public_key_pem(&key.pem).map_err(|err| {
+                    // The PEM itself is never echoed into the error: it is
+                    // public material, but putting configuration into messages
+                    // that reach logs is a habit worth not forming.
+                    AuthError::Configuration(format!(
+                        "key {index} ({}) is not a valid ES256 public key: {err}",
+                        key.kid.as_deref().unwrap_or("no kid")
+                    ))
+                })?
+            }
+        };
+
+        Ok(Self {
+            kid: key.kid.clone(),
+            verifier,
+        })
+    }
+}
+
+#[async_trait]
+impl AuthHook for CatAuthHook {
+    async fn on_setup(
+        &self,
+        session: &SessionContext,
+        tokens: &[AuthToken],
+    ) -> Result<AuthDecision, AuthError> {
+        // §9.3.1.5 lets a peer present more than one token, and §9.2.2.1 lets
+        // the parameter repeat. Accept the first that satisfies this scope
+        // rather than only the first that is CAT-typed: a client mid-rotation,
+        // or one holding tokens for several relays, legitimately sends
+        // several, and only some will be usable here.
+        let mut candidates = tokens
+            .iter()
+            .filter(|token| token.token_type == CAT_TOKEN_TYPE)
+            .peekable();
+
+        if candidates.peek().is_none() {
+            tracing::debug!(
+                scope = session.scope().unwrap_or("<unscoped>"),
+                presented = tokens.len(),
+                "no CAT token in CLIENT_SETUP"
+            );
+            return Ok(AuthDecision::deny(DenyReason::TokenMissing));
+        }
+
+        let mut budget = MAX_SETUP_VERIFICATIONS;
+        let mut denial: Option<DenyReason> = None;
+        let mut verified = None;
+        for token in candidates {
+            match self.verify(token, &mut budget) {
+                Ok(result) => {
+                    verified = Some(result);
+                    break;
+                }
+                // Keep the most specific reason across tokens, for the same
+                // reason `more_informative` does across keys: which token the
+                // peer happened to list last should not decide what is
+                // reported.
+                Err(reason) => denial = Some(more_specific_denial(denial, reason)),
+            }
+        }
+
+        let Some((decoded, expires_at)) = verified else {
+            return Ok(AuthDecision::deny(
+                denial.unwrap_or(DenyReason::TokenInvalid),
+            ));
+        };
+
+        // Session establishment is itself an authorized action: a token that
+        // grants no CLIENT_SETUP scope must not open a session. CLIENT_SETUP
+        // carries no Track Name, so it is evaluated without the track
+        // predicate, as the namespace-level actions are.
+        if !scope_authorizes(&decoded, MoqtAction::ClientSetup, None, None) {
+            tracing::debug!(
+                scope = session.scope().unwrap_or("<unscoped>"),
+                subject = decoded.informational.sub.as_deref(),
+                "CAT token does not authorize CLIENT_SETUP"
+            );
+            return Ok(AuthDecision::deny(DenyReason::ScopeMismatch));
+        }
+
+        tracing::debug!(
+            scope = session.scope().unwrap_or("<unscoped>"),
+            subject = decoded.informational.sub.as_deref(),
+            "CAT token accepted"
+        );
+
+        Ok(AuthDecision::allow(principal_from(
+            decoded,
+            expires_at,
+            self.clock_skew,
+        )))
+    }
+
+    async fn on_request(&self, request: &AuthRequest<'_>) -> Result<AuthDecision, AuthError> {
+        let Some(principal) = request.principal.claims::<CatPrincipal>() else {
+            // Only reachable if a principal from a different hook were routed
+            // here, which the per-scope hook lifetime prevents. Fail closed and
+            // surface it as a fault rather than a denial.
+            return Err(AuthError::Backend(
+                "session principal was not established by the CAT hook".to_string(),
+            ));
+        };
+
+        Ok(self.authorize(request.principal, principal, &request.operation))
+    }
+}
+
+/// Build the [`Principal`] carried for the session.
+fn principal_from(token: CatToken, expires_at: i64, clock_skew: i64) -> Principal {
+    Principal::new(
+        token.informational.sub.clone(),
+        CatPrincipal {
+            token,
+            expires_at,
+            clock_skew,
+        },
+    )
+}
+
+/// Map a relay operation onto the MOQT action triple the `moqt` claim is
+/// evaluated against.
+///
+/// Total by construction: [`AuthzOperation`] has one variant per live
+/// authorization point, so adding a variant is a compile error here rather
+/// than a silent denial at runtime.
+fn map_operation(operation: &AuthzOperation<'_>) -> (MoqtAction, Vec<Vec<u8>>, Option<Vec<u8>>) {
+    match operation {
+        AuthzOperation::PublishNamespace { namespace } => (
+            MoqtAction::PublishNamespace,
+            namespace_tuple(namespace),
+            None,
+        ),
+        AuthzOperation::Publish { namespace, track } => (
+            MoqtAction::Publish,
+            namespace_tuple(namespace),
+            Some(track.as_bytes().to_vec()),
+        ),
+        AuthzOperation::Subscribe { namespace, track } => (
+            MoqtAction::Subscribe,
+            namespace_tuple(namespace),
+            Some(track.as_bytes().to_vec()),
+        ),
+        AuthzOperation::SubscribeNamespace { prefix } => {
+            (MoqtAction::SubscribeNamespace, prefix_tuple(prefix), None)
+        }
+        AuthzOperation::TrackStatus { namespace, track } => (
+            MoqtAction::TrackStatus,
+            namespace_tuple(namespace),
+            Some(track.as_bytes().to_vec()),
+        ),
+    }
+}
+
+fn scope_authorizes(
+    token: &CatToken,
+    action: MoqtAction,
+    namespace: Option<&[Vec<u8>]>,
+    track: Option<&[u8]>,
+) -> bool {
+    token.moqt.moqt.as_ref().is_some_and(|scopes| {
+        scopes.iter().any(|scope| {
+            scope.allows_action(&action)
+                && namespace.is_none_or(|namespace| scope.matches_namespace(namespace))
+                && track.is_none_or(|track| scope.matches_track(track))
+        })
+    })
+}
+
+fn namespace_tuple(namespace: &TrackNamespace) -> Vec<Vec<u8>> {
+    namespace
+        .fields
+        .iter()
+        .map(|field| field.value.clone())
+        .collect()
+}
+
+fn prefix_tuple(prefix: &TrackNamespacePrefix) -> Vec<Vec<u8>> {
+    prefix
+        .fields
+        .iter()
+        .map(|field| field.value.clone())
+        .collect()
+}
+
+/// Read the `kid` from a token's protected header without verifying it.
+///
+/// This is a **hint only**. It narrows which keys are worth trying; the
+/// signature check that follows is what establishes trust. Nothing here may
+/// deny: the header is attacker-controlled at this point, so letting it
+/// produce a verdict would hand the peer a say in its own authorization.
+///
+/// Every unusable shape therefore degrades to `None`, meaning "no hint, try
+/// every key", and the token is judged solely on its signature. That includes
+/// a `kid` that is not valid UTF-8 — RFC 8152 §3.1 types `kid` as `bstr` and
+/// thumbprint-style identifiers are routinely non-textual, while
+/// [`AuthPublicKey::kid`] is operator-facing text. Such a token simply has no
+/// identifier this relay can match, which is not grounds for rejection.
+///
+/// Degrading is also cheap: `decode_token` reads `alg` from the same header
+/// and fails before performing any signature operation, so a garbage header
+/// costs a few CBOR parses rather than a set of ECDSA verifications.
+///
+/// [`AuthPublicKey::kid`]: crate::AuthPublicKey::kid
+fn header_kid(token: &[u8]) -> Option<String> {
+    let (header, _) = cose_parts(token)?;
+    let value: ciborium::Value = ciborium::de::from_reader(header.as_slice()).ok()?;
+
+    let ciborium::Value::Map(entries) = value else {
+        return None;
+    };
+
+    entries.into_iter().find_map(|(label, value)| {
+        // COSE header label 4 is `kid` (RFC 8152 §3.1).
+        let ciborium::Value::Integer(label) = label else {
+            return None;
+        };
+        if i64::try_from(label) != Ok(4) {
+            return None;
+        }
+
+        match value {
+            // cat-token encodes `kid` as a text string.
+            ciborium::Value::Text(kid) => Some(kid),
+            // COSE defines it as a byte string. Matchable only when it happens
+            // to be text, since configured identifiers are text.
+            ciborium::Value::Bytes(kid) => String::from_utf8(kid).ok(),
+            _ => None,
+        }
+    })
+}
+
+/// Whether the protected COSE header declares any critical extension.
+fn has_critical_header(token: &[u8]) -> bool {
+    let Some((header, _)) = cose_parts(token) else {
+        return false;
+    };
+    let Ok(ciborium::Value::Map(entries)) = ciborium::de::from_reader(header.as_slice()) else {
+        return false;
+    };
+
+    entries.into_iter().any(|(label, _)| {
+        matches!(label, ciborium::Value::Integer(label) if i64::try_from(label) == Ok(2))
+    })
+}
+
+/// Pick the more useful of two verification failures.
+///
+/// A key whose signature check failed says nothing about the token beyond
+/// "not this key", whereas an error raised after the signature verified —
+/// malformed CBOR, a missing claim — describes the token itself. Reporting the
+/// first failure encountered would make the denial reason, and the error code
+/// on the wire, depend on how many keys the scope happens to have configured.
+fn more_informative(current: Option<CatError>, candidate: CatError) -> CatError {
+    fn is_key_mismatch(err: &CatError) -> bool {
+        matches!(
+            err,
+            CatError::SignatureVerificationFailed | CatError::AlgorithmMismatch { .. }
+        )
+    }
+
+    match current {
+        Some(current) if !is_key_mismatch(&current) => current,
+        _ => candidate,
+    }
+}
+
+/// Pick the more useful of two token-level denials.
+///
+/// The same idea as [`more_informative`], one level up: with several tokens
+/// presented, "this one is not for you" says less than "this one is expired",
+/// and which the peer listed last should not decide what gets reported.
+fn more_specific_denial(current: Option<DenyReason>, candidate: DenyReason) -> DenyReason {
+    fn is_generic(reason: &DenyReason) -> bool {
+        matches!(reason, DenyReason::TokenInvalid | DenyReason::TokenMissing)
+    }
+
+    match current {
+        Some(current) if !is_generic(&current) => current,
+        _ => candidate,
+    }
+}
+
+/// CWT and CAT claim keys this relay either enforces or can safely ignore.
+///
+/// Everything else is refused. An allowlist rather than a denylist because a
+/// claim the relay has never heard of is, by construction, one it is not
+/// enforcing — and every CAT extension claim so far has been a restriction.
+///
+/// The permitted set is deliberately small:
+///
+/// | key | claim | why it is safe |
+/// |-----|-------|----------------|
+/// | 1 | `iss` | enforced |
+/// | 2 | `sub` | identity, not a constraint |
+/// | 3 | `aud` | enforced |
+/// | 4 | `exp` | enforced, and required |
+/// | 5 | `nbf` | enforced |
+/// | 6 | `iat` | informational |
+/// | 7 | `cti` | token identifier; only a constraint with a replay cache, and `catreplay` — which asks for one — is refused |
+/// | 310 | `catv` | describes the token, not its bearer |
+/// | 320 | `catifdata` | data for `catif`, which is itself refused |
+/// | 323 | `catr` | renewal hint; the token still expires on schedule |
+/// | 327 | `moqt` | enforced |
+/// | 328 | `moqt-reval` | refused by `validate_moqt_claims` |
+const PERMITTED_CLAIM_KEYS: &[i64] = &[1, 2, 3, 4, 5, 6, 7, 310, 320, 323, 327, 328];
+
+/// The first claim in the token's payload that this relay cannot enforce.
+///
+/// Reads the **raw CWT payload** rather than the decoded [`CatToken`] so a
+/// future dependency update cannot quietly widen the set of constraints this
+/// relay accepts without corresponding enforcement support.
+fn unenforceable_claim(raw_token: &[u8]) -> Option<String> {
+    // A payload that cannot be re-read here already verified, so treat the
+    // inconsistency as a reason to refuse rather than to trust.
+    let Some((_, cbor)) = cose_parts(raw_token) else {
+        return Some("unreadable payload".to_string());
+    };
+
+    let Ok(ciborium::Value::Map(entries)) = ciborium::de::from_reader(cbor.as_slice()) else {
+        return Some("unreadable payload".to_string());
+    };
+
+    let mut present = Vec::new();
+    for (key, _) in entries {
+        let ciborium::Value::Integer(label) = key else {
+            // CWT claim keys are integers; a text key is a JWT-ism and not
+            // something this relay evaluates.
+            return Some("non-integer claim key".to_string());
+        };
+        let Ok(label) = i64::try_from(label) else {
+            return Some("claim out of range".to_string());
+        };
+        if !PERMITTED_CLAIM_KEYS.contains(&label) {
+            return Some(claim_name(label));
+        }
+        // A claim key appearing twice leaves it to the decoder which copy
+        // wins, so a second, differently-encoded copy could decide what the
+        // relay enforces. RFC 8949 §5.6 calls duplicate map keys invalid
+        // anyway; refusing removes the ambiguity rather than resolving it.
+        if present.contains(&label) {
+            return Some(format!("duplicate claim: {}", claim_name(label)));
+        }
+        present.push(label);
+    }
+
+    None
+}
+
+/// Extract the protected header and payload from a COSE_Sign1 or COSE_Mac0.
+fn cose_parts(token: &[u8]) -> Option<(Vec<u8>, Vec<u8>)> {
+    let value: ciborium::Value = ciborium::de::from_reader(token).ok()?;
+    let ciborium::Value::Tag(17 | 18, inner) = value else {
+        return None;
+    };
+    let ciborium::Value::Array(parts) = *inner else {
+        return None;
+    };
+    if parts.len() != 4 {
+        return None;
+    }
+    let ciborium::Value::Bytes(header) = &parts[0] else {
+        return None;
+    };
+    let ciborium::Value::Bytes(payload) = &parts[2] else {
+        return None;
+    };
+    Some((header.clone(), payload.clone()))
+}
+
+/// A readable name for a claim key, for logs. Falls back to the number.
+fn claim_name(key: i64) -> String {
+    let name = match key {
+        8 => "cnf",
+        282 => "geohash",
+        308 => "catreplay",
+        309 => "catpor",
+        311 => "catnip",
+        312 => "catu",
+        313 => "catm",
+        314 => "catalpn",
+        315 => "cath",
+        316 => "catgeoiso3166",
+        317 => "catgeocoord",
+        318 => "catgeoalt",
+        319 => "cattpk",
+        321 => "catdpop",
+        322 => "catif",
+        324 => "or",
+        325 => "nor",
+        326 => "and",
+        _ => return format!("claim {key}"),
+    };
+    name.to_string()
+}
+
+/// Translate a `cat-token` error into a relay denial reason.
+fn map_cat_error(err: CatError) -> DenyReason {
+    match err {
+        CatError::TokenExpired | CatError::TokenNotYetValid => DenyReason::TokenExpired,
+        CatError::InvalidIssuer => DenyReason::IssuerUnknown,
+        CatError::ReplayAttackDetected => DenyReason::TokenReplayed,
+        CatError::MoqtActionNotAuthorized(_) => DenyReason::ScopeMismatch,
+        CatError::InvalidTokenFormat
+        | CatError::InvalidCbor(_)
+        | CatError::InvalidBase64(_)
+        | CatError::MissingRequiredClaim(_) => DenyReason::TokenMalformed,
+        CatError::InvalidAudience
+        | CatError::SignatureVerificationFailed
+        | CatError::UnsupportedAlgorithm(_)
+        | CatError::AlgorithmMismatch { .. } => DenyReason::TokenInvalid,
+        other => DenyReason::PolicyDenied {
+            message: other.to_string(),
+        },
+    }
+}
+
+/// Seconds since the UNIX epoch, or `None` if the clock is before it.
+///
+/// A pre-epoch clock means the host has no usable notion of time, which makes
+/// every expiry check meaningless. Callers must treat `None` as a denial:
+/// substituting a placeholder would silently make every token look unexpired
+/// for as long as the clock stayed wrong.
+fn try_now_unix() -> Option<i64> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|elapsed| elapsed.as_secs() as i64)
+}
+
+/// Seconds since the UNIX epoch, saturating at 0 for a pre-epoch clock.
+///
+/// Only for comparisons where a too-small value is the conservative answer —
+/// `try_now_unix` is the right choice anywhere a wrong clock must deny.
+fn now_unix() -> i64 {
+    try_now_unix().unwrap_or(0)
+}
+
+fn duration_to_seconds(duration: Duration) -> i64 {
+    i64::try_from(duration.as_secs()).unwrap_or(i64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use bytes::Bytes;
+    // `CryptographicAlgorithm` brings `sign` and `algorithm_id` into scope for
+    // the hand-rolled token minting below.
+    use cat_token::{
+        create_signing_input, encode_token, CatTokenBuilder, CryptographicAlgorithm, Cwt,
+        MoqtScopeBuilder,
+    };
+    use moq_transport::coding::TrackName;
+    use p256::pkcs8::EncodePublicKey;
+
+    /// A generated ES256 keypair plus the PEM a scope would be configured with.
+    struct TestKey {
+        signer: Es256Algorithm,
+        pem: String,
+    }
+
+    fn generate_key() -> TestKey {
+        let signer = Es256Algorithm::new_with_key_pair().expect("keypair");
+        let pem = signer
+            .verifying_key()
+            .to_public_key_pem(Default::default())
+            .expect("public key pem");
+        TestKey { signer, pem }
+    }
+
+    /// Encode a token carrying a `kid` header.
+    ///
+    /// `cat_token::encode_token` builds its header from a freshly constructed
+    /// `Cwt`, whose `kid` is always `None`, so the library cannot emit one.
+    /// Third-party C4M issuers can and do, which is exactly the case
+    /// [`header_kid`] exists to handle — so the tests mint such tokens through
+    /// the same public CWT primitives the library itself uses.
+    fn encode_with_kid(token: &CatToken, signer: &Es256Algorithm, kid: &str) -> Vec<u8> {
+        encode_with_raw_kid(token, signer, ciborium::Value::Text(kid.to_string()))
+    }
+
+    /// As [`encode_with_kid`], but with an arbitrary CBOR value in the `kid`
+    /// header, for exercising the encodings COSE permits beyond a text string.
+    fn encode_with_raw_kid(
+        token: &CatToken,
+        signer: &Es256Algorithm,
+        kid: ciborium::Value,
+    ) -> Vec<u8> {
+        encode_with_extra_headers(
+            token,
+            signer,
+            vec![(ciborium::Value::Integer(4.into()), kid)],
+        )
+    }
+
+    fn encode_with_extra_headers(
+        token: &CatToken,
+        signer: &Es256Algorithm,
+        extra: Vec<(ciborium::Value, ciborium::Value)>,
+    ) -> Vec<u8> {
+        let cwt = Cwt::new(signer.algorithm_id(), token.clone());
+
+        let mut headers = vec![
+            (
+                ciborium::Value::Integer(1.into()),
+                ciborium::Value::Integer(signer.algorithm_id().into()),
+            ),
+            (
+                ciborium::Value::Integer(16.into()),
+                ciborium::Value::Text("CAT".to_string()),
+            ),
+        ];
+        headers.extend(extra);
+        let header = ciborium::Value::Map(headers);
+
+        let mut header_cbor = Vec::new();
+        ciborium::ser::into_writer(&header, &mut header_cbor).expect("header cbor");
+        let payload_cbor = cwt.encode_payload().expect("payload cbor");
+
+        let signing_input =
+            create_signing_input(&header_cbor, &payload_cbor, signer.algorithm_id())
+                .expect("signing input");
+        let signature = signer.sign(&signing_input).expect("sign");
+
+        let cose = ciborium::Value::Tag(
+            18,
+            Box::new(ciborium::Value::Array(vec![
+                ciborium::Value::Bytes(header_cbor),
+                ciborium::Value::Map(vec![]),
+                ciborium::Value::Bytes(payload_cbor),
+                ciborium::Value::Bytes(signature),
+            ])),
+        );
+        let mut encoded = Vec::new();
+        ciborium::ser::into_writer(&cose, &mut encoded).expect("COSE_Sign1");
+        encoded
+    }
+
+    fn config(keys: Vec<AuthPublicKey>) -> ScopeAuthConfig {
+        ScopeAuthConfig::new(keys)
+            .with_issuers(vec!["test-issuer".to_string()])
+            .with_audiences(vec!["test-relay".to_string()])
+    }
+
+    fn hook(keys: Vec<AuthPublicKey>) -> CatAuthHook {
+        CatAuthHook::new(&config(keys), Some("test-scope")).expect("hook builds")
+    }
+
+    /// A token granting CLIENT_SETUP plus publisher rights under a namespace
+    /// prefix.
+    fn publisher_token(signer: &Es256Algorithm, prefix: &[&[u8]]) -> Bytes {
+        mint(signer, prefix, true, None, 3600)
+    }
+
+    /// A token granting CLIENT_SETUP plus subscriber rights under a prefix.
+    fn subscriber_token(signer: &Es256Algorithm, prefix: &[&[u8]]) -> Bytes {
+        mint(signer, prefix, false, None, 3600)
+    }
+
+    fn mint(
+        signer: &Es256Algorithm,
+        prefix: &[&[u8]],
+        publisher: bool,
+        kid: Option<&str>,
+        expires_in: i64,
+    ) -> Bytes {
+        let mut scope = MoqtScopeBuilder::new();
+        scope = if publisher {
+            scope.publisher()
+        } else {
+            scope.subscriber()
+        };
+        for part in prefix {
+            scope = scope.namespace_prefix(part);
+        }
+        let scope = scope.track_prefix(b"").build();
+
+        let setup_scope = MoqtScopeBuilder::new()
+            .action(MoqtAction::ClientSetup)
+            .build();
+
+        let token = CatTokenBuilder::new()
+            .issuer("test-issuer")
+            .single_audience("test-relay")
+            .subject("test-subject")
+            .expires_in(expires_in)
+            .moqt_scope(scope)
+            .moqt_scope(setup_scope)
+            .build()
+            .expect("build token");
+
+        let encoded = match kid {
+            Some(kid) => encode_with_kid(&token, signer, kid),
+            None => encode_token(&token, signer).expect("encode"),
+        };
+        Bytes::from(encoded)
+    }
+
+    fn auth_token(value: Bytes) -> AuthToken {
+        AuthToken::new(CAT_TOKEN_TYPE, value.to_vec())
+    }
+
+    fn session() -> SessionContext {
+        SessionContext::public(Some("test-scope".to_string()))
+    }
+
+    async fn principal_for(hook: &CatAuthHook, value: Bytes) -> Principal {
+        hook.on_setup(&session(), &[auth_token(value)])
+            .await
+            .expect("no fault")
+            .into_principal()
+            .expect("allowed")
+    }
+
+    /// A valid, minimally-scoped token: publisher under `sports`, plus setup.
+    fn base_token() -> CatToken {
+        CatTokenBuilder::new()
+            .issuer("test-issuer")
+            .single_audience("test-relay")
+            .subject("test-subject")
+            .expires_in(3600)
+            .moqt_scope(
+                MoqtScopeBuilder::new()
+                    .publisher()
+                    .namespace_prefix(b"sports")
+                    .track_prefix(b"")
+                    .build(),
+            )
+            .moqt_scope(
+                MoqtScopeBuilder::new()
+                    .action(MoqtAction::ClientSetup)
+                    .build(),
+            )
+            .build()
+            .expect("build token")
+    }
+
+    /// Encode [`base_token`] with one extra claim spliced into the payload.
+    ///
+    /// Goes through the CBOR directly because the point is to produce shapes
+    /// `cat-token`'s own encoder cannot, which is precisely what a third-party
+    /// issuer following the RFCs will emit.
+    fn mint_with_extra_claim(
+        signer: &Es256Algorithm,
+        claim_key: i64,
+        value: ciborium::Value,
+    ) -> Vec<u8> {
+        let cwt = Cwt::new(signer.algorithm_id(), base_token());
+        let payload_cbor = cwt.encode_payload().expect("payload cbor");
+
+        let ciborium::Value::Map(mut entries) =
+            ciborium::de::from_reader::<ciborium::Value, _>(payload_cbor.as_slice())
+                .expect("payload is a map")
+        else {
+            panic!("payload is a map");
+        };
+        entries.push((ciborium::Value::Integer(claim_key.into()), value));
+
+        let mut payload_cbor = Vec::new();
+        ciborium::ser::into_writer(&ciborium::Value::Map(entries), &mut payload_cbor)
+            .expect("re-encode");
+
+        let header = ciborium::Value::Map(vec![
+            (
+                ciborium::Value::Integer(1.into()),
+                ciborium::Value::Integer(signer.algorithm_id().into()),
+            ),
+            (
+                ciborium::Value::Integer(16.into()),
+                ciborium::Value::Text("CAT".to_string()),
+            ),
+        ]);
+        let mut header_cbor = Vec::new();
+        ciborium::ser::into_writer(&header, &mut header_cbor).expect("header cbor");
+
+        let signing_input =
+            create_signing_input(&header_cbor, &payload_cbor, signer.algorithm_id())
+                .expect("signing input");
+        let signature = signer.sign(&signing_input).expect("sign");
+
+        let cose = ciborium::Value::Tag(
+            18,
+            Box::new(ciborium::Value::Array(vec![
+                ciborium::Value::Bytes(header_cbor),
+                ciborium::Value::Map(vec![]),
+                ciborium::Value::Bytes(payload_cbor),
+                ciborium::Value::Bytes(signature),
+            ])),
+        );
+        let mut encoded = Vec::new();
+        ciborium::ser::into_writer(&cose, &mut encoded).expect("COSE_Sign1");
+        encoded
+    }
+
+    /// A token whose scopes carry a non-empty track prefix — the canonical
+    /// publisher shape, and the one the library's own `roles::publisher`
+    /// helper produces.
+    fn track_scoped_token(signer: &Es256Algorithm, track_prefix: &[u8]) -> Bytes {
+        let token = CatTokenBuilder::new()
+            .issuer("test-issuer")
+            .single_audience("test-relay")
+            .subject("test-subject")
+            .expires_in(3600)
+            .moqt_scope(
+                MoqtScopeBuilder::new()
+                    .publisher()
+                    .subscriber()
+                    .namespace_prefix(b"sports")
+                    .track_prefix(track_prefix)
+                    .build(),
+            )
+            .moqt_scope(
+                MoqtScopeBuilder::new()
+                    .action(MoqtAction::ClientSetup)
+                    .build(),
+            )
+            .build()
+            .expect("build token");
+
+        Bytes::from(encode_token(&token, signer).expect("encode"))
+    }
+
+    /// Copy a principal with its recorded expiry moved.
+    ///
+    /// Expiry is checked against the system clock, which a paused tokio
+    /// runtime does not control, so moving the token's expiry is the only way
+    /// to exercise the boundary without sleeping through real seconds.
+    fn rewind_expiry(claims: &CatPrincipal, expires_at: i64) -> Principal {
+        Principal::new(
+            claims.token.informational.sub.clone(),
+            CatPrincipal {
+                token: claims.token.clone(),
+                expires_at,
+                clock_skew: claims.clock_skew,
+            },
+        )
+    }
+
+    async fn decide(
+        hook: &CatAuthHook,
+        principal: &Principal,
+        operation: AuthzOperation<'_>,
+    ) -> AuthDecision {
+        let request = AuthRequest {
+            session: &session(),
+            principal,
+            operation,
+            request_id: Some(1),
+        };
+        hook.on_request(&request).await.expect("no fault")
+    }
+
+    // ------------------------------------------------------------------
+    // Construction / configuration
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn rejects_an_empty_key_set() {
+        let err = CatAuthHook::new(&config(vec![]), None).expect_err("must fail");
+        assert!(matches!(err, AuthError::Configuration(_)), "{err:?}");
+    }
+
+    #[test]
+    fn rejects_more_than_the_maximum_keys() {
+        let keys = (0..MAX_SCOPE_AUTH_KEYS + 1)
+            .map(|_| AuthPublicKey::es256(generate_key().pem))
+            .collect();
+
+        let err = CatAuthHook::new(&config(keys), None).expect_err("must fail");
+        assert!(
+            err.to_string().contains("at most 5"),
+            "{err} should name the bound"
+        );
+    }
+
+    #[test]
+    fn accepts_exactly_the_maximum_keys() {
+        let keys = (0..MAX_SCOPE_AUTH_KEYS)
+            .map(|_| AuthPublicKey::es256(generate_key().pem))
+            .collect();
+
+        assert!(CatAuthHook::new(&config(keys), None).is_ok());
+    }
+
+    #[test]
+    fn rejects_unparseable_key_material() {
+        let good = generate_key();
+        let keys = vec![
+            AuthPublicKey::es256(good.pem),
+            AuthPublicKey::es256("-----BEGIN PUBLIC KEY-----\nnope\n-----END PUBLIC KEY-----"),
+        ];
+
+        // One bad key fails the whole scope: a rotating set must not silently
+        // degrade into a working single-key configuration.
+        let err = CatAuthHook::new(&config(keys), None).expect_err("must fail");
+        assert!(matches!(err, AuthError::Configuration(_)), "{err:?}");
+    }
+
+    #[test]
+    fn rejects_duplicate_key_identifiers() {
+        let keys = vec![
+            AuthPublicKey::es256(generate_key().pem).with_kid("rotating"),
+            AuthPublicKey::es256(generate_key().pem).with_kid("rotating"),
+        ];
+
+        let err = CatAuthHook::new(&config(keys), None).expect_err("must fail");
+        assert!(err.to_string().contains("duplicate"), "{err}");
+    }
+
+    // ------------------------------------------------------------------
+    // Setup
+    // ------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn accepts_a_valid_token() {
+        let key = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(key.pem)]);
+
+        let decision = hook
+            .on_setup(
+                &session(),
+                &[auth_token(publisher_token(&key.signer, &[b"sports"]))],
+            )
+            .await
+            .unwrap();
+
+        assert!(decision.is_allowed());
+        assert_eq!(
+            decision.principal().unwrap().subject(),
+            Some("test-subject")
+        );
+    }
+
+    #[tokio::test]
+    async fn denies_when_no_token_is_presented() {
+        let key = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(key.pem)]);
+
+        let decision = hook.on_setup(&session(), &[]).await.unwrap();
+        assert!(matches!(
+            decision.deny_reason(),
+            Some(DenyReason::TokenMissing)
+        ));
+    }
+
+    #[tokio::test]
+    async fn ignores_tokens_of_other_types() {
+        let key = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(key.pem)]);
+
+        let other = AuthToken::new(0, b"out-of-band".to_vec());
+
+        let decision = hook.on_setup(&session(), &[other]).await.unwrap();
+        assert!(matches!(
+            decision.deny_reason(),
+            Some(DenyReason::TokenMissing)
+        ));
+    }
+
+    #[tokio::test]
+    async fn denies_a_token_signed_by_an_unknown_key() {
+        let configured = generate_key();
+        let attacker = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(configured.pem)]);
+
+        let decision = hook
+            .on_setup(
+                &session(),
+                &[auth_token(publisher_token(&attacker.signer, &[b"sports"]))],
+            )
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            decision.deny_reason(),
+            Some(DenyReason::TokenInvalid)
+        ));
+    }
+
+    #[tokio::test]
+    async fn denies_an_expired_token() {
+        let key = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(key.pem)]);
+
+        // Well past the default 60s skew tolerance.
+        let expired = mint(&key.signer, &[b"sports"], true, None, -3600);
+
+        let decision = hook
+            .on_setup(&session(), &[auth_token(expired)])
+            .await
+            .unwrap();
+        assert!(matches!(
+            decision.deny_reason(),
+            Some(DenyReason::TokenExpired)
+        ));
+    }
+
+    #[tokio::test]
+    async fn denies_a_token_from_an_unexpected_issuer() {
+        let key = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(key.pem)]);
+
+        let scope = MoqtScopeBuilder::new()
+            .publisher()
+            .namespace_prefix(b"sports")
+            .track_prefix(b"")
+            .build();
+        let token = CatTokenBuilder::new()
+            .issuer("some-other-issuer")
+            .single_audience("test-relay")
+            .subject("test-subject")
+            .expires_in(3600)
+            .moqt_scope(scope)
+            .build()
+            .expect("build token");
+        let encoded = Bytes::from(encode_token(&token, &key.signer).unwrap());
+
+        let decision = hook
+            .on_setup(&session(), &[auth_token(encoded)])
+            .await
+            .unwrap();
+        assert!(matches!(
+            decision.deny_reason(),
+            Some(DenyReason::IssuerUnknown)
+        ));
+    }
+
+    #[tokio::test]
+    async fn denies_a_token_for_another_audience() {
+        let key = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(key.pem)]);
+
+        let scope = MoqtScopeBuilder::new()
+            .publisher()
+            .namespace_prefix(b"sports")
+            .track_prefix(b"")
+            .build();
+        let token = CatTokenBuilder::new()
+            .issuer("test-issuer")
+            .single_audience("some-other-relay")
+            .subject("test-subject")
+            .expires_in(3600)
+            .moqt_scope(scope)
+            .build()
+            .expect("build token");
+        let encoded = Bytes::from(encode_token(&token, &key.signer).unwrap());
+
+        let decision = hook
+            .on_setup(&session(), &[auth_token(encoded)])
+            .await
+            .unwrap();
+        assert!(matches!(
+            decision.deny_reason(),
+            Some(DenyReason::TokenInvalid)
+        ));
+    }
+
+    #[tokio::test]
+    async fn denies_a_token_that_does_not_grant_client_setup() {
+        let key = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(key.pem)]);
+
+        // Publisher rights but no CLIENT_SETUP scope.
+        let scope = MoqtScopeBuilder::new()
+            .publisher()
+            .namespace_prefix(b"sports")
+            .track_prefix(b"")
+            .build();
+        let token = CatTokenBuilder::new()
+            .issuer("test-issuer")
+            .single_audience("test-relay")
+            .subject("test-subject")
+            .expires_in(3600)
+            .moqt_scope(scope)
+            .build()
+            .expect("build token");
+        let encoded = Bytes::from(encode_token(&token, &key.signer).unwrap());
+
+        let decision = hook
+            .on_setup(&session(), &[auth_token(encoded)])
+            .await
+            .unwrap();
+        assert!(matches!(
+            decision.deny_reason(),
+            Some(DenyReason::ScopeMismatch)
+        ));
+    }
+
+    #[tokio::test]
+    async fn denies_a_token_with_no_moqt_claim() {
+        let key = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(key.pem)]);
+
+        // "The default for all actions is 'Blocked'": a token carrying no
+        // `moqt` claim authorizes nothing.
+        let token = CatTokenBuilder::new()
+            .issuer("test-issuer")
+            .single_audience("test-relay")
+            .subject("test-subject")
+            .expires_in(3600)
+            .build()
+            .expect("build token");
+        let encoded = Bytes::from(encode_token(&token, &key.signer).unwrap());
+
+        let decision = hook
+            .on_setup(&session(), &[auth_token(encoded)])
+            .await
+            .unwrap();
+        assert!(matches!(
+            decision.deny_reason(),
+            Some(DenyReason::ScopeMismatch)
+        ));
+    }
+
+    #[tokio::test]
+    async fn denies_a_token_requiring_revalidation() {
+        let key = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(key.pem)]);
+
+        // The relay does not revalidate mid-session, so c4m requires it to
+        // reject any token carrying `moqt-reval`.
+        let scope = MoqtScopeBuilder::new()
+            .publisher()
+            .namespace_prefix(b"sports")
+            .track_prefix(b"")
+            .build();
+        let setup = MoqtScopeBuilder::new()
+            .action(MoqtAction::ClientSetup)
+            .build();
+        let token = CatTokenBuilder::new()
+            .issuer("test-issuer")
+            .single_audience("test-relay")
+            .subject("test-subject")
+            .expires_in(3600)
+            .moqt_scope(scope)
+            .moqt_scope(setup)
+            .moqt_reval(30.0)
+            .build()
+            .expect("build token");
+        let encoded = Bytes::from(encode_token(&token, &key.signer).unwrap());
+
+        let decision = hook
+            .on_setup(&session(), &[auth_token(encoded)])
+            .await
+            .unwrap();
+        assert!(
+            !decision.is_allowed(),
+            "revalidation-bound token must be denied"
+        );
+    }
+
+    #[tokio::test]
+    async fn denies_garbage_token_values() {
+        let key = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(key.pem)]);
+
+        for value in [
+            Bytes::from_static(b""),
+            Bytes::from_static(b"not-a-token"),
+            Bytes::from_static(b"a.b"),
+            Bytes::from_static(b"a.b.c.d"),
+            Bytes::from_static(b"!!!.###.$$$"),
+            Bytes::from_static(&[0xff, 0xfe, 0xfd]),
+        ] {
+            let decision = hook
+                .on_setup(&session(), &[auth_token(value.clone())])
+                .await
+                .unwrap();
+            assert!(!decision.is_allowed(), "{value:?} must not be allowed");
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Key selection
+    // ------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn verifies_against_any_key_in_the_set() {
+        // A token signed by the last configured key must still verify, which is
+        // what makes a rotation overlap work.
+        for signing_index in 0..MAX_SCOPE_AUTH_KEYS {
+            let generated: Vec<TestKey> =
+                (0..MAX_SCOPE_AUTH_KEYS).map(|_| generate_key()).collect();
+            let keys = generated
+                .iter()
+                .map(|key| AuthPublicKey::es256(key.pem.clone()))
+                .collect();
+            let hook = hook(keys);
+
+            let token = publisher_token(&generated[signing_index].signer, &[b"sports"]);
+            let decision = hook
+                .on_setup(&session(), &[auth_token(token)])
+                .await
+                .unwrap();
+
+            assert!(
+                decision.is_allowed(),
+                "token signed by key {signing_index} should verify"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn denies_when_no_key_in_the_set_matches() {
+        let generated: Vec<TestKey> = (0..MAX_SCOPE_AUTH_KEYS).map(|_| generate_key()).collect();
+        let keys = generated
+            .iter()
+            .map(|key| AuthPublicKey::es256(key.pem.clone()))
+            .collect();
+        let hook = hook(keys);
+
+        let attacker = generate_key();
+        let token = publisher_token(&attacker.signer, &[b"sports"]);
+
+        let decision = hook
+            .on_setup(&session(), &[auth_token(token)])
+            .await
+            .unwrap();
+        assert!(!decision.is_allowed());
+    }
+
+    #[tokio::test]
+    async fn selects_the_key_named_by_the_token_kid() {
+        let old = generate_key();
+        let new = generate_key();
+        let hook = hook(vec![
+            AuthPublicKey::es256(old.pem).with_kid("old"),
+            AuthPublicKey::es256(new.pem).with_kid("new"),
+        ]);
+
+        // Signed by "new" and labelled as such.
+        let token = mint(&new.signer, &[b"sports"], true, Some("new"), 3600);
+        assert!(hook
+            .on_setup(&session(), &[auth_token(token)])
+            .await
+            .unwrap()
+            .is_allowed());
+
+        // Signed by "old" and labelled as such.
+        let token = mint(&old.signer, &[b"sports"], true, Some("old"), 3600);
+        assert!(hook
+            .on_setup(&session(), &[auth_token(token)])
+            .await
+            .unwrap()
+            .is_allowed());
+    }
+
+    #[tokio::test]
+    async fn a_kid_less_key_can_verify_a_token_bearing_a_kid() {
+        // An operator who configures keys without identifiers should not have
+        // clients rejected merely for labelling their tokens.
+        let key = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(key.pem)]);
+
+        let token = mint(&key.signer, &[b"sports"], true, Some("whatever"), 3600);
+        assert!(hook
+            .on_setup(&session(), &[auth_token(token)])
+            .await
+            .unwrap()
+            .is_allowed());
+    }
+
+    /// `kid` reorders the key list so the named key is tried first; it never
+    /// removes a key, so a mismatched label cannot deny a valid signature.
+    #[test]
+    fn a_kid_reorders_but_never_excludes_keys() {
+        let hook = hook(vec![
+            AuthPublicKey::es256(generate_key().pem),
+            AuthPublicKey::es256(generate_key().pem).with_kid("a"),
+            AuthPublicKey::es256(generate_key().pem).with_kid("b"),
+        ]);
+
+        let kids = |kid: Option<&str>| -> Vec<Option<String>> {
+            hook.candidate_keys(kid)
+                .into_iter()
+                .map(|key| key.kid.clone())
+                .collect()
+        };
+
+        // The named key first, then the others, with none dropped.
+        assert_eq!(
+            kids(Some("b")),
+            vec![Some("b".to_string()), None, Some("a".to_string())]
+        );
+
+        // A name matching nothing still yields every key, in configured order.
+        assert_eq!(
+            kids(Some("absent")),
+            vec![None, Some("a".to_string()), Some("b".to_string())]
+        );
+
+        // No name means no reordering.
+        assert_eq!(
+            kids(None),
+            vec![None, Some("a".to_string()), Some("b".to_string())]
+        );
+
+        for kid in [Some("a"), Some("b"), Some("absent"), None] {
+            assert_eq!(
+                kids(kid).len(),
+                hook.keys.len(),
+                "every key must remain a candidate for kid {kid:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn header_kid_reads_the_cose_label() {
+        let key = generate_key();
+
+        let labelled = mint(&key.signer, &[b"sports"], true, Some("rotating"), 3600);
+        assert_eq!(header_kid(&labelled), Some("rotating".to_string()));
+
+        let unlabelled = publisher_token(&key.signer, &[b"sports"]);
+        assert_eq!(header_kid(&unlabelled), None);
+    }
+
+    /// An unreadable header yields no hint. It must never produce a verdict:
+    /// the header is attacker-controlled, and the signature is what decides.
+    #[test]
+    fn header_kid_degrades_to_no_hint_on_malformed_input() {
+        for value in [
+            &b""[..],
+            &b"only-one-part"[..],
+            &b"two.parts"[..],
+            &b"four.parts.are.wrong"[..],
+            &b".empty.header"[..],
+            &b"!!!not-base64!!!.b.c"[..],
+            &[0xff, 0xfe, 0xfd][..],
+        ] {
+            assert_eq!(
+                header_kid(value),
+                None,
+                "{:?} should yield no hint",
+                String::from_utf8_lossy(value)
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn a_token_with_an_unsupported_critical_header_is_refused() {
+        let key = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(key.pem.clone())]);
+        let encoded = encode_with_extra_headers(
+            &base_token(),
+            &key.signer,
+            vec![
+                (
+                    ciborium::Value::Integer(2.into()),
+                    ciborium::Value::Array(vec![ciborium::Value::Integer(42.into())]),
+                ),
+                (
+                    ciborium::Value::Integer(42.into()),
+                    ciborium::Value::Bool(true),
+                ),
+            ],
+        );
+
+        let decision = hook
+            .on_setup(&session(), &[auth_token(Bytes::from(encoded))])
+            .await
+            .unwrap();
+        assert!(!decision.is_allowed());
+    }
+
+    /// RFC 8152 §3.1 types `kid` as `bstr`, so real issuers emit thumbprints
+    /// that are not text, and COSE permits other shapes entirely. None of
+    /// those may cause a rejection — a token the relay holds the key for must
+    /// still be accepted.
+    #[tokio::test]
+    async fn an_unmatchable_kid_does_not_prevent_verification() {
+        let key = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(key.pem.clone())]);
+
+        let token = CatTokenBuilder::new()
+            .issuer("test-issuer")
+            .single_audience("test-relay")
+            .subject("test-subject")
+            .expires_in(3600)
+            .moqt_scope(
+                MoqtScopeBuilder::new()
+                    .publisher()
+                    .namespace_prefix(b"sports")
+                    .track_prefix(b"")
+                    .build(),
+            )
+            .moqt_scope(
+                MoqtScopeBuilder::new()
+                    .action(MoqtAction::ClientSetup)
+                    .build(),
+            )
+            .build()
+            .expect("build token");
+
+        // A binary thumbprint, an integer label, and an outright absent header
+        // map: each is unusable as a hint, none is grounds for denial.
+        for kid in [
+            ciborium::Value::Bytes(vec![0xde, 0xad, 0xbe, 0xef]),
+            ciborium::Value::Integer(7.into()),
+            ciborium::Value::Null,
+        ] {
+            let encoded = encode_with_raw_kid(&token, &key.signer, kid.clone());
+            let decision = hook
+                .on_setup(&session(), &[auth_token(Bytes::from(encoded))])
+                .await
+                .unwrap();
+
+            assert!(
+                decision.is_allowed(),
+                "a token with kid {kid:?} must still verify against the configured key"
+            );
+        }
+    }
+
+    /// A `kid` naming no configured key is a hint that matched nothing, not a
+    /// rejection: the signature still decides. Otherwise a relabelled issuer
+    /// or a typo in one configured identifier is an outage.
+    #[tokio::test]
+    async fn a_kid_naming_no_configured_key_still_verifies() {
+        let key = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(key.pem).with_kid("known")]);
+
+        let token = mint(&key.signer, &[b"sports"], true, Some("unknown"), 3600);
+
+        assert!(hook
+            .on_setup(&session(), &[auth_token(token)])
+            .await
+            .unwrap()
+            .is_allowed());
+    }
+
+    // ------------------------------------------------------------------
+    // Per-request authorization
+    // ------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn publisher_token_allows_publish_and_denies_subscribe() {
+        let key = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(key.pem)]);
+        let principal = principal_for(&hook, publisher_token(&key.signer, &[b"sports"])).await;
+
+        let namespace = TrackNamespace::from_utf8_path("sports/football");
+        let track = TrackName::from("video");
+
+        assert!(decide(
+            &hook,
+            &principal,
+            AuthzOperation::PublishNamespace {
+                namespace: &namespace
+            }
+        )
+        .await
+        .is_allowed());
+
+        assert!(decide(
+            &hook,
+            &principal,
+            AuthzOperation::Publish {
+                namespace: &namespace,
+                track: &track
+            }
+        )
+        .await
+        .is_allowed());
+
+        assert!(!decide(
+            &hook,
+            &principal,
+            AuthzOperation::Subscribe {
+                namespace: &namespace,
+                track: &track
+            }
+        )
+        .await
+        .is_allowed());
+    }
+
+    #[tokio::test]
+    async fn subscriber_token_allows_subscribe_and_denies_publish() {
+        let key = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(key.pem)]);
+        let principal = principal_for(&hook, subscriber_token(&key.signer, &[b"sports"])).await;
+
+        let namespace = TrackNamespace::from_utf8_path("sports/football");
+        let track = TrackName::from("video");
+
+        assert!(decide(
+            &hook,
+            &principal,
+            AuthzOperation::Subscribe {
+                namespace: &namespace,
+                track: &track
+            }
+        )
+        .await
+        .is_allowed());
+
+        assert!(!decide(
+            &hook,
+            &principal,
+            AuthzOperation::PublishNamespace {
+                namespace: &namespace
+            }
+        )
+        .await
+        .is_allowed());
+    }
+
+    #[tokio::test]
+    async fn denies_operations_outside_the_granted_namespace() {
+        let key = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(key.pem)]);
+        let principal = principal_for(&hook, publisher_token(&key.signer, &[b"sports"])).await;
+
+        let other = TrackNamespace::from_utf8_path("news/politics");
+
+        let decision = decide(
+            &hook,
+            &principal,
+            AuthzOperation::PublishNamespace { namespace: &other },
+        )
+        .await;
+
+        assert!(matches!(
+            decision.deny_reason(),
+            Some(DenyReason::ScopeMismatch)
+        ));
+    }
+
+    /// c4m matches the track predicate "against the Track Name", and
+    /// PUBLISH_NAMESPACE / SUBSCRIBE_NAMESPACE carry none. Applying it anyway
+    /// tests it against an empty name, which fails for any non-empty prefix —
+    /// so the canonical publisher scope would be granted PUBLISH while being
+    /// denied the PUBLISH_NAMESPACE that has to precede it.
+    #[tokio::test]
+    async fn namespace_level_actions_ignore_the_track_predicate() {
+        let key = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(key.pem)]);
+
+        let principal = principal_for(&hook, track_scoped_token(&key.signer, b"live/")).await;
+
+        let namespace = TrackNamespace::from_utf8_path("sports/football");
+        let prefix = TrackNamespacePrefix::from_utf8_path("sports");
+
+        assert!(
+            decide(
+                &hook,
+                &principal,
+                AuthzOperation::PublishNamespace {
+                    namespace: &namespace
+                }
+            )
+            .await
+            .is_allowed(),
+            "a track-scoped token must still be able to announce its namespace"
+        );
+
+        assert!(
+            decide(
+                &hook,
+                &principal,
+                AuthzOperation::SubscribeNamespace { prefix: &prefix }
+            )
+            .await
+            .is_allowed(),
+            "a track-scoped token must still be able to subscribe to the prefix"
+        );
+
+        // The predicate still applies where a Track Name exists.
+        assert!(
+            decide(
+                &hook,
+                &principal,
+                AuthzOperation::Publish {
+                    namespace: &namespace,
+                    track: &TrackName::from("live/video"),
+                }
+            )
+            .await
+            .is_allowed(),
+            "a matching track name is permitted"
+        );
+
+        assert!(
+            !decide(
+                &hook,
+                &principal,
+                AuthzOperation::Publish {
+                    namespace: &namespace,
+                    track: &TrackName::from("premium/4k"),
+                }
+            )
+            .await
+            .is_allowed(),
+            "a track name outside the prefix must be denied"
+        );
+
+        assert!(
+            !decide(
+                &hook,
+                &principal,
+                AuthzOperation::Subscribe {
+                    namespace: &namespace,
+                    track: &TrackName::from("premium/4k"),
+                }
+            )
+            .await
+            .is_allowed(),
+            "the track predicate must still gate SUBSCRIBE"
+        );
+    }
+
+    /// A CLIENT_SETUP scope sharing a token with a track predicate must not be
+    /// blocked by it: CLIENT_SETUP carries no Track Name either.
+    #[tokio::test]
+    async fn client_setup_ignores_the_track_predicate() {
+        let key = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(key.pem)]);
+
+        let token = CatTokenBuilder::new()
+            .issuer("test-issuer")
+            .single_audience("test-relay")
+            .subject("test-subject")
+            .expires_in(3600)
+            // One scope, granting setup and publish, narrowed by track prefix.
+            .moqt_scope(
+                MoqtScopeBuilder::new()
+                    .action(MoqtAction::ClientSetup)
+                    .action(MoqtAction::PublishNamespace)
+                    .action(MoqtAction::Publish)
+                    .namespace_prefix(b"sports")
+                    .track_prefix(b"live/")
+                    .build(),
+            )
+            .build()
+            .expect("build token");
+        let encoded = Bytes::from(encode_token(&token, &key.signer).unwrap());
+
+        assert!(hook
+            .on_setup(&session(), &[auth_token(encoded)])
+            .await
+            .unwrap()
+            .is_allowed());
+    }
+
+    /// A token carrying a restriction the relay does not evaluate must be
+    /// refused, not honoured with the restriction quietly dropped.
+    #[tokio::test]
+    async fn tokens_carrying_unenforceable_restrictions_are_refused() {
+        let key = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(key.pem)]);
+
+        let base = || {
+            CatTokenBuilder::new()
+                .issuer("test-issuer")
+                .single_audience("test-relay")
+                .subject("test-subject")
+                .expires_in(3600)
+                .moqt_scope(
+                    MoqtScopeBuilder::new()
+                        .publisher()
+                        .namespace_prefix(b"sports")
+                        .track_prefix(b"")
+                        .build(),
+                )
+                .moqt_scope(
+                    MoqtScopeBuilder::new()
+                        .action(MoqtAction::ClientSetup)
+                        .build(),
+                )
+        };
+
+        // Single-use, and geographically pinned: both are constraints this
+        // relay never evaluates, so both must deny.
+        for token in [
+            base()
+                .replay_protection(cat_token::ReplayProtection::Prohibited)
+                .build()
+                .expect("build token"),
+            base().geohash("9q8yy").build().expect("build token"),
+        ] {
+            let encoded = Bytes::from(encode_token(&token, &key.signer).unwrap());
+            let decision = hook
+                .on_setup(&session(), &[auth_token(encoded)])
+                .await
+                .unwrap();
+
+            assert!(
+                !decision.is_allowed(),
+                "a token with an unenforceable restriction must be refused"
+            );
+        }
+
+        // The same token without those claims is fine, so the refusal is
+        // attributable to the claim and not to the fixture.
+        let token = base().build().expect("build token");
+        let encoded = Bytes::from(encode_token(&token, &key.signer).unwrap());
+        assert!(hook
+            .on_setup(&session(), &[auth_token(encoded)])
+            .await
+            .unwrap()
+            .is_allowed());
+    }
+
+    /// SUBSCRIBE_NAMESPACE grants discovery of a prefix; it does not imply the
+    /// right to receive the tracks under it.
+    ///
+    /// The relay's SUBSCRIBE_NAMESPACE handler can push PUBLISH and stream
+    /// objects for matching tracks, so it authorizes each one as a SUBSCRIBE
+    /// before doing so (`Producer::publish_track_for_namespace`). This pins
+    /// the policy that fix depends on: the two actions are distinct, and a
+    /// track predicate still applies to the per-track decision.
+    #[tokio::test]
+    async fn subscribe_namespace_does_not_imply_subscribe() {
+        let key = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(key.pem)]);
+
+        // Discovery of the prefix only: no Subscribe action at all.
+        let token = CatTokenBuilder::new()
+            .issuer("test-issuer")
+            .single_audience("test-relay")
+            .subject("test-subject")
+            .expires_in(3600)
+            .moqt_scope(
+                MoqtScopeBuilder::new()
+                    .action(MoqtAction::ClientSetup)
+                    .action(MoqtAction::SubscribeNamespace)
+                    .namespace_prefix(b"sports")
+                    .build(),
+            )
+            .build()
+            .expect("build token");
+        let encoded = Bytes::from(encode_token(&token, &key.signer).unwrap());
+        let principal = principal_for(&hook, encoded).await;
+
+        let prefix = TrackNamespacePrefix::from_utf8_path("sports");
+        let namespace = TrackNamespace::from_utf8_path("sports/football");
+
+        assert!(
+            decide(
+                &hook,
+                &principal,
+                AuthzOperation::SubscribeNamespace { prefix: &prefix }
+            )
+            .await
+            .is_allowed(),
+            "the prefix subscription itself is granted"
+        );
+
+        assert!(
+            !decide(
+                &hook,
+                &principal,
+                AuthzOperation::Subscribe {
+                    namespace: &namespace,
+                    track: &TrackName::from("video"),
+                }
+            )
+            .await
+            .is_allowed(),
+            "delivery of a track under that prefix is not"
+        );
+
+        // The narrower, likelier shape: discovery of the whole prefix, but
+        // delivery only of tracks whose name matches.
+        let restricted = principal_for(&hook, track_scoped_token(&key.signer, b"preview-")).await;
+
+        assert!(decide(
+            &hook,
+            &restricted,
+            AuthzOperation::SubscribeNamespace { prefix: &prefix }
+        )
+        .await
+        .is_allowed());
+        assert!(decide(
+            &hook,
+            &restricted,
+            AuthzOperation::Subscribe {
+                namespace: &namespace,
+                track: &TrackName::from("preview-clip"),
+            }
+        )
+        .await
+        .is_allowed());
+        assert!(
+            !decide(
+                &hook,
+                &restricted,
+                AuthzOperation::Subscribe {
+                    namespace: &namespace,
+                    track: &TrackName::from("premium-4k"),
+                }
+            )
+            .await
+            .is_allowed(),
+            "a track outside the grant must not be deliverable via the prefix"
+        );
+    }
+
+    /// c4m §3.1.1 requires a relay to reject a request whose DPoP proof or key
+    /// binding fails. This relay performs no DPoP validation, so a
+    /// sender-constrained token must be refused rather than silently accepted
+    /// with bearer semantics.
+    #[tokio::test]
+    async fn a_sender_constrained_token_is_refused() {
+        use cat_token::ConfirmationClaim;
+
+        let key = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(key.pem)]);
+
+        let mut token = base_token();
+        token.dpop.cnf = Some(ConfirmationClaim {
+            jkt: vec![0xab; 32],
+            ckt: None,
+        });
+
+        let encoded = Bytes::from(encode_token(&token, &key.signer).unwrap());
+        let decision = hook
+            .on_setup(&session(), &[auth_token(encoded)])
+            .await
+            .unwrap();
+
+        assert!(
+            !decision.is_allowed(),
+            "a DPoP-bound token must not be honoured as a bearer token"
+        );
+    }
+
+    /// The refusal must not depend on the CBOR shape a claim happens to use.
+    ///
+    /// `cat-token`'s decoder recognizes only the shapes it emits and silently
+    /// drops the rest, so checking the decoded token would miss, for instance,
+    /// a `cnf` in RFC 8747's COSE_Key form — turning a proof-of-possession
+    /// credential into a bearer credential.
+    #[tokio::test]
+    async fn restrictive_claims_are_refused_whatever_shape_they_take() {
+        let key = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(key.pem)]);
+
+        // (claim key, a value `cat-token`'s decoder does *not* recognize)
+        let smuggled = [
+            // cnf as an RFC 8747 COSE_Key rather than {3: bstr}.
+            (
+                8,
+                ciborium::Value::Map(vec![(
+                    ciborium::Value::Integer(1.into()),
+                    ciborium::Value::Integer(2.into()),
+                )]),
+            ),
+            // cnf carrying jkt as text rather than bytes.
+            (
+                8,
+                ciborium::Value::Map(vec![(
+                    ciborium::Value::Integer(3.into()),
+                    ciborium::Value::Text("thumbprint".to_string()),
+                )]),
+            ),
+            (8, ciborium::Value::Bytes(vec![0x01, 0x02])),
+            // catreplay as an integer rather than text.
+            (308, ciborium::Value::Integer(1.into())),
+            // catu as text rather than an integer.
+            (312, ciborium::Value::Text("3".to_string())),
+            (319, ciborium::Value::Bytes(vec![0xaa])),
+            (321, ciborium::Value::Bool(true)),
+            // A composite claim, which the decoder drops entirely.
+            (326, ciborium::Value::Array(vec![])),
+            // A claim from no registry at all.
+            (9999, ciborium::Value::Integer(1.into())),
+        ];
+
+        for (claim_key, value) in smuggled {
+            let encoded = mint_with_extra_claim(&key.signer, claim_key, value.clone());
+
+            // The signature and the standard claims are all valid; only the
+            // smuggled claim should stand in the way.
+            let decision = hook
+                .on_setup(&session(), &[auth_token(Bytes::from(encoded))])
+                .await
+                .unwrap();
+
+            assert!(
+                !decision.is_allowed(),
+                "claim {claim_key} encoded as {value:?} must be refused"
+            );
+        }
+    }
+
+    /// Permitting a claim because it is enforced is only sound if the decoder
+    /// understood it.
+    ///
+    /// RFC 8392 types `nbf` as "integer or floating-point number" and
+    /// `cat-token` accepts only the integer form, so a conformant issuer's
+    /// float `nbf` would otherwise be dropped and the not-before silently
+    /// ignored — a post-dated token usable before its window opens.
+    #[tokio::test]
+    async fn a_load_bearing_claim_in_an_unsupported_encoding_is_refused() {
+        let key = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(key.pem)]);
+
+        let future = (now_unix() + 3600) as f64;
+        // Claims the base token does not already carry, so these are genuinely
+        // "present on the wire, dropped by the decoder" rather than duplicates.
+        let unsupported = [
+            // nbf: RFC 8392 permits a float NumericDate.
+            (5, ciborium::Value::Float(future)),
+            (5, ciborium::Value::Text(future.to_string())),
+            // moqt-reval: c4m requires refusing a token that demands
+            // revalidation, which cannot happen if the claim is dropped.
+            (328, ciborium::Value::Text("300".to_string())),
+            (328, ciborium::Value::Bool(true)),
+            (328, ciborium::Value::Integer(300.into())),
+        ];
+
+        for (claim_key, value) in unsupported {
+            let encoded = mint_with_extra_claim(&key.signer, claim_key, value.clone());
+            let decision = hook
+                .on_setup(&session(), &[auth_token(Bytes::from(encoded))])
+                .await
+                .unwrap();
+
+            assert!(
+                !decision.is_allowed(),
+                "claim {claim_key} as {value:?} was dropped by the decoder and \
+                 must not be treated as absent"
+            );
+        }
+    }
+
+    /// A repeated claim key leaves the decoder to pick a winner, so a second
+    /// copy in a shape it prefers could decide what the relay enforces.
+    #[tokio::test]
+    async fn a_duplicated_claim_is_refused() {
+        let key = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(key.pem)]);
+
+        // Each of these already appears in the base token, so splicing another
+        // in produces a duplicate.
+        for (claim_key, value) in [
+            (1, ciborium::Value::Text("attacker".to_string())),
+            (3, ciborium::Value::Integer(1.into())),
+            (4, ciborium::Value::Integer((now_unix() + 60).into())),
+            (327, ciborium::Value::Array(vec![])),
+        ] {
+            let encoded = mint_with_extra_claim(&key.signer, claim_key, value.clone());
+            let decision = hook
+                .on_setup(&session(), &[auth_token(Bytes::from(encoded))])
+                .await
+                .unwrap();
+
+            assert!(
+                !decision.is_allowed(),
+                "a duplicated claim {claim_key} must be refused"
+            );
+        }
+    }
+
+    /// A post-dated token must not be usable before its window opens,
+    /// whichever encoding its `nbf` uses.
+    #[tokio::test]
+    async fn a_not_yet_valid_token_is_refused() {
+        let key = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(key.pem)]);
+
+        // The integer form the library does understand.
+        let mut token = base_token();
+        token.core.nbf = Some(now_unix() + 3600);
+        let encoded = Bytes::from(encode_token(&token, &key.signer).unwrap());
+        assert!(!hook
+            .on_setup(&session(), &[auth_token(encoded)])
+            .await
+            .unwrap()
+            .is_allowed());
+
+        // And the float form it does not.
+        let encoded = mint_with_extra_claim(
+            &key.signer,
+            5,
+            ciborium::Value::Float((now_unix() + 3600) as f64),
+        );
+        assert!(!hook
+            .on_setup(&session(), &[auth_token(Bytes::from(encoded))])
+            .await
+            .unwrap()
+            .is_allowed());
+    }
+
+    /// The allowlist must not refuse the claims a normal token carries.
+    #[tokio::test]
+    async fn permitted_claims_are_accepted() {
+        let key = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(key.pem)]);
+
+        let mut token = base_token();
+        token.core.cti = Some(b"token-id".to_vec());
+        token.informational.iat = Some(now_unix());
+        token.cat.catv = Some(1);
+        token.request.catr = Some(
+            cat_token::CatRenewal::automatic()
+                .with_expadd(600.0)
+                .expect("valid renewal"),
+        );
+        token.informational.catifdata = Some(vec!["data".to_string()]);
+
+        let encoded = Bytes::from(encode_token(&token, &key.signer).unwrap());
+        assert!(hook
+            .on_setup(&session(), &[auth_token(encoded)])
+            .await
+            .unwrap()
+            .is_allowed());
+    }
+
+    /// An extreme not-before is outside the relay's supported token horizon.
+    #[tokio::test]
+    async fn an_implausible_not_before_is_refused() {
+        let key = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(key.pem)]);
+
+        for nbf in [
+            i64::MIN,
+            i64::MIN / 2,
+            now_unix() - 10 * MAX_TOKEN_LIFETIME_SECS,
+        ] {
+            let mut token = CatTokenBuilder::new()
+                .issuer("test-issuer")
+                .single_audience("test-relay")
+                .subject("test-subject")
+                .expires_in(3600)
+                .moqt_scope(
+                    MoqtScopeBuilder::new()
+                        .publisher()
+                        .namespace_prefix(b"sports")
+                        .track_prefix(b"")
+                        .build(),
+                )
+                .moqt_scope(
+                    MoqtScopeBuilder::new()
+                        .action(MoqtAction::ClientSetup)
+                        .build(),
+                )
+                .build()
+                .expect("build token");
+            token.core.nbf = Some(nbf);
+
+            let encoded = Bytes::from(encode_token(&token, &key.signer).unwrap());
+            // Must deny, and in particular must not panic on the way.
+            let decision = hook
+                .on_setup(&session(), &[auth_token(encoded)])
+                .await
+                .unwrap();
+            assert!(!decision.is_allowed(), "nbf {nbf} must be refused");
+        }
+    }
+
+    /// Admission cost must not scale with what the peer chooses to send.
+    /// Without a budget, `MAX_SETUP_TOKENS` tokens against a full key set would
+    /// buy 40 signature verifications per connection attempt.
+    #[tokio::test]
+    async fn signature_verifications_are_budgeted_per_session() {
+        let generated: Vec<TestKey> = (0..MAX_SCOPE_AUTH_KEYS).map(|_| generate_key()).collect();
+        let keys = generated
+            .iter()
+            .map(|key| AuthPublicKey::es256(key.pem.clone()))
+            .collect();
+        let hook = hook(keys);
+
+        // Every token is signed by an unconfigured key, so each exhausts the
+        // whole candidate list before failing.
+        let attacker = generate_key();
+        let mut tokens: Vec<AuthToken> = (0..crate::auth::MAX_SETUP_TOKENS)
+            .map(|_| auth_token(publisher_token(&attacker.signer, &[b"sports"])))
+            .collect();
+        tokens.push(auth_token(publisher_token(
+            &generated[0].signer,
+            &[b"sports"],
+        )));
+
+        let decision = hook.on_setup(&session(), &tokens).await.unwrap();
+        assert!(
+            !decision.is_allowed(),
+            "a valid token after budget exhaustion must be unreachable"
+        );
+    }
+
+    /// The budget must not reject honest clients. Two cases have to fit: one
+    /// token against a full key set mid-rotation, and a client presenting a
+    /// token for another relay before the one that works here.
+    #[tokio::test]
+    async fn the_budget_admits_the_honest_worst_case() {
+        let generated: Vec<TestKey> = (0..MAX_SCOPE_AUTH_KEYS).map(|_| generate_key()).collect();
+        let keys: Vec<AuthPublicKey> = generated
+            .iter()
+            .map(|key| AuthPublicKey::es256(key.pem.clone()))
+            .collect();
+        let hook = hook(keys);
+
+        // Signed by the last key, so every earlier one is tried and fails.
+        let token = publisher_token(&generated[MAX_SCOPE_AUTH_KEYS - 1].signer, &[b"sports"]);
+        assert!(
+            hook.on_setup(&session(), &[auth_token(token)])
+                .await
+                .unwrap()
+                .is_allowed(),
+            "one token against a full key set must fit the budget"
+        );
+
+        // A token this relay cannot verify, followed by one it can: the first
+        // exhausts all five keys before the second is reached.
+        let elsewhere = generate_key();
+        let tokens = vec![
+            auth_token(publisher_token(&elsewhere.signer, &[b"sports"])),
+            auth_token(publisher_token(
+                &generated[MAX_SCOPE_AUTH_KEYS - 1].signer,
+                &[b"sports"],
+            )),
+        ];
+        assert!(
+            hook.on_setup(&session(), &tokens)
+                .await
+                .unwrap()
+                .is_allowed(),
+            "two tokens against a full key set must fit the budget"
+        );
+    }
+
+    /// §9.3.1.5 permits more than one token. A token that does not satisfy
+    /// this scope must not mask a later one that does.
+    #[tokio::test]
+    async fn a_later_token_is_tried_when_an_earlier_one_fails() {
+        let configured = generate_key();
+        let other = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(configured.pem)]);
+
+        let unusable = auth_token(publisher_token(&other.signer, &[b"sports"]));
+        let usable = auth_token(publisher_token(&configured.signer, &[b"sports"]));
+
+        let decision = hook
+            .on_setup(&session(), &[unusable, usable])
+            .await
+            .unwrap();
+
+        assert!(
+            decision.is_allowed(),
+            "the second token should have been tried"
+        );
+    }
+
+    #[tokio::test]
+    async fn subscribe_namespace_is_authorized_against_the_prefix() {
+        let key = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(key.pem)]);
+        let principal = principal_for(&hook, subscriber_token(&key.signer, &[b"sports"])).await;
+
+        let granted = TrackNamespacePrefix::from_utf8_path("sports");
+        assert!(decide(
+            &hook,
+            &principal,
+            AuthzOperation::SubscribeNamespace { prefix: &granted }
+        )
+        .await
+        .is_allowed());
+
+        let other = TrackNamespacePrefix::from_utf8_path("news");
+        assert!(!decide(
+            &hook,
+            &principal,
+            AuthzOperation::SubscribeNamespace { prefix: &other }
+        )
+        .await
+        .is_allowed());
+    }
+
+    /// Namespace announcements authorize each concrete namespace as the prefix
+    /// naming exactly it, so a namespace *below* the granted prefix must still
+    /// be announceable. Getting this wrong would silently break discovery for
+    /// every ordinary prefix subscription.
+    #[tokio::test]
+    async fn a_namespace_below_the_granted_prefix_is_announceable() {
+        let key = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(key.pem)]);
+        let principal = principal_for(&hook, subscriber_token(&key.signer, &[b"sports"])).await;
+
+        for path in ["sports", "sports/football", "sports/football/match-42"] {
+            let namespace = TrackNamespacePrefix::from_utf8_path(path);
+            assert!(
+                decide(
+                    &hook,
+                    &principal,
+                    AuthzOperation::SubscribeNamespace { prefix: &namespace }
+                )
+                .await
+                .is_allowed(),
+                "{path} is under the granted prefix and must be announceable"
+            );
+        }
+
+        let outside = TrackNamespacePrefix::from_utf8_path("news/politics");
+        assert!(
+            !decide(
+                &hook,
+                &principal,
+                AuthzOperation::SubscribeNamespace { prefix: &outside }
+            )
+            .await
+            .is_allowed(),
+            "a namespace outside the grant must not be announced"
+        );
+    }
+
+    /// The case the announcement filter exists for: a `nil` terminator limits
+    /// the grant to an exact namespace depth, so deeper namespaces must not be
+    /// disclosed even though the prefix subscription itself is allowed.
+    #[tokio::test]
+    async fn a_nil_terminated_scope_hides_deeper_namespaces() {
+        let key = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(key.pem)]);
+
+        let token = CatTokenBuilder::new()
+            .issuer("test-issuer")
+            .single_audience("test-relay")
+            .subject("test-subject")
+            .expires_in(3600)
+            .moqt_scope(
+                MoqtScopeBuilder::new()
+                    .subscriber()
+                    .action(MoqtAction::ClientSetup)
+                    .namespace_exact(b"sports")
+                    .namespace_nil()
+                    .build(),
+            )
+            .build()
+            .expect("build token");
+        let encoded = Bytes::from(encode_token(&token, &key.signer).unwrap());
+        let principal = principal_for(&hook, encoded).await;
+
+        let granted = TrackNamespacePrefix::from_utf8_path("sports");
+        assert!(
+            decide(
+                &hook,
+                &principal,
+                AuthzOperation::SubscribeNamespace { prefix: &granted }
+            )
+            .await
+            .is_allowed(),
+            "the exact namespace is granted"
+        );
+
+        let deeper = TrackNamespacePrefix::from_utf8_path("sports/football");
+        assert!(
+            !decide(
+                &hook,
+                &principal,
+                AuthzOperation::SubscribeNamespace { prefix: &deeper }
+            )
+            .await
+            .is_allowed(),
+            "a nil terminator must hide deeper namespaces from announcement"
+        );
+    }
+
+    /// A session must stop being authorized once its token expires, even
+    /// though no fresh signature check happens per request.
+    ///
+    /// Driven by rewinding the principal's recorded expiry rather than by
+    /// sleeping: `now_unix` reads the system clock, which a paused tokio
+    /// runtime does not control, so a sleep-based version would have to
+    /// outwait real seconds and would still sit on a truncation boundary.
+    #[tokio::test]
+    async fn a_token_expiring_mid_session_stops_authorizing_requests() {
+        let key = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(key.pem)]);
+
+        let live = principal_for(&hook, publisher_token(&key.signer, &[b"sports"])).await;
+        let namespace = TrackNamespace::from_utf8_path("sports/football");
+
+        // While the token is live the operation is permitted.
+        assert!(decide(
+            &hook,
+            &live,
+            AuthzOperation::PublishNamespace {
+                namespace: &namespace
+            }
+        )
+        .await
+        .is_allowed());
+
+        // Same token and claims, but expiry now comfortably in the past.
+        let claims = live.claims::<CatPrincipal>().expect("cat principal");
+        let expired = rewind_expiry(claims, now_unix() - claims.clock_skew - 60);
+
+        let decision = decide(
+            &hook,
+            &expired,
+            AuthzOperation::PublishNamespace {
+                namespace: &namespace,
+            },
+        )
+        .await;
+        assert!(
+            matches!(decision.deny_reason(), Some(DenyReason::TokenExpired)),
+            "expected expiry, got {:?}",
+            decision.deny_reason()
+        );
+    }
+
+    /// Expiry is evaluated against the skew tolerance, not the raw timestamp.
+    #[tokio::test]
+    async fn expiry_respects_the_clock_skew_tolerance() {
+        let key = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(key.pem)]);
+
+        let live = principal_for(&hook, publisher_token(&key.signer, &[b"sports"])).await;
+        let claims = live.claims::<CatPrincipal>().expect("cat principal");
+        let namespace = TrackNamespace::from_utf8_path("sports/football");
+
+        // Expired a moment ago, but still inside the tolerance window.
+        let within_skew = rewind_expiry(claims, now_unix() - claims.clock_skew / 2);
+
+        assert!(
+            decide(
+                &hook,
+                &within_skew,
+                AuthzOperation::PublishNamespace {
+                    namespace: &namespace
+                }
+            )
+            .await
+            .is_allowed(),
+            "a token inside the skew window must still authorize"
+        );
+    }
+
+    /// A token with no `exp` is unrevokable, so it is refused outright rather
+    /// than becoming a permanent credential.
+    #[tokio::test]
+    async fn a_token_without_an_expiry_is_refused() {
+        let key = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(key.pem)]);
+
+        let token = CatTokenBuilder::new()
+            .issuer("test-issuer")
+            .single_audience("test-relay")
+            .subject("test-subject")
+            .moqt_scope(
+                MoqtScopeBuilder::new()
+                    .publisher()
+                    .namespace_prefix(b"sports")
+                    .track_prefix(b"")
+                    .build(),
+            )
+            .moqt_scope(
+                MoqtScopeBuilder::new()
+                    .action(MoqtAction::ClientSetup)
+                    .build(),
+            )
+            .build()
+            .expect("build token");
+        assert!(token.core.exp.is_none(), "fixture must omit exp");
+
+        let encoded = Bytes::from(encode_token(&token, &key.signer).unwrap());
+        let decision = hook
+            .on_setup(&session(), &[auth_token(encoded)])
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            decision.deny_reason(),
+            Some(DenyReason::TokenInvalid)
+        ));
+    }
+
+    /// An expiry beyond the relay's maximum lifetime is refused: it is the
+    /// unbounded credential the `exp` requirement exists to prevent, and it is
+    /// not a bounded bearer credential.
+    #[tokio::test]
+    async fn an_implausibly_distant_expiry_is_refused() {
+        let key = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(key.pem)]);
+
+        // Bounded above by what chrono can represent, since the fixture builds
+        // the expiry as an offset from now.
+        for expires_in in [MAX_TOKEN_LIFETIME_SECS + 3600, 100 * 365 * 24 * 60 * 60] {
+            let token = mint(&key.signer, &[b"sports"], true, None, expires_in);
+            let decision = hook
+                .on_setup(&session(), &[auth_token(token)])
+                .await
+                .unwrap();
+
+            assert!(
+                !decision.is_allowed(),
+                "expiry {expires_in}s away must be refused"
+            );
+        }
+
+        // Just inside the limit is still accepted.
+        let token = mint(
+            &key.signer,
+            &[b"sports"],
+            true,
+            None,
+            MAX_TOKEN_LIFETIME_SECS - 60,
+        );
+        assert!(hook
+            .on_setup(&session(), &[auth_token(token)])
+            .await
+            .unwrap()
+            .is_allowed());
+    }
+
+    /// A scope may not ask for a skew so large that expiry stops meaning
+    /// anything, nor one that overflows the library's `exp + tolerance`.
+    #[test]
+    fn clock_skew_is_clamped() {
+        let key = generate_key();
+        let config = ScopeAuthConfig::new(vec![AuthPublicKey::es256(key.pem)])
+            .with_clock_skew(Duration::from_secs(u64::MAX));
+
+        let hook = CatAuthHook::new(&config, None).expect("hook builds");
+        assert_eq!(hook.clock_skew, MAX_CLOCK_SKEW_SECS);
+    }
+
+    #[tokio::test]
+    async fn a_token_within_its_lifetime_keeps_authorizing() {
+        let key = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(key.pem)]);
+
+        let live = principal_for(&hook, publisher_token(&key.signer, &[b"sports"])).await;
+        let namespace = TrackNamespace::from_utf8_path("sports/football");
+
+        assert!(decide(
+            &hook,
+            &live,
+            AuthzOperation::PublishNamespace {
+                namespace: &namespace
+            }
+        )
+        .await
+        .is_allowed());
+    }
+
+    #[tokio::test]
+    async fn a_principal_from_another_hook_is_a_fault_not_an_allow() {
+        let key = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(key.pem)]);
+
+        let foreign = Principal::anonymous();
+        let namespace = TrackNamespace::from_utf8_path("sports/football");
+        let request = AuthRequest {
+            session: &session(),
+            principal: &foreign,
+            operation: AuthzOperation::PublishNamespace {
+                namespace: &namespace,
+            },
+            request_id: None,
+        };
+
+        let err = hook
+            .on_request(&request)
+            .await
+            .expect_err("a foreign principal is a fault");
+        assert!(matches!(err, AuthError::Backend(_)), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn authorization_does_not_depend_on_the_relay_scope_string() {
+        // The scope label is for logging; authorization comes from the claims.
+        let key = generate_key();
+        let hook = hook(vec![AuthPublicKey::es256(key.pem)]);
+        let principal = principal_for(&hook, publisher_token(&key.signer, &[b"sports"])).await;
+
+        let namespace = TrackNamespace::from_utf8_path("sports/football");
+        let elsewhere = SessionContext::public(Some("a-completely-different-scope".to_string()));
+        let request = AuthRequest {
+            session: &elsewhere,
+            principal: &principal,
+            operation: AuthzOperation::PublishNamespace {
+                namespace: &namespace,
+            },
+            request_id: None,
+        };
+
+        assert!(hook.on_request(&request).await.unwrap().is_allowed());
+    }
+
+    #[test]
+    fn cat_errors_map_onto_deny_reasons() {
+        assert!(matches!(
+            map_cat_error(CatError::TokenExpired),
+            DenyReason::TokenExpired
+        ));
+        assert!(matches!(
+            map_cat_error(CatError::TokenNotYetValid),
+            DenyReason::TokenExpired
+        ));
+        assert!(matches!(
+            map_cat_error(CatError::InvalidIssuer),
+            DenyReason::IssuerUnknown
+        ));
+        assert!(matches!(
+            map_cat_error(CatError::SignatureVerificationFailed),
+            DenyReason::TokenInvalid
+        ));
+        assert!(matches!(
+            map_cat_error(CatError::InvalidTokenFormat),
+            DenyReason::TokenMalformed
+        ));
+        assert!(matches!(
+            map_cat_error(CatError::ReplayAttackDetected),
+            DenyReason::TokenReplayed
+        ));
+        assert!(matches!(
+            map_cat_error(CatError::MoqtActionNotAuthorized("x".into())),
+            DenyReason::ScopeMismatch
+        ));
+    }
+}

--- a/moq-relay-ietf/src/auth/hook.rs
+++ b/moq-relay-ietf/src/auth/hook.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 Cloudflare Inc., Luke Curley, Mike English and contributors
+// SPDX-FileCopyrightText: 2026 Cloudflare Inc.
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use async_trait::async_trait;

--- a/moq-relay-ietf/src/auth/hook.rs
+++ b/moq-relay-ietf/src/auth/hook.rs
@@ -1,0 +1,170 @@
+// SPDX-FileCopyrightText: 2024-2026 Cloudflare Inc., Luke Curley, Mike English and contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use async_trait::async_trait;
+
+use super::{AuthDecision, AuthError, AuthRequest, AuthToken, DenyReason, Principal};
+use crate::SessionContext;
+
+/// Pluggable authorization for a MoQT session.
+///
+/// A hook is built per scope from [`ScopeConfig::auth`] and shared by every
+/// session in that scope. Both methods are required rather than defaulted: a
+/// default that allows would silently authorize everything in any
+/// implementation that forgot to override it, so the compiler is made to
+/// insist that every hook states a verdict. Use [`AllowAllAuthHook`] to opt
+/// into permissive behaviour explicitly.
+///
+/// # Contract
+///
+/// * [`on_setup`] runs once per session, before either half of the session is
+///   constructed. Denying it terminates the session.
+/// * [`on_request`] runs before every authorization-relevant request, and is
+///   given the [`Principal`] that `on_setup` established. Implementations
+///   should treat it as a hot path and avoid cryptography there — verify at
+///   setup and carry the validated state in the principal.
+/// * Returning `Err` is never an allow. The relay treats it as a denial and
+///   counts it separately as a fault.
+///
+/// [`ScopeConfig::auth`]: crate::ScopeConfig::auth
+/// [`on_setup`]: Self::on_setup
+/// [`on_request`]: Self::on_request
+#[async_trait]
+pub trait AuthHook: Send + Sync {
+    /// Authorize session establishment and establish the peer's identity.
+    ///
+    /// `tokens` holds every AUTHORIZATION TOKEN decoded from CLIENT_SETUP, in
+    /// the order sent, with aliases already resolved. It may be empty; a hook
+    /// that requires a token must deny in that case.
+    async fn on_setup(
+        &self,
+        session: &SessionContext,
+        tokens: &[AuthToken],
+    ) -> Result<AuthDecision, AuthError>;
+
+    /// Authorize a single request against the identity from setup.
+    async fn on_request(&self, request: &AuthRequest<'_>) -> Result<AuthDecision, AuthError>;
+}
+
+/// A hook that allows every operation.
+///
+/// Provided so that permissive behaviour is something a deployment names
+/// explicitly. The relay does not install it by default: a scope with no
+/// [`ScopeConfig::auth`] runs with no hook at all, which costs nothing on the
+/// request path.
+///
+/// [`ScopeConfig::auth`]: crate::ScopeConfig::auth
+pub struct AllowAllAuthHook;
+
+#[async_trait]
+impl AuthHook for AllowAllAuthHook {
+    async fn on_setup(
+        &self,
+        _session: &SessionContext,
+        _tokens: &[AuthToken],
+    ) -> Result<AuthDecision, AuthError> {
+        Ok(AuthDecision::allow(Principal::anonymous()))
+    }
+
+    async fn on_request(&self, _request: &AuthRequest<'_>) -> Result<AuthDecision, AuthError> {
+        Ok(AuthDecision::allow(Principal::anonymous()))
+    }
+}
+
+/// A hook that denies every operation.
+///
+/// Installed for a scope whose authorization configuration cannot be turned
+/// into a working hook, so that a misconfiguration fails closed for the whole
+/// scope instead of admitting sessions unauthenticated. The reason is captured
+/// once at construction and reported on every denial.
+pub(crate) struct DenyAllAuthHook {
+    reason: String,
+}
+
+impl DenyAllAuthHook {
+    pub(crate) fn new(reason: impl Into<String>) -> Self {
+        Self {
+            reason: reason.into(),
+        }
+    }
+
+    fn deny(&self) -> AuthDecision {
+        AuthDecision::deny(DenyReason::PolicyDenied {
+            message: self.reason.clone(),
+        })
+    }
+}
+
+#[async_trait]
+impl AuthHook for DenyAllAuthHook {
+    async fn on_setup(
+        &self,
+        _session: &SessionContext,
+        _tokens: &[AuthToken],
+    ) -> Result<AuthDecision, AuthError> {
+        Ok(self.deny())
+    }
+
+    async fn on_request(&self, _request: &AuthRequest<'_>) -> Result<AuthDecision, AuthError> {
+        Ok(self.deny())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::AuthzOperation;
+    use moq_transport::coding::TrackNamespace;
+
+    fn session() -> SessionContext {
+        SessionContext::public(Some("scope-a".to_string()))
+    }
+
+    #[tokio::test]
+    async fn allow_all_allows_setup_and_requests() {
+        let hook = AllowAllAuthHook;
+        let session = session();
+
+        assert!(hook.on_setup(&session, &[]).await.unwrap().is_allowed());
+
+        let namespace = TrackNamespace::from_utf8_path("sports/football");
+        let principal = Principal::anonymous();
+        let request = AuthRequest {
+            session: &session,
+            principal: &principal,
+            operation: AuthzOperation::PublishNamespace {
+                namespace: &namespace,
+            },
+            request_id: Some(1),
+        };
+
+        assert!(hook.on_request(&request).await.unwrap().is_allowed());
+    }
+
+    #[tokio::test]
+    async fn deny_all_denies_setup_and_requests() {
+        let hook = DenyAllAuthHook::new("no keys configured");
+        let session = session();
+
+        let decision = hook.on_setup(&session, &[]).await.unwrap();
+        assert!(!decision.is_allowed());
+        assert!(decision
+            .deny_reason()
+            .unwrap()
+            .to_string()
+            .contains("no keys"));
+
+        let namespace = TrackNamespace::from_utf8_path("sports/football");
+        let principal = Principal::anonymous();
+        let request = AuthRequest {
+            session: &session,
+            principal: &principal,
+            operation: AuthzOperation::PublishNamespace {
+                namespace: &namespace,
+            },
+            request_id: Some(1),
+        };
+
+        assert!(!hook.on_request(&request).await.unwrap().is_allowed());
+    }
+}

--- a/moq-relay-ietf/src/auth/mod.rs
+++ b/moq-relay-ietf/src/auth/mod.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 Cloudflare Inc., Luke Curley, Mike English and contributors
+// SPDX-FileCopyrightText: 2026 Cloudflare Inc.
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 //! Session and request authorization for the relay.
@@ -89,6 +89,8 @@ pub(crate) use scope::ScopeAuthorizer;
 pub(crate) use session::{authorize, SessionAuth};
 
 use crate::DEFAULT_SCOPE_AUTH_TTL;
+
+const UNSCOPED: &str = "<unscoped>";
 
 /// Session termination code for UNAUTHORIZED (draft-16 §13.4.1).
 pub(crate) const SESSION_ERROR_UNAUTHORIZED: u32 = 0x2;

--- a/moq-relay-ietf/src/auth/mod.rs
+++ b/moq-relay-ietf/src/auth/mod.rs
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: 2024-2026 Cloudflare Inc., Luke Curley, Mike English and contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Session and request authorization for the relay.
+//!
+//! # Model
+//!
+//! Authorization is a per-scope policy, not a relay-wide switch. After
+//! [`Coordinator::resolve_scope`] identifies which scope a connection belongs
+//! to, [`Coordinator::get_scope_config`] supplies that scope's
+//! [`ScopeAuthConfig`], including the public keys used to verify tokens. A
+//! scope that returns no policy runs exactly as it did before this module
+//! existed.
+//!
+//! Where a policy is present, enforcement happens at two points:
+//!
+//! * **Setup.** The AUTHORIZATION TOKEN parameters from CLIENT_SETUP are
+//!   decoded (see [`decode_setup_tokens`]) and handed to
+//!   [`AuthHook::on_setup`]. A denial terminates the session before either
+//!   half of it is constructed.
+//! * **Request.** Every SUBSCRIBE, SUBSCRIBE_NAMESPACE, TRACK_STATUS,
+//!   PUBLISH_NAMESPACE and PUBLISH is checked with [`AuthHook::on_request`]
+//!   before the relay acts on it. A denial rejects that request and leaves the
+//!   session running.
+//!
+//! Cryptography is confined to setup. The identity established there is
+//! carried in a [`Principal`], so per-request checks are pure claim
+//! evaluation. Expiry is re-checked on every request, so no *new* request is
+//! authorized more than [`ScopeAuthConfig::clock_skew`] past the token's
+//! `exp`. That tolerance exists to absorb clock differences between issuer
+//! and relay, and it applies to the per-request check exactly as it does at
+//! setup — so "expired" in practice means `exp + clock_skew`, not `exp`. The
+//! CAT hook clamps the configured value so a scope cannot widen the window
+//! indefinitely.
+//!
+//! # Revocation, and what it does not cover
+//!
+//! Rotating a scope's keys stops new sessions being established with the old
+//! key within one [`ScopeAuthConfig::ttl`], but does **not** terminate
+//! sessions already running: a session holds the hook it was admitted with.
+//! Token expiry is therefore what bounds a compromised credential, which is
+//! why the CAT hook requires `exp` and caps how far ahead it may be.
+//!
+//! Expiry bounds *admission*, not *delivery*. A SUBSCRIBE authorized before
+//! the token expired keeps streaming afterwards, because nothing revisits an
+//! established subscription — so a leaked token buys media for as long as the
+//! session survives, not merely until `exp`. Tearing down in-flight
+//! subscriptions at expiry, and re-resolving the hook when a scope's
+//! configuration changes, are the two pieces that would close this; neither is
+//! implemented.
+//!
+//! # Failing closed
+//!
+//! Once a scope has opted in, anything short of an explicit allow denies:
+//!
+//! * a coordinator that cannot be reached,
+//! * a configuration with no keys, too many keys, or unparseable key material,
+//! * a relay built without the scheme's feature,
+//! * a hook that returns an error,
+//! * a missing, malformed, expired or out-of-scope token.
+//!
+//! The one deliberate exception is a scope that never opted in, which is not
+//! an authorization failure but the absence of a policy.
+//!
+//! [`Coordinator::resolve_scope`]: crate::Coordinator::resolve_scope
+//! [`Coordinator::get_scope_config`]: crate::Coordinator::get_scope_config
+//! [`ScopeAuthConfig`]: crate::ScopeAuthConfig
+
+mod hook;
+mod scope;
+mod session;
+mod token;
+mod types;
+
+#[cfg(feature = "auth-cat")]
+mod cat;
+
+pub use hook::{AllowAllAuthHook, AuthHook};
+pub use token::{decode_setup_tokens, TokenError, CAT_TOKEN_TYPE, MAX_SETUP_TOKENS};
+pub use types::{
+    AuthDecision, AuthError, AuthRequest, AuthToken, AuthzOperation, DenyReason, Principal, Verdict,
+};
+
+#[cfg(feature = "auth-cat")]
+pub use cat::CatAuthHook;
+
+pub(crate) use hook::DenyAllAuthHook;
+pub(crate) use scope::ScopeAuthorizer;
+pub(crate) use session::{authorize, SessionAuth};
+
+use crate::DEFAULT_SCOPE_AUTH_TTL;
+
+/// Session termination code for UNAUTHORIZED (draft-16 §13.4.1).
+pub(crate) const SESSION_ERROR_UNAUTHORIZED: u32 = 0x2;

--- a/moq-relay-ietf/src/auth/scope.rs
+++ b/moq-relay-ietf/src/auth/scope.rs
@@ -1,0 +1,583 @@
+// SPDX-FileCopyrightText: 2024-2026 Cloudflare Inc., Luke Curley, Mike English and contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Resolves a scope's authorization policy into a hook, and caches it.
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+use std::time::{Duration, Instant};
+
+use super::{AuthError, AuthHook, DenyAllAuthHook};
+use crate::{Coordinator, ScopeAuthConfig};
+
+/// How long an unusable configuration is cached before it is retried.
+///
+/// Short enough that fixing a misconfiguration takes effect promptly, long
+/// enough that a broken scope under load does not turn into a retry storm
+/// against the coordinator.
+const BROKEN_CONFIG_TTL: Duration = Duration::from_secs(30);
+
+/// Builds and caches the authorization hook for each scope.
+///
+/// [`Coordinator::get_scope_config`] is the source of truth for a scope's
+/// keys, but calling it per connection would put a coordinator round-trip and
+/// a set of PEM parses on the accept path. Results are therefore cached for
+/// [`ScopeAuthConfig::ttl`], which also bounds how long a key rotation takes
+/// to reach new sessions.
+pub(crate) struct ScopeAuthorizer {
+    coordinator: Arc<dyn Coordinator>,
+    cache: RwLock<HashMap<Option<String>, CacheEntry>>,
+}
+
+#[derive(Clone)]
+struct CacheEntry {
+    state: CacheState,
+    expires_at: Instant,
+}
+
+#[derive(Clone)]
+enum CacheState {
+    /// The scope requires token authorization.
+    Enforced(Arc<dyn AuthHook>),
+    /// The scope did not opt in; sessions skip authorization entirely.
+    Disabled,
+}
+
+impl ScopeAuthorizer {
+    pub(crate) fn new(coordinator: Arc<dyn Coordinator>) -> Self {
+        Self {
+            coordinator,
+            cache: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// The hook for a scope, or `None` if the scope does not require
+    /// authorization.
+    ///
+    /// Returns `Err` only when the scope's policy could not be determined at
+    /// all — the caller must fail closed, since it cannot know whether the
+    /// scope requires a token.
+    pub(crate) async fn resolve(
+        &self,
+        scope: Option<&str>,
+    ) -> Result<Option<Arc<dyn AuthHook>>, AuthError> {
+        if let Some(entry) = self.cached(scope) {
+            return Ok(entry.into_hook());
+        }
+
+        let config = self
+            .coordinator
+            .get_scope_config(scope)
+            .await
+            .map_err(|err| AuthError::Backend(format!("get_scope_config failed: {err}")))?;
+
+        let (state, ttl) = match config.auth {
+            None => {
+                // Logged once per TTL rather than per connection. "No policy"
+                // is a legitimate configuration, but it is indistinguishable
+                // from a coordinator that forgot to implement
+                // `get_scope_config`, so it should be visible in logs rather
+                // than inferred from the absence of anything.
+                tracing::info!(
+                    scope = scope.unwrap_or("<unscoped>"),
+                    "scope has no token authorization policy; admitting sessions on \
+                     scope permissions alone"
+                );
+                (CacheState::Disabled, super::DEFAULT_SCOPE_AUTH_TTL)
+            }
+            Some(auth) => {
+                let ttl = auth.effective_ttl();
+                match build_hook(&auth, scope) {
+                    Ok(hook) => (CacheState::Enforced(hook), ttl),
+                    // A scope that asked for authorization but cannot have it
+                    // must refuse every session, not run unauthenticated.
+                    Err(err) => {
+                        tracing::error!(
+                            scope = scope.unwrap_or("<unscoped>"),
+                            error = %err,
+                            "scope requires token authorization but its configuration is unusable; \
+                             refusing all sessions in this scope"
+                        );
+                        metrics::counter!(
+                            "moq_relay_auth_errors_total",
+                            "stage" => "scope_config"
+                        )
+                        .increment(1);
+                        (
+                            CacheState::Enforced(Arc::new(DenyAllAuthHook::new(err.to_string()))),
+                            BROKEN_CONFIG_TTL,
+                        )
+                    }
+                }
+            }
+        };
+
+        self.store(scope, state.clone(), ttl);
+
+        Ok(CacheEntry {
+            state,
+            expires_at: Instant::now() + ttl,
+        }
+        .into_hook())
+    }
+
+    fn cached(&self, scope: Option<&str>) -> Option<CacheEntry> {
+        let cache = self.cache.read().unwrap_or_else(|err| err.into_inner());
+        // `Option<&str>` cannot look up an `Option<String>` key directly, and
+        // the map is small (one entry per active scope), so an equality scan
+        // avoids allocating a key on every cache hit.
+        cache
+            .iter()
+            .find(|(key, _)| key.as_deref() == scope)
+            .map(|(_, entry)| entry)
+            .filter(|entry| entry.expires_at > Instant::now())
+            .cloned()
+    }
+
+    fn store(&self, scope: Option<&str>, state: CacheState, ttl: Duration) {
+        let mut cache = self.cache.write().unwrap_or_else(|err| err.into_inner());
+        cache.insert(
+            scope.map(str::to_string),
+            CacheEntry {
+                state,
+                expires_at: Instant::now() + ttl,
+            },
+        );
+    }
+
+    /// Drop a scope's cached policy, forcing the next session to re-fetch it.
+    #[cfg(test)]
+    pub(crate) fn invalidate(&self, scope: Option<&str>) {
+        let mut cache = self.cache.write().unwrap_or_else(|err| err.into_inner());
+        cache.retain(|key, _| key.as_deref() != scope);
+    }
+}
+
+impl CacheEntry {
+    fn into_hook(self) -> Option<Arc<dyn AuthHook>> {
+        match self.state {
+            CacheState::Enforced(hook) => Some(hook),
+            CacheState::Disabled => None,
+        }
+    }
+}
+
+/// Build the hook a scope's configuration calls for.
+///
+/// Separated from [`ScopeAuthorizer::resolve`] so that the feature boundary is
+/// a single function rather than a `cfg` scattered through the cache logic.
+fn build_hook(
+    config: &ScopeAuthConfig,
+    scope: Option<&str>,
+) -> Result<Arc<dyn AuthHook>, AuthError> {
+    #[cfg(feature = "auth-cat")]
+    {
+        Ok(Arc::new(super::CatAuthHook::new(config, scope)?))
+    }
+
+    #[cfg(not(feature = "auth-cat"))]
+    {
+        // Silence unused-parameter warnings without changing the signature.
+        let _ = (config, scope);
+        Err(AuthError::Configuration(
+            "relay was built without the `auth-cat` feature, so it cannot verify \
+             the tokens this scope requires"
+                .to_string(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use async_trait::async_trait;
+    use moq_native_ietf::quic;
+    use moq_transport::coding::TrackNamespace;
+
+    use crate::{
+        AuthPublicKey, CoordinatorContext, CoordinatorError, CoordinatorResult, NamespaceOrigin,
+        NamespaceRegistration, ScopeConfig,
+    };
+
+    /// A coordinator that returns a scripted config and counts calls, so the
+    /// tests can assert on caching rather than on wall-clock behaviour.
+    struct ScriptedCoordinator {
+        config: std::sync::Mutex<ScopeConfig>,
+        calls: AtomicUsize,
+        fail: std::sync::atomic::AtomicBool,
+    }
+
+    impl ScriptedCoordinator {
+        fn new(config: ScopeConfig) -> Self {
+            Self {
+                config: std::sync::Mutex::new(config),
+                calls: AtomicUsize::new(0),
+                fail: std::sync::atomic::AtomicBool::new(false),
+            }
+        }
+
+        fn calls(&self) -> usize {
+            self.calls.load(Ordering::SeqCst)
+        }
+
+        /// Only the key-rotation test needs to change the scripted config, and
+        /// that test requires a hook that actually builds.
+        #[cfg(feature = "auth-cat")]
+        fn set_config(&self, config: ScopeConfig) {
+            *self.config.lock().unwrap() = config;
+        }
+
+        fn set_failing(&self, failing: bool) {
+            self.fail.store(failing, Ordering::SeqCst);
+        }
+    }
+
+    #[async_trait]
+    impl Coordinator for ScriptedCoordinator {
+        async fn register_namespace(
+            &self,
+            _scope: Option<&str>,
+            _namespace: &TrackNamespace,
+            _context: &CoordinatorContext,
+        ) -> CoordinatorResult<NamespaceRegistration> {
+            Ok(NamespaceRegistration::new(()))
+        }
+
+        async fn unregister_namespace(
+            &self,
+            _scope: Option<&str>,
+            _namespace: &TrackNamespace,
+        ) -> CoordinatorResult<()> {
+            Ok(())
+        }
+
+        async fn lookup(
+            &self,
+            _scope: Option<&str>,
+            _namespace: &TrackNamespace,
+        ) -> CoordinatorResult<(NamespaceOrigin, Option<quic::Client>)> {
+            Err(CoordinatorError::NamespaceNotFound)
+        }
+
+        async fn get_scope_config(&self, _scope: Option<&str>) -> CoordinatorResult<ScopeConfig> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            if self.fail.load(Ordering::SeqCst) {
+                return Err(CoordinatorError::Other(anyhow::anyhow!("backend down")));
+            }
+            Ok(self.config.lock().unwrap().clone())
+        }
+    }
+
+    /// A syntactically valid ES256 public key, so configuration parses.
+    fn valid_pem() -> String {
+        use p256::ecdsa::SigningKey;
+        use p256::pkcs8::EncodePublicKey;
+
+        let signing = SigningKey::random(&mut rand_core_compat());
+        p256::ecdsa::VerifyingKey::from(&signing)
+            .to_public_key_pem(Default::default())
+            .expect("pem")
+    }
+
+    /// `p256` re-exports the RNG its own API expects; using it avoids pinning a
+    /// separate `rand` version in dev-dependencies.
+    fn rand_core_compat() -> impl p256::elliptic_curve::rand_core::CryptoRngCore {
+        p256::elliptic_curve::rand_core::OsRng
+    }
+
+    fn enforced_config() -> ScopeConfig {
+        ScopeConfig {
+            auth: Some(ScopeAuthConfig::new(vec![
+                AuthPublicKey::es256(valid_pem()),
+            ])),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn a_scope_without_auth_config_needs_no_hook() {
+        let coordinator = Arc::new(ScriptedCoordinator::new(ScopeConfig::default()));
+        let authorizer = ScopeAuthorizer::new(coordinator.clone());
+
+        assert!(authorizer.resolve(Some("open")).await.unwrap().is_none());
+        assert_eq!(coordinator.calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn results_are_cached_per_scope() {
+        let coordinator = Arc::new(ScriptedCoordinator::new(ScopeConfig::default()));
+        let authorizer = ScopeAuthorizer::new(coordinator.clone());
+
+        for _ in 0..5 {
+            authorizer.resolve(Some("tenant")).await.unwrap();
+        }
+        assert_eq!(coordinator.calls(), 1, "repeat resolves must hit the cache");
+
+        // A different scope is a separate cache entry.
+        authorizer.resolve(Some("other")).await.unwrap();
+        assert_eq!(coordinator.calls(), 2);
+
+        // The unscoped session is its own entry, distinct from any named scope.
+        authorizer.resolve(None).await.unwrap();
+        assert_eq!(coordinator.calls(), 3);
+        authorizer.resolve(None).await.unwrap();
+        assert_eq!(coordinator.calls(), 3);
+    }
+
+    /// A usable policy is cached for the TTL the coordinator asked for, so an
+    /// already-elapsed TTL forces a refetch. Needs the feature, since without
+    /// it the policy is unbuildable and takes the broken-config path below.
+    #[cfg(feature = "auth-cat")]
+    #[tokio::test]
+    async fn an_expired_entry_is_refetched() {
+        let coordinator = Arc::new(ScriptedCoordinator::new(ScopeConfig {
+            auth: Some(
+                ScopeAuthConfig::new(vec![AuthPublicKey::es256(valid_pem())])
+                    // Already elapsed by the time the next resolve runs.
+                    .with_ttl(Duration::from_nanos(1)),
+            ),
+            ..Default::default()
+        }));
+        let authorizer = ScopeAuthorizer::new(coordinator.clone());
+
+        authorizer.resolve(Some("tenant")).await.ok();
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        authorizer.resolve(Some("tenant")).await.ok();
+
+        assert_eq!(coordinator.calls(), 2, "an expired entry must be refetched");
+    }
+
+    /// An unusable policy is cached too, on its own shorter TTL, so a broken
+    /// scope under load does not turn into a retry storm against the
+    /// coordinator. It must still deny throughout.
+    #[tokio::test]
+    async fn a_broken_config_is_cached_and_keeps_denying() {
+        // Unbuildable in both configurations: with the feature because the key
+        // list is empty, without it because the scheme is unavailable.
+        let coordinator = Arc::new(ScriptedCoordinator::new(ScopeConfig {
+            auth: Some(
+                ScopeAuthConfig::new(vec![])
+                    // Ignored in favour of BROKEN_CONFIG_TTL.
+                    .with_ttl(Duration::from_nanos(1)),
+            ),
+            ..Default::default()
+        }));
+        let authorizer = ScopeAuthorizer::new(coordinator.clone());
+        let session = crate::SessionContext::public(Some("tenant".to_string()));
+
+        for _ in 0..3 {
+            let hook = authorizer.resolve(Some("tenant")).await.unwrap().unwrap();
+            assert!(
+                !hook.on_setup(&session, &[]).await.unwrap().is_allowed(),
+                "a broken scope must deny on every resolve"
+            );
+            tokio::time::sleep(Duration::from_millis(2)).await;
+        }
+
+        assert_eq!(
+            coordinator.calls(),
+            1,
+            "a broken config must be cached, not refetched per connection"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_coordinator_failure_fails_closed() {
+        let coordinator = Arc::new(ScriptedCoordinator::new(ScopeConfig::default()));
+        coordinator.set_failing(true);
+        let authorizer = ScopeAuthorizer::new(coordinator.clone());
+
+        // Not `Ok(None)`: the relay must not admit a session merely because it
+        // could not find out whether the scope requires a token.
+        let err = authorizer
+            .resolve(Some("tenant"))
+            .await
+            .err()
+            .expect("a backend failure must surface");
+        assert!(matches!(err, AuthError::Backend(_)), "{err:?}");
+    }
+
+    #[tokio::test]
+    async fn a_failure_is_not_cached_as_permissive() {
+        let coordinator = Arc::new(ScriptedCoordinator::new(ScopeConfig::default()));
+        coordinator.set_failing(true);
+        let authorizer = ScopeAuthorizer::new(coordinator.clone());
+
+        assert!(authorizer.resolve(Some("tenant")).await.is_err());
+
+        // Once the backend recovers the scope resolves normally: the failure
+        // left no poisoned entry behind.
+        coordinator.set_failing(false);
+        assert!(authorizer.resolve(Some("tenant")).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn an_unusable_config_denies_rather_than_disables() {
+        let coordinator = Arc::new(ScriptedCoordinator::new(ScopeConfig {
+            // Enabled but with no keys: unusable.
+            auth: Some(ScopeAuthConfig::new(vec![])),
+            ..Default::default()
+        }));
+        let authorizer = ScopeAuthorizer::new(coordinator.clone());
+
+        let hook = authorizer
+            .resolve(Some("tenant"))
+            .await
+            .unwrap()
+            .expect("a broken scope must still get a hook, not be waved through");
+
+        let session = crate::SessionContext::public(Some("tenant".to_string()));
+        assert!(!hook.on_setup(&session, &[]).await.unwrap().is_allowed());
+    }
+
+    #[tokio::test]
+    async fn too_many_keys_denies_rather_than_disables() {
+        let keys = (0..crate::MAX_SCOPE_AUTH_KEYS + 1)
+            .map(|_| AuthPublicKey::es256(valid_pem()))
+            .collect();
+        let coordinator = Arc::new(ScriptedCoordinator::new(ScopeConfig {
+            auth: Some(ScopeAuthConfig::new(keys)),
+            ..Default::default()
+        }));
+        let authorizer = ScopeAuthorizer::new(coordinator.clone());
+
+        let hook = authorizer.resolve(Some("tenant")).await.unwrap().unwrap();
+        let session = crate::SessionContext::public(Some("tenant".to_string()));
+        assert!(!hook.on_setup(&session, &[]).await.unwrap().is_allowed());
+    }
+
+    /// Without the feature, a scope that requires tokens cannot be served, so
+    /// it must refuse sessions rather than run unauthenticated.
+    #[cfg(not(feature = "auth-cat"))]
+    #[tokio::test]
+    async fn a_scope_requiring_tokens_is_refused_without_the_feature() {
+        let coordinator = Arc::new(ScriptedCoordinator::new(enforced_config()));
+        let authorizer = ScopeAuthorizer::new(coordinator.clone());
+
+        let hook = authorizer.resolve(Some("tenant")).await.unwrap().unwrap();
+        let session = crate::SessionContext::public(Some("tenant".to_string()));
+        let decision = hook.on_setup(&session, &[]).await.unwrap();
+
+        assert!(!decision.is_allowed());
+        assert!(
+            decision
+                .deny_reason()
+                .unwrap()
+                .to_string()
+                .contains("auth-cat"),
+            "the denial should name the missing feature"
+        );
+
+        // The request path must deny too. A hook that refused setup but waved
+        // requests through would be no protection at all for any session that
+        // reached the request stage by another route.
+        let namespace = TrackNamespace::from_utf8_path("sports/football");
+        let track = moq_transport::coding::TrackName::from("video");
+        let auth = crate::auth::SessionAuth::new(hook, crate::auth::Principal::anonymous());
+
+        for operation in [
+            crate::auth::AuthzOperation::PublishNamespace {
+                namespace: &namespace,
+            },
+            crate::auth::AuthzOperation::Publish {
+                namespace: &namespace,
+                track: &track,
+            },
+            crate::auth::AuthzOperation::Subscribe {
+                namespace: &namespace,
+                track: &track,
+            },
+        ] {
+            let label = operation.label();
+            assert!(
+                crate::auth::authorize(Some(&auth), &session, operation, None)
+                    .await
+                    .is_err(),
+                "{label} must be denied without the feature"
+            );
+        }
+    }
+
+    #[cfg(feature = "auth-cat")]
+    #[tokio::test]
+    async fn a_well_formed_scope_gets_a_working_hook() {
+        let coordinator = Arc::new(ScriptedCoordinator::new(enforced_config()));
+        let authorizer = ScopeAuthorizer::new(coordinator.clone());
+
+        let hook = authorizer.resolve(Some("tenant")).await.unwrap().unwrap();
+        let session = crate::SessionContext::public(Some("tenant".to_string()));
+
+        // No token presented, so denied - but by the CAT hook, on the merits.
+        let decision = hook.on_setup(&session, &[]).await.unwrap();
+        assert!(matches!(
+            decision.deny_reason(),
+            Some(crate::auth::DenyReason::TokenMissing)
+        ));
+    }
+
+    #[cfg(feature = "auth-cat")]
+    #[tokio::test]
+    async fn rotating_keys_reaches_new_sessions_after_the_ttl() {
+        let coordinator = Arc::new(ScriptedCoordinator::new(ScopeConfig {
+            auth: Some(
+                ScopeAuthConfig::new(vec![AuthPublicKey::es256(valid_pem())])
+                    .with_ttl(Duration::from_nanos(1)),
+            ),
+            ..Default::default()
+        }));
+        let authorizer = ScopeAuthorizer::new(coordinator.clone());
+
+        authorizer.resolve(Some("tenant")).await.unwrap();
+
+        // Rotate to a configuration the relay cannot use; after the TTL the
+        // scope must pick it up and start refusing.
+        coordinator.set_config(ScopeConfig {
+            auth: Some(ScopeAuthConfig::new(vec![])),
+            ..Default::default()
+        });
+        tokio::time::sleep(Duration::from_millis(5)).await;
+
+        let hook = authorizer.resolve(Some("tenant")).await.unwrap().unwrap();
+        let session = crate::SessionContext::public(Some("tenant".to_string()));
+        assert!(!hook.on_setup(&session, &[]).await.unwrap().is_allowed());
+        assert_eq!(coordinator.calls(), 2);
+    }
+
+    #[tokio::test]
+    async fn concurrent_resolves_are_consistent() {
+        // The cache is shared across connection tasks; this exercises the lock
+        // discipline under contention rather than asserting a call count, since
+        // concurrent misses may legitimately each fetch.
+        let coordinator = Arc::new(ScriptedCoordinator::new(ScopeConfig::default()));
+        let authorizer = Arc::new(ScopeAuthorizer::new(coordinator.clone()));
+
+        let mut tasks = Vec::new();
+        for _ in 0..32 {
+            let authorizer = authorizer.clone();
+            tasks.push(tokio::spawn(async move {
+                authorizer.resolve(Some("tenant")).await.unwrap().is_none()
+            }));
+        }
+
+        for task in tasks {
+            assert!(task.await.unwrap(), "every resolve must agree");
+        }
+    }
+
+    #[tokio::test]
+    async fn invalidate_forces_a_refetch() {
+        let coordinator = Arc::new(ScriptedCoordinator::new(ScopeConfig::default()));
+        let authorizer = ScopeAuthorizer::new(coordinator.clone());
+
+        authorizer.resolve(Some("tenant")).await.unwrap();
+        authorizer.resolve(Some("tenant")).await.unwrap();
+        assert_eq!(coordinator.calls(), 1);
+
+        authorizer.invalidate(Some("tenant"));
+        authorizer.resolve(Some("tenant")).await.unwrap();
+        assert_eq!(coordinator.calls(), 2);
+    }
+}

--- a/moq-relay-ietf/src/auth/scope.rs
+++ b/moq-relay-ietf/src/auth/scope.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 Cloudflare Inc., Luke Curley, Mike English and contributors
+// SPDX-FileCopyrightText: 2026 Cloudflare Inc.
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 //! Resolves a scope's authorization policy into a hook, and caches it.
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 
-use super::{AuthError, AuthHook, DenyAllAuthHook};
+use super::{AuthError, AuthHook, DenyAllAuthHook, UNSCOPED};
 use crate::{Coordinator, ScopeAuthConfig};
 
 /// How long an unusable configuration is cached before it is retried.
@@ -79,7 +79,7 @@ impl ScopeAuthorizer {
                 // `get_scope_config`, so it should be visible in logs rather
                 // than inferred from the absence of anything.
                 tracing::info!(
-                    scope = scope.unwrap_or("<unscoped>"),
+                    scope = scope.unwrap_or(UNSCOPED),
                     "scope has no token authorization policy; admitting sessions on \
                      scope permissions alone"
                 );
@@ -93,7 +93,7 @@ impl ScopeAuthorizer {
                     // must refuse every session, not run unauthenticated.
                     Err(err) => {
                         tracing::error!(
-                            scope = scope.unwrap_or("<unscoped>"),
+                            scope = scope.unwrap_or(UNSCOPED),
                             error = %err,
                             "scope requires token authorization but its configuration is unusable; \
                              refusing all sessions in this scope"

--- a/moq-relay-ietf/src/auth/session.rs
+++ b/moq-relay-ietf/src/auth/session.rs
@@ -1,0 +1,218 @@
+// SPDX-FileCopyrightText: 2024-2026 Cloudflare Inc., Luke Curley, Mike English and contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Per-session authorization state, carried by the producer and consumer.
+
+use std::sync::Arc;
+
+use super::{AuthHook, AuthRequest, AuthzOperation, DenyReason, Principal};
+use crate::SessionContext;
+
+/// The authorization state of one established session.
+///
+/// Created after [`AuthHook::on_setup`] allows the session, then cloned into
+/// the producer and consumer. Sessions in a scope that does not require
+/// authorization carry `None` instead, so the request path costs a single
+/// `Option` check.
+#[derive(Clone)]
+pub(crate) struct SessionAuth {
+    hook: Arc<dyn AuthHook>,
+    principal: Principal,
+}
+
+impl SessionAuth {
+    pub(crate) fn new(hook: Arc<dyn AuthHook>, principal: Principal) -> Self {
+        Self { hook, principal }
+    }
+
+    /// The authenticated subject, for logging.
+    pub(crate) fn subject(&self) -> Option<&str> {
+        self.principal.subject()
+    }
+
+    /// Authorize one operation.
+    ///
+    /// A hook fault is reported as a denial: the relay must not proceed with
+    /// an operation it failed to authorize. The two cases are still
+    /// distinguished in logs and metrics, because a fault indicates a relay or
+    /// configuration problem rather than a misbehaving peer.
+    pub(crate) async fn authorize(
+        &self,
+        session: &SessionContext,
+        operation: AuthzOperation<'_>,
+        request_id: Option<u64>,
+    ) -> Result<(), DenyReason> {
+        let label = operation.label();
+
+        let request = AuthRequest {
+            session,
+            principal: &self.principal,
+            operation,
+            request_id,
+        };
+
+        let decision = match self.hook.on_request(&request).await {
+            Ok(decision) => decision,
+            Err(err) => {
+                tracing::error!(
+                    scope = session.scope().unwrap_or("<unscoped>"),
+                    subject = self.subject(),
+                    operation = label,
+                    error = %err,
+                    "authorization hook failed; denying"
+                );
+                metrics::counter!(
+                    "moq_relay_auth_errors_total",
+                    "stage" => "request"
+                )
+                .increment(1);
+                return Err(DenyReason::HookFault {
+                    message: "authorization unavailable".to_string(),
+                });
+            }
+        };
+
+        match decision.into_principal() {
+            Ok(_) => Ok(()),
+            Err(reason) => {
+                tracing::debug!(
+                    scope = session.scope().unwrap_or("<unscoped>"),
+                    subject = self.subject(),
+                    operation = label,
+                    reason = %reason,
+                    "request denied"
+                );
+                metrics::counter!(
+                    "moq_relay_auth_denied_total",
+                    "phase" => "request",
+                    "operation" => label,
+                    "reason" => reason.label(),
+                )
+                .increment(1);
+                Err(reason)
+            }
+        }
+    }
+}
+
+/// Authorize an operation when the session may not require authorization.
+///
+/// Sessions in scopes without an authorization policy carry no [`SessionAuth`]
+/// and are always permitted. Keeping that check in one place stops each call
+/// site from re-deriving the `None` case.
+pub(crate) async fn authorize(
+    auth: Option<&SessionAuth>,
+    session: &SessionContext,
+    operation: AuthzOperation<'_>,
+    request_id: Option<u64>,
+) -> Result<(), DenyReason> {
+    match auth {
+        Some(auth) => auth.authorize(session, operation, request_id).await,
+        None => Ok(()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::{AllowAllAuthHook, AuthDecision, AuthError, AuthToken, DenyAllAuthHook};
+
+    use async_trait::async_trait;
+    use moq_transport::coding::TrackNamespace;
+
+    struct FaultyHook;
+
+    #[async_trait]
+    impl AuthHook for FaultyHook {
+        async fn on_setup(
+            &self,
+            _session: &SessionContext,
+            _tokens: &[AuthToken],
+        ) -> Result<AuthDecision, AuthError> {
+            Err(AuthError::Backend("boom".to_string()))
+        }
+
+        async fn on_request(&self, _request: &AuthRequest<'_>) -> Result<AuthDecision, AuthError> {
+            Err(AuthError::Backend("boom".to_string()))
+        }
+    }
+
+    fn session() -> SessionContext {
+        SessionContext::public(Some("scope".to_string()))
+    }
+
+    #[tokio::test]
+    async fn no_auth_state_permits_the_operation() {
+        let namespace = TrackNamespace::from_utf8_path("sports");
+        let result = authorize(
+            None,
+            &session(),
+            AuthzOperation::PublishNamespace {
+                namespace: &namespace,
+            },
+            None,
+        )
+        .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn an_allowing_hook_permits_the_operation() {
+        let auth = SessionAuth::new(Arc::new(AllowAllAuthHook), Principal::anonymous());
+        let namespace = TrackNamespace::from_utf8_path("sports");
+
+        assert!(authorize(
+            Some(&auth),
+            &session(),
+            AuthzOperation::PublishNamespace {
+                namespace: &namespace
+            },
+            Some(1),
+        )
+        .await
+        .is_ok());
+    }
+
+    #[tokio::test]
+    async fn a_denying_hook_blocks_the_operation() {
+        let auth = SessionAuth::new(
+            Arc::new(DenyAllAuthHook::new("nope")),
+            Principal::anonymous(),
+        );
+        let namespace = TrackNamespace::from_utf8_path("sports");
+
+        assert!(authorize(
+            Some(&auth),
+            &session(),
+            AuthzOperation::Subscribe {
+                namespace: &namespace,
+                track: &moq_transport::coding::TrackName::from("video"),
+            },
+            Some(1),
+        )
+        .await
+        .is_err());
+    }
+
+    /// A hook that errors must not be treated as an allow.
+    #[tokio::test]
+    async fn a_hook_fault_denies() {
+        let auth = SessionAuth::new(Arc::new(FaultyHook), Principal::anonymous());
+        let namespace = TrackNamespace::from_utf8_path("sports");
+
+        let err = authorize(
+            Some(&auth),
+            &session(),
+            AuthzOperation::PublishNamespace {
+                namespace: &namespace,
+            },
+            None,
+        )
+        .await
+        .expect_err("a fault must deny");
+
+        // The peer learns nothing about why: the reason is generic.
+        assert!(!err.to_string().contains("boom"), "{err}");
+    }
+}

--- a/moq-relay-ietf/src/auth/session.rs
+++ b/moq-relay-ietf/src/auth/session.rs
@@ -1,11 +1,11 @@
-// SPDX-FileCopyrightText: 2024-2026 Cloudflare Inc., Luke Curley, Mike English and contributors
+// SPDX-FileCopyrightText: 2026 Cloudflare Inc.
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 //! Per-session authorization state, carried by the producer and consumer.
 
 use std::sync::Arc;
 
-use super::{AuthHook, AuthRequest, AuthzOperation, DenyReason, Principal};
+use super::{AuthHook, AuthRequest, AuthzOperation, DenyReason, Principal, UNSCOPED};
 use crate::SessionContext;
 
 /// The authorization state of one established session.
@@ -55,7 +55,7 @@ impl SessionAuth {
             Ok(decision) => decision,
             Err(err) => {
                 tracing::error!(
-                    scope = session.scope().unwrap_or("<unscoped>"),
+                    scope = session.scope().unwrap_or(UNSCOPED),
                     subject = self.subject(),
                     operation = label,
                     error = %err,
@@ -76,7 +76,7 @@ impl SessionAuth {
             Ok(_) => Ok(()),
             Err(reason) => {
                 tracing::debug!(
-                    scope = session.scope().unwrap_or("<unscoped>"),
+                    scope = session.scope().unwrap_or(UNSCOPED),
                     subject = self.subject(),
                     operation = label,
                     reason = %reason,

--- a/moq-relay-ietf/src/auth/token.rs
+++ b/moq-relay-ietf/src/auth/token.rs
@@ -1,0 +1,430 @@
+// SPDX-FileCopyrightText: 2024-2026 Cloudflare Inc., Luke Curley, Mike English and contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! AUTHORIZATION TOKEN parameter decoding (draft-ietf-moq-transport-16
+//! §9.2.2.1, §9.3.1.5).
+//!
+//! The parameter value is a single Token structure:
+//!
+//! ```text
+//! Token {
+//!   Alias Type (i),
+//!   [Token Alias (i),]
+//!   [Token Type (i),]
+//!   [Token Value (..)]
+//! }
+//! ```
+//!
+//! Two properties of this format are easy to get wrong and are both load
+//! bearing here:
+//!
+//! * **Token Value is not length-prefixed.** `(..)` runs to the end of the
+//!   parameter value, so its length comes from the enclosing key-value pair.
+//! * **One Token per parameter.** §9.2.2.1 permits the parameter to be
+//!   repeated, so multiple tokens arrive as repeated key-value pairs rather
+//!   than as a sequence packed into one value.
+
+use moq_transport::coding::{Decode, KeyValuePairs, Value, VarInt};
+use moq_transport::setup::ParameterType;
+
+use super::AuthToken;
+
+/// Alias Type code points (draft-16 §13.1, Table 7).
+mod alias_type {
+    /// Retire an alias. Carries an alias but no type or value.
+    pub const DELETE: u64 = 0x0;
+    /// Bind an alias to a type and value for the rest of the session.
+    pub const REGISTER: u64 = 0x1;
+    /// Reference a previously registered alias. No type or value.
+    pub const USE_ALIAS: u64 = 0x2;
+    /// Inline type and value, no alias.
+    pub const USE_VALUE: u64 = 0x3;
+}
+
+/// Token type for a Common Access Token (draft-ietf-moq-c4m-01 §7.1).
+pub const CAT_TOKEN_TYPE: u64 = 0x01;
+
+/// Upper bound on tokens accepted from a single CLIENT_SETUP.
+///
+/// §9.2.2.1 lets the parameter repeat without stating a limit, but each token
+/// costs signature verifications at setup, so a receiver has to bound it. Four
+/// is well above any honest case — a client holding credentials for several
+/// relays presents one or two — while the real protection against a peer
+/// inflating admission cost is the verification budget, since a single token
+/// can already be tried against every configured key.
+pub const MAX_SETUP_TOKENS: usize = 4;
+
+/// A failure to decode an AUTHORIZATION TOKEN parameter.
+///
+/// Each variant maps to the session termination code draft-16 mandates for
+/// that condition; see [`session_error_code`](TokenError::session_error_code).
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum TokenError {
+    /// The Token structure could not be decoded.
+    #[error("malformed token structure: {0}")]
+    Malformed(&'static str),
+
+    /// DELETE or USE_ALIAS appeared in CLIENT_SETUP. §9.2.2.1 requires the
+    /// server to close the session with PROTOCOL_VIOLATION, since no alias can
+    /// have been registered before the first message of the session.
+    #[error("alias type {0:#x} is not permitted in CLIENT_SETUP")]
+    AliasInSetup(u64),
+
+    /// The parameter was present but not bytes-valued.
+    #[error("AUTHORIZATION TOKEN parameter must be bytes-encoded")]
+    NotBytes,
+
+    /// More tokens than [`MAX_SETUP_TOKENS`] were presented.
+    #[error("too many authorization tokens: {0}")]
+    TooMany(usize),
+}
+
+impl TokenError {
+    /// The session termination code for this failure (draft-16 §13.4.1).
+    pub fn session_error_code(&self) -> u32 {
+        match self {
+            // §9.2.2.1: "If a server receives Alias Type DELETE (0x0) or
+            // USE_ALIAS (0x2) in a CLIENT_SETUP message, it MUST close the
+            // session with a PROTOCOL_VIOLATION."
+            Self::AliasInSetup(_) => 0x3,
+            // §9.2.2.1: "If the Token structure cannot be decoded, the receiver
+            // MUST close the Session with KEY_VALUE_FORMATTING_ERROR."
+            Self::Malformed(_) | Self::NotBytes => 0x6,
+            // Not a decoding failure; a resource bound. UNAUTHORIZED.
+            Self::TooMany(_) => 0x2,
+        }
+    }
+
+    /// The reason phrase sent to the peer. Fixed text, never validation detail.
+    pub fn reason_phrase(&self) -> &'static str {
+        match self {
+            Self::AliasInSetup(_) => "token alias not permitted in setup",
+            Self::Malformed(_) | Self::NotBytes => "malformed authorization token",
+            Self::TooMany(_) => "too many authorization tokens",
+        }
+    }
+
+    /// A stable, low-cardinality label for metrics.
+    pub fn metric_label(&self) -> &'static str {
+        match self {
+            Self::AliasInSetup(_) => "alias_in_setup",
+            Self::Malformed(_) | Self::NotBytes => "token_malformed",
+            Self::TooMany(_) => "too_many_tokens",
+        }
+    }
+}
+
+/// Decode every AUTHORIZATION TOKEN parameter from a CLIENT_SETUP parameter set.
+///
+/// Iterates the parameters directly rather than using [`KeyValuePairs::get`],
+/// which returns only the first match and would silently drop the repetitions
+/// §9.2.2.1 permits.
+///
+/// Returns tokens in the order they appeared. An absent parameter yields an
+/// empty vector; whether that is acceptable is the caller's policy decision.
+pub fn decode_setup_tokens(params: &KeyValuePairs) -> Result<Vec<AuthToken>, TokenError> {
+    let key = u64::from(ParameterType::AuthorizationToken);
+    let mut tokens = Vec::new();
+
+    let present = params.0.iter().filter(|kvp| kvp.key == key).count();
+
+    for kvp in params.0.iter().filter(|kvp| kvp.key == key) {
+        let Value::BytesValue(bytes) = &kvp.value else {
+            return Err(TokenError::NotBytes);
+        };
+
+        // Decode every parameter even once the bound is exceeded, so that a
+        // structural violation is still reported as one. §9.2.2.1's "MUST
+        // close with PROTOCOL_VIOLATION" for an alias directive in
+        // CLIENT_SETUP does not stop applying because the peer also sent too
+        // many tokens.
+        let token = decode_token(bytes)?;
+        if tokens.len() < MAX_SETUP_TOKENS {
+            tokens.push(token);
+        }
+    }
+
+    if present > MAX_SETUP_TOKENS {
+        return Err(TokenError::TooMany(present));
+    }
+
+    Ok(tokens)
+}
+
+/// Decode one Token structure from a parameter value.
+///
+/// Borrows the caller's bytes rather than copying them: the value is a bearer
+/// credential, and an intermediate `Bytes` would be a second copy that nothing
+/// zeroizes. `&[u8]` implements `Buf`, so decoding advances the borrow instead,
+/// leaving [`AuthToken`]'s zeroizing buffer as the only copy this module makes.
+fn decode_token(value: &[u8]) -> Result<AuthToken, TokenError> {
+    let mut buf = value;
+
+    let alias_type = VarInt::decode(&mut buf)
+        .map_err(|_| TokenError::Malformed("missing alias type"))?
+        .into_inner();
+
+    match alias_type {
+        // Both reference an alias that cannot exist yet: CLIENT_SETUP is the
+        // first message of the session, so nothing has been registered.
+        alias_type::DELETE | alias_type::USE_ALIAS => Err(TokenError::AliasInSetup(alias_type)),
+
+        // §9.3.1.5: a server that advertises no MAX_AUTH_TOKEN_CACHE_SIZE
+        // "MUST NOT fail the session with AUTH_TOKEN_CACHE_OVERFLOW. Instead,
+        // it MUST treat the parameter as Alias Type USE_VALUE." We never
+        // advertise the parameter, so its default of 0 applies and every
+        // registration is handled as an inline value. The alias is consumed
+        // and discarded.
+        alias_type::REGISTER => {
+            VarInt::decode(&mut buf)
+                .map_err(|_| TokenError::Malformed("REGISTER missing token alias"))?;
+            decode_type_and_value(buf)
+        }
+
+        alias_type::USE_VALUE => decode_type_and_value(buf),
+
+        // An unrecognized alias type means the rest of the structure cannot be
+        // interpreted, which §9.2.2.1 treats as a decode failure.
+        _ => Err(TokenError::Malformed("unknown alias type")),
+    }
+}
+
+/// Decode the trailing `Token Type (i)` and `Token Value (..)`.
+///
+/// The value is whatever remains: it carries no length prefix of its own.
+fn decode_type_and_value(mut buf: &[u8]) -> Result<AuthToken, TokenError> {
+    let token_type = VarInt::decode(&mut buf)
+        .map_err(|_| TokenError::Malformed("missing token type"))?
+        .into_inner();
+
+    Ok(AuthToken::new(token_type, buf.to_vec()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use moq_transport::coding::{Encode, KeyValuePair};
+
+    /// Build a parameter set from raw AUTHORIZATION TOKEN values, preserving
+    /// repeats. `KeyValuePairs::set` deduplicates by key, so the repeated-key
+    /// case has to be constructed directly.
+    fn params(values: Vec<Vec<u8>>) -> KeyValuePairs {
+        let key = u64::from(ParameterType::AuthorizationToken);
+        KeyValuePairs(
+            values
+                .into_iter()
+                .map(|value| KeyValuePair::new_bytes(key, value))
+                .collect(),
+        )
+    }
+
+    fn varint(value: u64) -> Vec<u8> {
+        let mut buf = Vec::new();
+        VarInt::try_from(value).unwrap().encode(&mut buf).unwrap();
+        buf
+    }
+
+    /// A USE_VALUE token, encoded the way a conformant peer would.
+    fn use_value(token_type: u64, value: &[u8]) -> Vec<u8> {
+        let mut buf = varint(alias_type::USE_VALUE);
+        buf.extend_from_slice(&varint(token_type));
+        buf.extend_from_slice(value);
+        buf
+    }
+
+    #[test]
+    fn decodes_a_use_value_token() {
+        let decoded = decode_setup_tokens(&params(vec![use_value(CAT_TOKEN_TYPE, b"payload")]))
+            .expect("well-formed");
+
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(decoded[0].token_type, CAT_TOKEN_TYPE);
+        assert_eq!(decoded[0].expose_value(), b"payload");
+    }
+
+    /// The PoC used 0x2 for USE_VALUE. Per §13.1 Table 7 that is USE_ALIAS,
+    /// which §9.2.2.1 forbids in CLIENT_SETUP.
+    #[test]
+    fn use_value_is_0x3_and_use_alias_is_rejected() {
+        assert_eq!(alias_type::USE_VALUE, 0x3);
+        assert_eq!(alias_type::USE_ALIAS, 0x2);
+
+        let mut mislabelled = varint(0x2);
+        mislabelled.extend_from_slice(&varint(CAT_TOKEN_TYPE));
+        mislabelled.extend_from_slice(b"payload");
+
+        assert_eq!(
+            decode_setup_tokens(&params(vec![mislabelled])).unwrap_err(),
+            TokenError::AliasInSetup(0x2)
+        );
+    }
+
+    #[test]
+    fn delete_in_setup_is_a_protocol_violation() {
+        let mut delete = varint(alias_type::DELETE);
+        delete.extend_from_slice(&varint(7));
+
+        let err = decode_setup_tokens(&params(vec![delete])).unwrap_err();
+        assert_eq!(err, TokenError::AliasInSetup(0x0));
+        // §9.2.2.1 mandates PROTOCOL_VIOLATION (0x3) specifically.
+        assert_eq!(err.session_error_code(), 0x3);
+    }
+
+    #[test]
+    fn use_alias_in_setup_is_a_protocol_violation() {
+        let mut use_alias = varint(alias_type::USE_ALIAS);
+        use_alias.extend_from_slice(&varint(3));
+
+        let err = decode_setup_tokens(&params(vec![use_alias])).unwrap_err();
+        assert_eq!(err, TokenError::AliasInSetup(0x2));
+        assert_eq!(err.session_error_code(), 0x3);
+    }
+
+    /// §9.3.1.5: with no MAX_AUTH_TOKEN_CACHE_SIZE advertised, REGISTER is
+    /// handled as USE_VALUE rather than failing the session.
+    #[test]
+    fn register_is_treated_as_use_value() {
+        let mut register = varint(alias_type::REGISTER);
+        register.extend_from_slice(&varint(42)); // Token Alias
+        register.extend_from_slice(&varint(CAT_TOKEN_TYPE));
+        register.extend_from_slice(b"payload");
+
+        let decoded = decode_setup_tokens(&params(vec![register])).expect("treated as USE_VALUE");
+
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(decoded[0].token_type, CAT_TOKEN_TYPE);
+        assert_eq!(decoded[0].expose_value(), b"payload");
+    }
+
+    /// The value runs to the end of the parameter. A payload that begins with
+    /// bytes resembling a varint length must survive intact — this is exactly
+    /// what a length-prefixed parser corrupts.
+    #[test]
+    fn token_value_is_not_length_prefixed() {
+        // 0x07 would be read as "length 7" by a length-prefixing parser,
+        // truncating a 12-byte payload.
+        let payload = b"\x07\x41\x42\x43\x44\x45\x46\x47\x48\x49\x4a\x4b";
+        let decoded =
+            decode_setup_tokens(&params(vec![use_value(CAT_TOKEN_TYPE, payload)])).unwrap();
+
+        assert_eq!(decoded[0].expose_value(), payload);
+        assert_eq!(decoded[0].expose_value().len(), 12);
+    }
+
+    #[test]
+    fn empty_token_value_is_accepted_by_the_decoder() {
+        // Structurally valid: Token Value is optional in the grammar. Whether
+        // an empty CAT payload is acceptable is the hook's decision, not the
+        // decoder's.
+        let decoded = decode_setup_tokens(&params(vec![use_value(CAT_TOKEN_TYPE, b"")])).unwrap();
+
+        assert_eq!(decoded.len(), 1);
+        assert!(decoded[0].expose_value().is_empty());
+    }
+
+    /// §9.2.2.1: "The AUTHORIZATION TOKEN parameter MAY be repeated within a
+    /// message." Each repeat is its own key-value pair.
+    #[test]
+    fn repeated_parameters_all_decode() {
+        let decoded = decode_setup_tokens(&params(vec![
+            use_value(CAT_TOKEN_TYPE, b"first"),
+            use_value(0, b"second"),
+            use_value(CAT_TOKEN_TYPE, b"third"),
+        ]))
+        .unwrap();
+
+        assert_eq!(decoded.len(), 3);
+        assert_eq!(decoded[0].expose_value(), b"first");
+        assert_eq!(decoded[1].token_type, 0);
+        assert_eq!(decoded[2].expose_value(), b"third");
+    }
+
+    #[test]
+    fn absent_parameter_yields_no_tokens() {
+        assert!(decode_setup_tokens(&KeyValuePairs::default())
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn other_parameters_are_ignored() {
+        let mut p = KeyValuePairs::default();
+        p.set_intvalue(u64::from(ParameterType::MaxRequestId), 100);
+        p.set_bytesvalue(u64::from(ParameterType::Path), b"/tenant".to_vec());
+
+        assert!(decode_setup_tokens(&p).unwrap().is_empty());
+    }
+
+    #[test]
+    fn empty_parameter_value_is_malformed() {
+        let err = decode_setup_tokens(&params(vec![vec![]])).unwrap_err();
+        assert_eq!(err, TokenError::Malformed("missing alias type"));
+        assert_eq!(err.session_error_code(), 0x6);
+    }
+
+    #[test]
+    fn use_value_without_token_type_is_malformed() {
+        let err = decode_setup_tokens(&params(vec![varint(alias_type::USE_VALUE)])).unwrap_err();
+        assert_eq!(err, TokenError::Malformed("missing token type"));
+        assert_eq!(err.session_error_code(), 0x6);
+    }
+
+    #[test]
+    fn register_without_alias_is_malformed() {
+        let err = decode_setup_tokens(&params(vec![varint(alias_type::REGISTER)])).unwrap_err();
+        assert_eq!(err, TokenError::Malformed("REGISTER missing token alias"));
+    }
+
+    #[test]
+    fn unknown_alias_type_is_malformed() {
+        let err = decode_setup_tokens(&params(vec![varint(0x9)])).unwrap_err();
+        assert_eq!(err, TokenError::Malformed("unknown alias type"));
+        assert_eq!(err.session_error_code(), 0x6);
+    }
+
+    #[test]
+    fn truncated_varint_is_malformed() {
+        // 0x40 opens a two-byte varint whose second byte never arrives.
+        let err = decode_setup_tokens(&params(vec![vec![0x40]])).unwrap_err();
+        assert_eq!(err, TokenError::Malformed("missing alias type"));
+    }
+
+    #[test]
+    fn int_valued_parameter_is_rejected() {
+        let key = u64::from(ParameterType::AuthorizationToken);
+        let p = KeyValuePairs(vec![KeyValuePair::new_int(key, 5)]);
+
+        let err = decode_setup_tokens(&p).unwrap_err();
+        assert_eq!(err, TokenError::NotBytes);
+        assert_eq!(err.session_error_code(), 0x6);
+    }
+
+    #[test]
+    fn token_count_is_bounded() {
+        let values = (0..MAX_SETUP_TOKENS + 1)
+            .map(|_| use_value(CAT_TOKEN_TYPE, b"payload"))
+            .collect();
+
+        let err = decode_setup_tokens(&params(values)).unwrap_err();
+        assert!(matches!(err, TokenError::TooMany(_)));
+
+        // Exactly at the bound is still accepted.
+        let at_limit = (0..MAX_SETUP_TOKENS)
+            .map(|_| use_value(CAT_TOKEN_TYPE, b"payload"))
+            .collect();
+        assert_eq!(
+            decode_setup_tokens(&params(at_limit)).unwrap().len(),
+            MAX_SETUP_TOKENS
+        );
+    }
+
+    #[test]
+    fn multi_byte_varint_token_type_round_trips() {
+        // 0x63346d is the value cat-token uses for its own "c4m" type; it needs
+        // a four-byte varint, exercising the non-trivial encoding path.
+        let decoded = decode_setup_tokens(&params(vec![use_value(0x63346d, b"payload")])).unwrap();
+
+        assert_eq!(decoded[0].token_type, 0x63346d);
+        assert_eq!(decoded[0].expose_value(), b"payload");
+    }
+}

--- a/moq-relay-ietf/src/auth/token.rs
+++ b/moq-relay-ietf/src/auth/token.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 Cloudflare Inc., Luke Curley, Mike English and contributors
+// SPDX-FileCopyrightText: 2026 Cloudflare Inc.
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 //! AUTHORIZATION TOKEN parameter decoding (draft-ietf-moq-transport-16

--- a/moq-relay-ietf/src/auth/types.rs
+++ b/moq-relay-ietf/src/auth/types.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 Cloudflare Inc., Luke Curley, Mike English and contributors
+// SPDX-FileCopyrightText: 2026 Cloudflare Inc.
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use std::any::Any;

--- a/moq-relay-ietf/src/auth/types.rs
+++ b/moq-relay-ietf/src/auth/types.rs
@@ -1,0 +1,487 @@
+// SPDX-FileCopyrightText: 2024-2026 Cloudflare Inc., Luke Curley, Mike English and contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::any::Any;
+use std::fmt;
+use std::sync::Arc;
+
+use moq_transport::coding::{TrackName, TrackNamespace, TrackNamespacePrefix};
+use moq_transport::message::RequestErrorCode;
+use secrecy::{ExposeSecret, SecretSlice};
+
+use crate::SessionContext;
+
+/// A resolved AUTHORIZATION TOKEN (draft-16 §9.2.2.1).
+///
+/// Alias bookkeeping is resolved before a hook sees this, so implementations
+/// always get a Token Type and Token Value pair, never a raw alias directive.
+///
+/// The value is a bearer credential: anyone holding the bytes can act as the
+/// peer until the token expires. It is therefore held in a [`SecretSlice`],
+/// which zeroizes on drop and redacts under `Debug`, and reading it requires
+/// an explicit [`expose_secret`](ExposeSecret::expose_secret) — so a copy is
+/// something a caller has to ask for rather than something that happens by
+/// accident.
+///
+/// # What this does and does not protect
+///
+/// It bounds the lifetime of this one copy, and this is the only copy the
+/// relay's own decoding creates — [`decode_setup_tokens`] borrows the
+/// parameter rather than duplicating it. It does **not** make the process
+/// secret-free. Others exist and none are zeroized:
+///
+/// * the QUIC receive path, and the transport's `Reader` buffer, which
+///   retains the raw CLIENT_SETUP for the life of the session;
+/// * [`Session::setup_params`], likewise for the life of the session;
+/// * with the `auth-cat` feature, the allocations `cat-token` makes per
+///   verification attempt while base64-decoding the token and re-encoding the
+///   signing input — together these reconstruct the token exactly, and there
+///   are up to `MAX_SETUP_VERIFICATIONS` attempts.
+///
+/// So this narrows one window rather than closing the file. Its real value is
+/// the type: reading a bearer credential requires saying
+/// [`expose_secret`](ExposeSecret::expose_secret), and `Debug` cannot print
+/// one by accident.
+///
+/// Deliberately not [`Clone`] — `secrecy` would permit it, but duplicating a
+/// credential should be a visible act, and no caller needs it.
+///
+/// [`decode_setup_tokens`]: super::decode_setup_tokens
+/// [`Session::setup_params`]: moq_transport::session::Session::setup_params
+#[derive(Debug)]
+pub struct AuthToken {
+    /// Token type from the IANA "MOQT Auth Token Type" registry. Type 0 is
+    /// reserved for types negotiated out of band.
+    pub token_type: u64,
+
+    /// The token payload. Its serialization is defined by `token_type`.
+    ///
+    /// Read with `token.value.expose_secret()`, or [`expose_value`].
+    ///
+    /// [`expose_value`]: Self::expose_value
+    pub value: SecretSlice<u8>,
+}
+
+impl AuthToken {
+    /// Wrap a decoded token value.
+    ///
+    /// Takes an owned `Vec` so the caller hands over its copy rather than
+    /// leaving one behind for the allocator to recycle unzeroized. That holds
+    /// when the vector's capacity equals its length, as it does for the
+    /// `to_vec` in [`decode_setup_tokens`]: conversion to a boxed slice then
+    /// reuses the allocation instead of reallocating and freeing the original.
+    ///
+    /// [`decode_setup_tokens`]: super::decode_setup_tokens
+    pub fn new(token_type: u64, value: Vec<u8>) -> Self {
+        Self {
+            token_type,
+            value: SecretSlice::from(value),
+        }
+    }
+
+    /// The token payload.
+    ///
+    /// Named for what it does: every read of a bearer credential should be
+    /// visible at the call site.
+    pub fn expose_value(&self) -> &[u8] {
+        self.value.expose_secret()
+    }
+}
+
+/// An authenticated identity, established once at session setup.
+///
+/// Carries hook-private validated state — for the CAT hook, the decoded token —
+/// so that per-request authorization is a pure claims check with no
+/// cryptography. Cheap to clone: the claims are behind an [`Arc`].
+#[derive(Clone)]
+pub struct Principal {
+    /// Token subject (`sub`), for logging and metrics only. Never an
+    /// authorization input: authorization decisions come from the claims.
+    subject: Option<String>,
+
+    /// Validated state owned by the hook that produced this principal.
+    claims: Arc<dyn Any + Send + Sync>,
+}
+
+impl Principal {
+    /// Create a principal carrying hook-private validated state.
+    pub fn new<T: Any + Send + Sync>(subject: Option<String>, claims: T) -> Self {
+        Self {
+            subject,
+            claims: Arc::new(claims),
+        }
+    }
+
+    /// Create a principal with no claims, for hooks that carry no per-session
+    /// state.
+    pub fn anonymous() -> Self {
+        Self::new(None, ())
+    }
+
+    /// The token subject, for logging and metrics.
+    pub fn subject(&self) -> Option<&str> {
+        self.subject.as_deref()
+    }
+
+    /// Recover the claims this principal was created with.
+    ///
+    /// Returns `None` if the principal came from a different hook. A hook that
+    /// only ever sees principals it created should treat `None` as an internal
+    /// error and deny.
+    pub fn claims<T: Any + Send + Sync>(&self) -> Option<&T> {
+        self.claims.downcast_ref::<T>()
+    }
+}
+
+impl fmt::Debug for Principal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Principal")
+            .field("subject", &self.subject)
+            .finish_non_exhaustive()
+    }
+}
+
+/// The operation being authorized.
+///
+/// Each variant corresponds to a live authorization point in the relay. FETCH
+/// is absent because the transport answers it with NOT_SUPPORTED, so no
+/// authorization decision is ever reached for it.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum AuthzOperation<'a> {
+    /// Inbound PUBLISH_NAMESPACE (draft-16 §9.20).
+    PublishNamespace { namespace: &'a TrackNamespace },
+
+    /// Inbound PUBLISH for a single track (§9.13).
+    Publish {
+        namespace: &'a TrackNamespace,
+        track: &'a TrackName,
+    },
+
+    /// Inbound SUBSCRIBE (§9.9).
+    Subscribe {
+        namespace: &'a TrackNamespace,
+        track: &'a TrackName,
+    },
+
+    /// Inbound SUBSCRIBE_NAMESPACE (§9.25).
+    SubscribeNamespace { prefix: &'a TrackNamespacePrefix },
+
+    /// Inbound TRACK_STATUS (§9.19).
+    TrackStatus {
+        namespace: &'a TrackNamespace,
+        track: &'a TrackName,
+    },
+}
+
+impl AuthzOperation<'_> {
+    /// A stable label for logs and metrics.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::PublishNamespace { .. } => "publish_namespace",
+            Self::Publish { .. } => "publish",
+            Self::Subscribe { .. } => "subscribe",
+            Self::SubscribeNamespace { .. } => "subscribe_namespace",
+            Self::TrackStatus { .. } => "track_status",
+        }
+    }
+}
+
+/// A single authorization request.
+pub struct AuthRequest<'a> {
+    /// The session the request arrived on.
+    pub session: &'a SessionContext,
+
+    /// The identity established at setup.
+    pub principal: &'a Principal,
+
+    /// What the peer is asking to do.
+    pub operation: AuthzOperation<'a>,
+
+    /// Request ID of the message being authorized, when known.
+    pub request_id: Option<u64>,
+}
+
+/// A hook's verdict.
+#[derive(Debug, Clone)]
+pub struct AuthDecision {
+    pub verdict: Verdict,
+}
+
+impl AuthDecision {
+    /// Allow the operation, establishing the given identity.
+    pub fn allow(principal: Principal) -> Self {
+        Self {
+            verdict: Verdict::Allow(principal),
+        }
+    }
+
+    /// Deny the operation.
+    pub fn deny(reason: DenyReason) -> Self {
+        Self {
+            verdict: Verdict::Deny(reason),
+        }
+    }
+
+    /// Whether the operation was allowed.
+    pub fn is_allowed(&self) -> bool {
+        matches!(self.verdict, Verdict::Allow(_))
+    }
+
+    /// The established identity, if allowed.
+    pub fn principal(&self) -> Option<&Principal> {
+        match &self.verdict {
+            Verdict::Allow(principal) => Some(principal),
+            Verdict::Deny(_) => None,
+        }
+    }
+
+    /// The denial reason, if denied.
+    pub fn deny_reason(&self) -> Option<&DenyReason> {
+        match &self.verdict {
+            Verdict::Allow(_) => None,
+            Verdict::Deny(reason) => Some(reason),
+        }
+    }
+
+    /// Consume the decision, yielding the identity if allowed.
+    pub fn into_principal(self) -> Result<Principal, DenyReason> {
+        match self.verdict {
+            Verdict::Allow(principal) => Ok(principal),
+            Verdict::Deny(reason) => Err(reason),
+        }
+    }
+}
+
+/// Allow, carrying the established identity, or deny with a reason.
+#[derive(Debug, Clone)]
+pub enum Verdict {
+    Allow(Principal),
+    Deny(DenyReason),
+}
+
+/// Why an operation was denied.
+///
+/// Abstract on purpose: the relay maps these onto wire codes, and the mapping
+/// differs between session termination (§13.4.1) and per-request rejection
+/// (§13.4.2).
+#[derive(Debug, Clone, thiserror::Error)]
+#[non_exhaustive]
+pub enum DenyReason {
+    /// No AUTHORIZATION TOKEN of a usable type was presented.
+    #[error("token missing")]
+    TokenMissing,
+
+    /// The token was structurally valid but did not verify, or carried
+    /// unacceptable standard claims such as `iss` or `aud`.
+    #[error("token invalid")]
+    TokenInvalid,
+
+    /// The token is outside its `exp` / `nbf` validity window.
+    #[error("token expired")]
+    TokenExpired,
+
+    /// The token was replayed.
+    #[error("token replayed")]
+    TokenReplayed,
+
+    /// The token could not be decoded.
+    #[error("token malformed")]
+    TokenMalformed,
+
+    /// The token is valid but its claims do not cover this operation.
+    #[error("operation outside token scope")]
+    ScopeMismatch,
+
+    /// The token was issued by an issuer this scope does not accept.
+    #[error("issuer unknown")]
+    IssuerUnknown,
+
+    /// Denied for a hook-specific reason that is a property of the token or
+    /// the scope's configuration, and so holds for as long as the session
+    /// does — an unenforceable claim, an unusable key set.
+    ///
+    /// Callers may cache this the same way they cache the named variants.
+    #[error("{message}")]
+    PolicyDenied { message: String },
+
+    /// The hook could not reach a verdict: an unreachable backend, an
+    /// unusable clock.
+    ///
+    /// Denies like any other reason, but says nothing about the request, so
+    /// it must be retried rather than remembered — and it indicates a relay
+    /// or infrastructure problem rather than a misbehaving peer.
+    #[error("{message}")]
+    HookFault { message: String },
+}
+
+impl DenyReason {
+    /// Whether this is a decision about the peer's authority, rather than a
+    /// failure to reach one.
+    ///
+    /// A policy denial is a property of the token or the scope configuration
+    /// and holds for as long as the session does, so a caller may cache it.
+    /// [`HookFault`](Self::HookFault) is the only variant that may not be
+    /// cached: it describes the relay's own state, which can recover between
+    /// one request and the next.
+    pub fn is_policy_denial(&self) -> bool {
+        !matches!(self, Self::HookFault { .. })
+    }
+
+    /// A stable label for metrics. Deliberately low-cardinality, and never
+    /// derived from peer-controlled text.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::TokenMissing => "token_missing",
+            Self::TokenInvalid => "token_invalid",
+            Self::TokenExpired => "token_expired",
+            Self::TokenReplayed => "token_replayed",
+            Self::TokenMalformed => "token_malformed",
+            Self::ScopeMismatch => "scope_mismatch",
+            Self::IssuerUnknown => "issuer_unknown",
+            Self::PolicyDenied { .. } => "policy_denied",
+            Self::HookFault { .. } => "hook_fault",
+        }
+    }
+
+    /// The REQUEST_ERROR code for rejecting a single request (§13.4.2).
+    ///
+    /// Malformed and expired tokens have dedicated codes; everything else is
+    /// UNAUTHORIZED. The reason phrase sent alongside is fixed text, so no
+    /// detail about why validation failed reaches the peer.
+    pub fn request_error_code(&self) -> u64 {
+        match self {
+            Self::TokenMalformed => RequestErrorCode::MalformedAuthToken as u64,
+            Self::TokenExpired => RequestErrorCode::ExpiredAuthToken as u64,
+            _ => RequestErrorCode::Unauthorized as u64,
+        }
+    }
+}
+
+/// A failure to reach a verdict.
+///
+/// Distinct from [`DenyReason`]: a deny is an authorization outcome, whereas
+/// this means the hook could not evaluate the request at all. Both fail closed,
+/// but only this one indicates a relay or configuration fault worth alerting
+/// on, so the two are counted separately.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum AuthError {
+    /// The scope's authorization configuration is unusable — no keys, too many
+    /// keys, unparseable key material, or a scheme this binary was not built
+    /// with. Every session in the scope is refused until it is corrected.
+    #[error("scope authorization is misconfigured: {0}")]
+    Configuration(String),
+
+    /// A dependency needed to reach a verdict failed, such as the coordinator
+    /// being unreachable.
+    #[error("authorization backend failure: {0}")]
+    Backend(String),
+
+    /// The AUTHORIZATION TOKEN parameter could not be decoded. The peer
+    /// violated the wire format, so the session is terminated rather than the
+    /// individual request rejected.
+    #[error("malformed authorization token parameter: {0}")]
+    Malformed(#[from] super::TokenError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auth_token_debug_does_not_leak_the_value() {
+        let token = AuthToken::new(1, b"super-secret-bearer-token".to_vec());
+
+        let rendered = format!("{token:?}");
+        assert!(!rendered.contains("super-secret"), "{rendered}");
+        assert!(rendered.contains("REDACTED"), "{rendered}");
+        // The type is still identifiable for diagnostics.
+        assert!(rendered.contains("token_type: 1"), "{rendered}");
+    }
+
+    /// The value is reachable only through an explicit exposure, so a copy is
+    /// something a caller asks for rather than something that happens by
+    /// accident.
+    #[test]
+    fn auth_token_value_requires_explicit_exposure() {
+        let token = AuthToken::new(1, b"payload".to_vec());
+        assert_eq!(token.expose_value(), b"payload");
+        assert_eq!(token.value.expose_secret(), b"payload");
+    }
+
+    #[test]
+    fn principal_debug_does_not_leak_claims() {
+        let principal = Principal::new(Some("alice".to_string()), "sensitive-claims");
+        let rendered = format!("{principal:?}");
+        assert!(rendered.contains("alice"), "{rendered}");
+        assert!(!rendered.contains("sensitive-claims"), "{rendered}");
+    }
+
+    #[test]
+    fn principal_round_trips_typed_claims() {
+        #[derive(Debug, PartialEq)]
+        struct Claims(u32);
+
+        let principal = Principal::new(Some("bob".to_string()), Claims(7));
+        assert_eq!(principal.subject(), Some("bob"));
+        assert_eq!(principal.claims::<Claims>(), Some(&Claims(7)));
+        // A hook asking for a type it did not store gets None, not a panic.
+        assert_eq!(principal.claims::<String>(), None);
+    }
+
+    #[test]
+    fn decision_accessors_agree() {
+        let allow = AuthDecision::allow(Principal::anonymous());
+        assert!(allow.is_allowed());
+        assert!(allow.principal().is_some());
+        assert!(allow.deny_reason().is_none());
+
+        let deny = AuthDecision::deny(DenyReason::TokenMissing);
+        assert!(!deny.is_allowed());
+        assert!(deny.principal().is_none());
+        assert!(deny.deny_reason().is_some());
+        assert!(deny.into_principal().is_err());
+    }
+
+    /// Only a hook fault may be retried; everything else is a stable property
+    /// of the token or the scope and may be cached for the session.
+    #[test]
+    fn only_hook_faults_are_retryable() {
+        for stable in [
+            DenyReason::TokenMissing,
+            DenyReason::TokenInvalid,
+            DenyReason::TokenExpired,
+            DenyReason::TokenReplayed,
+            DenyReason::TokenMalformed,
+            DenyReason::ScopeMismatch,
+            DenyReason::IssuerUnknown,
+            DenyReason::PolicyDenied {
+                message: "unenforceable claim: cnf".to_string(),
+            },
+        ] {
+            assert!(
+                stable.is_policy_denial(),
+                "{stable} should be cacheable as a policy decision"
+            );
+        }
+
+        assert!(!DenyReason::HookFault {
+            message: "authorization unavailable".to_string(),
+        }
+        .is_policy_denial());
+    }
+
+    #[test]
+    fn deny_reasons_map_to_draft16_request_error_codes() {
+        // §13.4.2: MALFORMED_AUTH_TOKEN 0x4, EXPIRED_AUTH_TOKEN 0x5,
+        // UNAUTHORIZED 0x1.
+        assert_eq!(DenyReason::TokenMalformed.request_error_code(), 0x4);
+        assert_eq!(DenyReason::TokenExpired.request_error_code(), 0x5);
+        assert_eq!(DenyReason::TokenMissing.request_error_code(), 0x1);
+        assert_eq!(DenyReason::TokenInvalid.request_error_code(), 0x1);
+        assert_eq!(DenyReason::ScopeMismatch.request_error_code(), 0x1);
+        assert_eq!(DenyReason::IssuerUnknown.request_error_code(), 0x1);
+        assert_eq!(DenyReason::TokenReplayed.request_error_code(), 0x1);
+    }
+}

--- a/moq-relay-ietf/src/consumer.rs
+++ b/moq-relay-ietf/src/consumer.rs
@@ -12,6 +12,7 @@ use moq_transport::{
 };
 use tokio::sync::Semaphore;
 
+use crate::auth::{authorize, AuthzOperation, SessionAuth};
 use crate::{
     metrics::GaugeGuard, Coordinator, Locals, Producer, RemoteManager, SessionContext,
     SessionInterface, TrackRequest,
@@ -31,17 +32,30 @@ pub struct Consumer {
     forward: Option<Producer>, // Forward all announcements to this subscriber
     /// Relay-level context for this MoQT session.
     context: SessionContext,
+    /// Authorization state for this session. `None` when the scope has no
+    /// authorization policy, in which case every request is permitted.
+    auth: Option<SessionAuth>,
     publish_track_permits: Arc<Semaphore>,
 }
 
 impl Consumer {
-    pub fn new(
+    /// Create a consumer for a session.
+    ///
+    /// `auth` is the session's authorization state, and is deliberately a
+    /// required argument rather than something attached afterwards: a consumer
+    /// with no authorization accepts every publish, so forgetting to supply it
+    /// must be a compile error rather than a silent grant. `None` states that
+    /// the session needs no authorization — its scope has no policy, or the
+    /// relay dialled the peer itself.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
         subscriber: Subscriber,
         locals: Locals,
         coordinator: Arc<dyn Coordinator>,
         remotes: RemoteManager,
         forward: Option<Producer>,
         context: SessionContext,
+        auth: Option<SessionAuth>,
     ) -> Self {
         Self {
             subscriber,
@@ -50,6 +64,7 @@ impl Consumer {
             remotes,
             forward,
             context,
+            auth,
             publish_track_permits: Arc::new(Semaphore::new(MAX_INBOUND_PUBLISH_TRACKS_PER_SESSION)),
         }
     }
@@ -184,6 +199,23 @@ impl Consumer {
         // advertised for discovery and nothing more.
         if self.context.interface == SessionInterface::Internal {
             return self.serve_proxied(published_ns).await;
+        }
+
+        // Authorize before registering anything: an unauthorized namespace
+        // must leave no trace in the local registry or the coordinator.
+        if let Err(reason) = authorize(
+            self.auth.as_ref(),
+            &self.context,
+            AuthzOperation::PublishNamespace {
+                namespace: &published_ns.namespace,
+            },
+            Some(published_ns.info.request_id),
+        )
+        .await
+        {
+            metrics::counter!("moq_relay_announce_errors_total", "phase" => "auth").increment(1);
+            published_ns.reject(reason.request_error_code(), "unauthorized")?;
+            return Err(anyhow::anyhow!("unauthorized publish_namespace"));
         }
 
         // Register namespace routing metadata locally. This does not register
@@ -428,6 +460,23 @@ impl Consumer {
 
         let namespace = publish.namespace().clone();
         let track_name = publish.name().clone();
+
+        // Authorize before taking the reader or registering the track.
+        if let Err(reason) = authorize(
+            self.auth.as_ref(),
+            &self.context,
+            AuthzOperation::Publish {
+                namespace: &namespace,
+                track: &track_name,
+            },
+            None,
+        )
+        .await
+        {
+            metrics::counter!("moq_relay_publish_errors_total", "phase" => "auth").increment(1);
+            publish.close(ServeError::Closed(reason.request_error_code()));
+            return Err(anyhow::anyhow!("unauthorized publish"));
+        }
 
         // Take the reader first, then follow the same order as PUBLISH_NAMESPACE:
         // local registration → coordinator registration → PUBLISH_OK.

--- a/moq-relay-ietf/src/consumer.rs
+++ b/moq-relay-ietf/src/consumer.rs
@@ -195,12 +195,6 @@ impl Consumer {
         > = FuturesUnordered::new();
         let ns = published_ns.namespace.to_utf8_path();
 
-        // A namespace forwarded by a peer relay is proxied, not ours, so it is
-        // advertised for discovery and nothing more.
-        if self.context.interface == SessionInterface::Internal {
-            return self.serve_proxied(published_ns).await;
-        }
-
         // Authorize before registering anything: an unauthorized namespace
         // must leave no trace in the local registry or the coordinator.
         if let Err(reason) = authorize(
@@ -216,6 +210,12 @@ impl Consumer {
             metrics::counter!("moq_relay_announce_errors_total", "phase" => "auth").increment(1);
             published_ns.reject(reason.request_error_code(), "unauthorized")?;
             return Err(anyhow::anyhow!("unauthorized publish_namespace"));
+        }
+
+        // A namespace forwarded by a peer relay is proxied, not ours, so it is
+        // advertised for discovery and nothing more.
+        if self.context.interface == SessionInterface::Internal {
+            return self.serve_proxied(published_ns).await;
         }
 
         // Register namespace routing metadata locally. This does not register

--- a/moq-relay-ietf/src/coordinator.rs
+++ b/moq-relay-ietf/src/coordinator.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use std::net::SocketAddr;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use moq_native_ietf::quic;
@@ -206,6 +207,174 @@ pub struct ScopeConfig {
     /// Future: A `rendezvous_timeout` field may be added to control how long
     /// the relay waits for a publisher before giving up.
     pub lingering_subscribe: bool,
+
+    /// Token authorization policy for this scope.
+    ///
+    /// `None` — token authorization is not enforced. Admission rests on
+    /// [`ScopeInfo::permissions`] alone, which is the behaviour of every relay
+    /// whose coordinator does not populate this field.
+    ///
+    /// `Some` — enforced. Sessions in this scope must present a valid
+    /// AUTHORIZATION TOKEN in CLIENT_SETUP, and every subsequent request is
+    /// checked against the token's claims. The relay fails closed on anything
+    /// it cannot positively authorize, including a configuration it cannot
+    /// parse and a relay binary built without the corresponding feature.
+    pub auth: Option<ScopeAuthConfig>,
+}
+
+/// Maximum number of signing keys a scope may advertise.
+///
+/// Bounds the worst-case number of signature verifications performed when a
+/// token carries no key identifier and every configured key must be tried.
+/// Verification happens once per session at setup, not per request.
+pub const MAX_SCOPE_AUTH_KEYS: usize = 5;
+
+/// Token authorization policy for a scope.
+///
+/// Returned inside [`ScopeConfig::auth`]. The relay converts this into an
+/// authorization hook once per scope and caches it for [`ttl`](Self::ttl).
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct ScopeAuthConfig {
+    /// Public keys accepted for token signature verification, most recently
+    /// issued first so that the common case during a rotation overlap costs a
+    /// single verification.
+    ///
+    /// Must contain between 1 and [`MAX_SCOPE_AUTH_KEYS`] keys. An empty or
+    /// oversized list is a configuration error and the scope fails closed.
+    pub keys: Vec<AuthPublicKey>,
+
+    /// Accepted token issuers (`iss`). An empty list accepts any issuer.
+    pub issuers: Vec<String>,
+
+    /// Accepted token audiences (`aud`). An empty list accepts any audience.
+    pub audiences: Vec<String>,
+
+    /// Tolerance applied when checking `exp` and `nbf`.
+    pub clock_skew: Duration,
+
+    /// How long the relay may reuse this configuration before re-fetching it.
+    ///
+    /// Bounds the propagation delay of a key rotation or revocation. A zero
+    /// TTL is replaced with [`DEFAULT_SCOPE_AUTH_TTL`] rather than causing a
+    /// coordinator round-trip on every connection.
+    pub ttl: Duration,
+}
+
+/// TTL applied when [`ScopeAuthConfig::ttl`] is zero.
+pub const DEFAULT_SCOPE_AUTH_TTL: Duration = Duration::from_secs(300);
+
+/// Default clock skew applied when [`ScopeAuthConfig::clock_skew`] is zero.
+pub const DEFAULT_SCOPE_AUTH_CLOCK_SKEW: Duration = Duration::from_secs(60);
+
+impl ScopeAuthConfig {
+    /// Create a configuration from a set of keys, with default skew and TTL.
+    pub fn new(keys: Vec<AuthPublicKey>) -> Self {
+        Self {
+            keys,
+            issuers: Vec::new(),
+            audiences: Vec::new(),
+            clock_skew: DEFAULT_SCOPE_AUTH_CLOCK_SKEW,
+            ttl: DEFAULT_SCOPE_AUTH_TTL,
+        }
+    }
+
+    /// Restrict accepted issuers (`iss`).
+    pub fn with_issuers(mut self, issuers: Vec<String>) -> Self {
+        self.issuers = issuers;
+        self
+    }
+
+    /// Restrict accepted audiences (`aud`).
+    pub fn with_audiences(mut self, audiences: Vec<String>) -> Self {
+        self.audiences = audiences;
+        self
+    }
+
+    /// Set the clock skew tolerance for `exp` and `nbf`.
+    pub fn with_clock_skew(mut self, clock_skew: Duration) -> Self {
+        self.clock_skew = clock_skew;
+        self
+    }
+
+    /// Set how long the relay may cache this configuration.
+    pub fn with_ttl(mut self, ttl: Duration) -> Self {
+        self.ttl = ttl;
+        self
+    }
+
+    /// The effective cache TTL, substituting the default for zero.
+    pub fn effective_ttl(&self) -> Duration {
+        if self.ttl.is_zero() {
+            DEFAULT_SCOPE_AUTH_TTL
+        } else {
+            self.ttl
+        }
+    }
+
+    /// The effective clock skew, substituting the default for zero.
+    pub fn effective_clock_skew(&self) -> Duration {
+        if self.clock_skew.is_zero() {
+            DEFAULT_SCOPE_AUTH_CLOCK_SKEW
+        } else {
+            self.clock_skew
+        }
+    }
+}
+
+/// A public key a scope accepts for token signature verification.
+///
+/// The key is carried as PEM text rather than a parsed key type so that
+/// [`ScopeConfig`] stays free of cryptography dependencies: its shape is
+/// identical whether or not the relay was built with token support, and
+/// coordinators that speak JSON can carry it without a custom encoding.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct AuthPublicKey {
+    /// Key identifier, matched against the token's `kid` header.
+    ///
+    /// This is an **ordering hint, not a filter**. A token naming this key has
+    /// it tried first; every other configured key is still tried afterwards,
+    /// and a token naming a key the scope does not have falls back to trying
+    /// them all. The signature decides authenticity, and `kid` arrives
+    /// unauthenticated, so letting a mismatch reject a token would hand an
+    /// attacker-controlled label a say in the outcome — and would turn an
+    /// issuer relabelling its tokens, or one typo here, into an outage.
+    ///
+    /// Setting it is therefore an optimisation: it saves verifications during
+    /// a key rotation, and costs nothing if it is wrong.
+    pub kid: Option<String>,
+
+    /// The signature algorithm this key verifies.
+    pub algorithm: AuthKeyAlgorithm,
+
+    /// PEM-encoded SubjectPublicKeyInfo (`-----BEGIN PUBLIC KEY-----`).
+    pub pem: String,
+}
+
+impl AuthPublicKey {
+    /// Create an ES256 key from PEM-encoded SubjectPublicKeyInfo.
+    pub fn es256(pem: impl Into<String>) -> Self {
+        Self {
+            kid: None,
+            algorithm: AuthKeyAlgorithm::Es256,
+            pem: pem.into(),
+        }
+    }
+
+    /// Attach a key identifier, enabling `kid`-based key selection.
+    pub fn with_kid(mut self, kid: impl Into<String>) -> Self {
+        self.kid = Some(kid.into());
+        self
+    }
+}
+
+/// Signature algorithm of an [`AuthPublicKey`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum AuthKeyAlgorithm {
+    /// ECDSA using P-256 and SHA-256 (COSE algorithm -7).
+    Es256,
 }
 
 /// Result of subscribing to a namespace prefix via SUBSCRIBE_NAMESPACE.
@@ -599,18 +768,31 @@ pub trait Coordinator: Send + Sync {
     /// Get configuration for a resolved scope.
     ///
     /// Called after [`resolve_scope()`] to retrieve operational parameters
-    /// for the scope, such as origin fallback URLs and lingering subscriber
-    /// settings.
+    /// for the scope, such as origin fallback URLs, lingering subscriber
+    /// settings, and the token authorization policy.
     ///
     /// # Arguments
     ///
     /// * `scope` - The resolved scope identity from [`resolve_scope()`],
     ///   or `None` for unscoped sessions.
     ///
+    /// # Authorization
+    ///
+    /// [`ScopeConfig::auth`] carries the scope's token authorization policy,
+    /// including the public keys used to verify AUTHORIZATION TOKEN signatures.
+    /// Returning `None` (the default) leaves token authorization disabled for
+    /// the scope; returning `Some` enables it and makes the relay fail closed
+    /// on anything it cannot positively authorize.
+    ///
+    /// The relay caches the returned configuration per scope for
+    /// [`ScopeAuthConfig::ttl`], so this method is not called per connection.
+    /// Key rotation therefore takes effect for new sessions within one TTL;
+    /// sessions already established keep the keys they were admitted with.
+    ///
     /// # Default Implementation
     ///
     /// Returns default configuration (no origin fallback, lingering subscribe
-    /// disabled).
+    /// disabled, token authorization disabled).
     ///
     /// [`resolve_scope()`]: Coordinator::resolve_scope
     async fn get_scope_config(&self, _scope: Option<&str>) -> CoordinatorResult<ScopeConfig> {
@@ -1546,6 +1728,7 @@ mod tests {
         let config = ScopeConfig {
             origin_fallback: Some(Url::parse("https://origin.example.com").unwrap()),
             lingering_subscribe: true,
+            ..Default::default()
         };
         assert_eq!(
             config.origin_fallback.unwrap().as_str(),
@@ -1672,6 +1855,7 @@ mod tests {
             ScopeConfig {
                 origin_fallback: Some(Url::parse("https://ingest.example.com/origin").unwrap()),
                 lingering_subscribe: true,
+                ..Default::default()
             },
         );
 

--- a/moq-relay-ietf/src/lib.rs
+++ b/moq-relay-ietf/src/lib.rs
@@ -85,6 +85,7 @@ macro_rules! enabled_root_span {
 pub(crate) use enabled_root_span;
 
 mod api;
+mod auth;
 mod consumer;
 mod coordinator;
 mod covering_prefix_set;
@@ -99,6 +100,7 @@ mod upstream_namespaces;
 mod web;
 
 pub use api::*;
+pub use auth::*;
 pub use consumer::*;
 pub use coordinator::*;
 pub use local::*;

--- a/moq-relay-ietf/src/metrics.rs
+++ b/moq-relay-ietf/src/metrics.rs
@@ -22,11 +22,16 @@
 //! |------|--------|-------------|
 //! | `moq_relay_connections_total` | - | Total incoming connections accepted |
 //! | `moq_relay_connections_closed_total` | - | Total connections that have closed (graceful or error) |
-//! | `moq_relay_connection_errors_total` | `stage` | Connection failures (stage: session_accept, session_run) |
+//! | `moq_relay_connection_errors_total` | `stage` | Connection failures (stage: session_accept, scope_resolve, auth_setup, session_run) |
 //! | `moq_relay_publishers_total` | - | Total publishers (PUBLISH_NAMESPACE requests) received |
+//! | `moq_relay_published_tracks_total` | - | Total tracks offered via PUBLISH |
 //! | `moq_relay_announce_ok_total` | `kind` | Successful REQUEST_OK responses sent for PUBLISH_NAMESPACE (kind: client, proxied) |
-//! | `moq_relay_announce_errors_total` | `phase` | PUBLISH_NAMESPACE failures (phase: local_register, remote_register, coordinator_register, coordinator_lookup, send_ok, forward, peer_fanout) |
+//! | `moq_relay_announce_errors_total` | `phase` | PUBLISH_NAMESPACE failures (phase: auth, local_register, remote_register, coordinator_register, coordinator_lookup, send_ok, forward, peer_fanout) |
+//! | `moq_relay_publish_errors_total` | `phase` | PUBLISH failures (phase: auth, auth_fanout, session_limit, take_reader, local_register, coordinator_register, send_ok) |
 //! | `moq_relay_subscribers_total` | - | Total subscribers (SUBSCRIBE requests) received |
+//! | `moq_relay_subscribe_errors_total` | `phase` | SUBSCRIBE rejected by the relay (phase: auth) |
+//! | `moq_relay_subscribe_namespace_errors_total` | `phase` | SUBSCRIBE_NAMESPACE rejected by the relay (phase: auth) |
+//! | `moq_relay_track_status_errors_total` | `phase` | TRACK_STATUS rejected by the relay (phase: auth) |
 //! | `moq_relay_subscribe_not_found_total` | - | Track not found after checking all sources |
 //! | `moq_relay_subscribe_route_errors_total` | - | Infrastructure failure when routing to remote |
 //! | `moq_relay_subscribe_upstream_errors_total` | - | Upstream subscription could not be established, so the downstream SUBSCRIBE was rejected |
@@ -35,6 +40,8 @@
 //! | `moq_relay_cache_idle_evictions_total` | `source` | Unwatched cache entries evicted, releasing an upstream subscription (source: local, remote) |
 //! | `moq_relay_change_channel_lagged_total` | `channel` | Change notifications skipped by a lagging receiver, forcing a resync (channel: namespace, track) |
 //! | `moq_relay_lease_registry_lock_poisoned_total` | `operation` | Upstream namespace lease registry lock found poisoned (operation: acquire, release) |
+//! | `moq_relay_auth_denied_total` | `phase`, `operation`, `reason` | Operations refused by the authorization hook. `phase`: setup, request. `operation`: client_setup, publish_namespace, publish, subscribe, subscribe_namespace, track_status. `reason`: token_missing, token_invalid, token_expired, token_replayed, token_malformed, scope_mismatch, issuer_unknown, policy_denied, hook_fault, alias_in_setup, too_many_tokens |
+//! | `moq_relay_auth_errors_total` | `stage` | Authorization could not reach a verdict (stage: scope_config, setup, request). Distinct from `auth_denied_total`: these indicate a relay or configuration fault, not a rejected peer, and are the ones worth alerting on |
 //!
 //! ## Gauges
 //!
@@ -44,6 +51,7 @@
 //! | `moq_relay_active_publishers` | Current number of active publishers |
 //! | `moq_relay_active_subscriptions` | Current number of active subscriptions |
 //! | `moq_relay_active_tracks` | Current number of tracks being served |
+//! | `moq_relay_active_published_tracks` | Current number of exact tracks registered from PUBLISH |
 //! | `moq_relay_announced_namespaces` | Current number of namespaces registered via PUBLISH_NAMESPACE |
 //! | `moq_relay_upstream_connections` | Current number of upstream/origin connections |
 //!
@@ -51,7 +59,7 @@
 //!
 //! | Name | Labels | Description |
 //! |------|--------|-------------|
-//! | `moq_relay_subscribe_latency_seconds` | `source` | Time to resolve subscription (source: local, remote, not_found, route_error, upstream_error, downstream_left) |
+//! | `moq_relay_subscribe_latency_seconds` | `source` | Time to resolve subscription (source: local, remote, not_found, unauthorized, route_error, upstream_error, downstream_left) |
 
 use metrics::{describe_counter, describe_gauge, describe_histogram, Unit};
 
@@ -97,7 +105,7 @@ pub fn describe_metrics() {
     );
     describe_counter!(
         "moq_relay_announce_errors_total",
-        "PUBLISH_NAMESPACE failures by phase (local_register, remote_register, \
+        "PUBLISH_NAMESPACE failures by phase (auth, local_register, remote_register, \
          coordinator_register, coordinator_lookup, send_ok, forward, peer_fanout)"
     );
     describe_counter!(
@@ -135,6 +143,27 @@ pub fn describe_metrics() {
     describe_counter!(
         "moq_relay_lease_registry_lock_poisoned_total",
         "Upstream namespace lease registry lock found poisoned by operation (acquire, release)"
+    );
+    describe_counter!(
+        "moq_relay_auth_denied_total",
+        "Operations denied by the authorization hook, by phase (setup, request), operation, and reason"
+    );
+    describe_counter!(
+        "moq_relay_auth_errors_total",
+        "Authorization failures that prevented a verdict being reached, by stage (scope_config, setup, request). \
+         Distinct from moq_relay_auth_denied_total: these indicate a relay or configuration fault, not a rejected peer"
+    );
+    describe_counter!(
+        "moq_relay_subscribe_errors_total",
+        "SUBSCRIBE requests rejected by the relay, by phase (auth)"
+    );
+    describe_counter!(
+        "moq_relay_subscribe_namespace_errors_total",
+        "SUBSCRIBE_NAMESPACE requests rejected by the relay, by phase (auth)"
+    );
+    describe_counter!(
+        "moq_relay_track_status_errors_total",
+        "TRACK_STATUS requests rejected by the relay, by phase (auth)"
     );
 
     // Gauges

--- a/moq-relay-ietf/src/metrics.rs
+++ b/moq-relay-ietf/src/metrics.rs
@@ -83,7 +83,7 @@ pub fn describe_metrics() {
     );
     describe_counter!(
         "moq_relay_connection_errors_total",
-        "Connection failures by stage (session_accept, session_run)"
+        "Connection failures by stage (session_accept, scope_resolve, auth_setup, session_run)"
     );
     describe_counter!(
         "moq_relay_publishers_total",
@@ -95,7 +95,7 @@ pub fn describe_metrics() {
     );
     describe_counter!(
         "moq_relay_publish_errors_total",
-        "Publisher-initiated PUBLISH failures by phase (take_reader, local_register, coordinator_register, send_ok)"
+        "Publisher-initiated PUBLISH failures by phase (session_limit, auth, auth_fanout, take_reader, local_register, coordinator_register, send_ok)"
     );
     describe_counter!(
         "moq_relay_announce_ok_total",

--- a/moq-relay-ietf/src/producer.rs
+++ b/moq-relay-ietf/src/producer.rs
@@ -2,22 +2,21 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use std::collections::HashSet;
-use std::sync::Arc;
 
 use futures::{stream::FuturesUnordered, FutureExt, StreamExt};
 use moq_transport::{
-    coding::{KeyValuePairs, TrackNamespace},
+    coding::{KeyValuePairs, TrackNamespace, TrackNamespacePrefix},
     message::SubscribeOptions,
     serve::{FullTrackName, ServeError, TrackReader, TracksReader},
     session::{Publisher, SessionError, Subscribed, SubscribedNamespace, TrackStatusRequested},
 };
 use tokio::sync::broadcast;
 
+use crate::auth::{authorize, AuthzOperation, DenyReason, SessionAuth};
 use crate::{
     metrics::{GaugeGuard, TimingGuard},
     upstream_namespaces::UpstreamNamespaces,
-    Coordinator, Locals, NamespaceChange, RemoteManager, SessionContext, TrackChange,
-    UpstreamReady,
+    Locals, NamespaceChange, RemoteManager, SessionContext, TrackChange, UpstreamReady,
 };
 
 /// Producer of tracks to a remote Subscriber
@@ -29,6 +28,9 @@ pub struct Producer {
     upstream_namespaces: UpstreamNamespaces,
     /// Relay-level context for this MoQT session.
     context: SessionContext,
+    /// Authorization state for this session. `None` when the scope has no
+    /// authorization policy, in which case every request is permitted.
+    auth: Option<SessionAuth>,
 }
 
 /// Why the wait for upstream readiness ended without the subscription being
@@ -48,25 +50,21 @@ enum UpstreamWait {
 }
 
 impl Producer {
-    pub fn new(
-        publisher: Publisher,
-        locals: Locals,
-        remotes: RemoteManager,
-        coordinator: Arc<dyn Coordinator>,
-        context: SessionContext,
-    ) -> Self {
-        let (upstream_namespaces, runner) =
-            UpstreamNamespaces::new(locals.clone(), remotes.clone(), coordinator);
-        tokio::spawn(runner.run());
-        Self::new_with_upstream_namespaces(publisher, locals, remotes, upstream_namespaces, context)
-    }
-
+    /// Create a producer for a session.
+    ///
+    /// `auth` is the session's authorization state, and is deliberately a
+    /// required argument rather than something attached afterwards: a producer
+    /// with no authorization serves every request, so forgetting to supply it
+    /// must be a compile error rather than a silent grant. `None` states that
+    /// the session needs no authorization — its scope has no policy, or the
+    /// relay dialled the peer itself.
     pub(crate) fn new_with_upstream_namespaces(
         publisher: Publisher,
         locals: Locals,
         remotes: RemoteManager,
         upstream_namespaces: UpstreamNamespaces,
         context: SessionContext,
+        auth: Option<SessionAuth>,
     ) -> Self {
         Self {
             publisher,
@@ -74,6 +72,7 @@ impl Producer {
             remotes,
             upstream_namespaces,
             context,
+            auth,
         }
     }
 
@@ -166,6 +165,26 @@ impl Producer {
 
         let namespace = subscribed.track_namespace.clone();
         let track_name = subscribed.track_name.clone();
+
+        // Authorize before any lookup: deciding after would let response
+        // timing reveal whether a track the peer may not access exists.
+        if let Err(reason) = authorize(
+            self.auth.as_ref(),
+            &self.context,
+            AuthzOperation::Subscribe {
+                namespace: &namespace,
+                track: &track_name,
+            },
+            Some(subscribed.id),
+        )
+        .await
+        {
+            metrics::counter!("moq_relay_subscribe_errors_total", "phase" => "auth").increment(1);
+            timing_guard.set_label("source", "unauthorized");
+            let err = ServeError::Closed(reason.request_error_code());
+            subscribed.close(err.clone())?;
+            return Err(err.into());
+        }
 
         // Local lookup order inside Locals:
         // 1. actual FullTrackName -> TrackReader media cache
@@ -293,6 +312,24 @@ impl Producer {
         self,
         mut subscribed_namespace: SubscribedNamespace,
     ) -> Result<(), anyhow::Error> {
+        // Authorize before taking the upstream lease: an unauthorized prefix
+        // must not cause the relay to open upstream subscriptions.
+        if let Err(reason) = authorize(
+            self.auth.as_ref(),
+            &self.context,
+            AuthzOperation::SubscribeNamespace {
+                prefix: &subscribed_namespace.namespace_prefix,
+            },
+            Some(subscribed_namespace.info.request_id),
+        )
+        .await
+        {
+            metrics::counter!("moq_relay_subscribe_namespace_errors_total", "phase" => "auth")
+                .increment(1);
+            subscribed_namespace.reject(reason.request_error_code(), "unauthorized")?;
+            return Err(anyhow::anyhow!("unauthorized subscribe_namespace"));
+        }
+
         let wants_namespace = wants_namespace(subscribed_namespace.subscribe_options);
         let wants_publish = wants_publish(subscribed_namespace.subscribe_options);
         let namespace_changes = self.locals.subscribe_namespace_changes();
@@ -324,7 +361,8 @@ impl Producer {
         let mut known_namespaces = HashSet::new();
 
         if wants_namespace {
-            self.send_namespace_snapshot(&mut subscribed_namespace, &mut known_namespaces)?;
+            self.send_namespace_snapshot(&mut subscribed_namespace, &mut known_namespaces)
+                .await?;
         }
 
         let mut known_tracks = HashSet::new();
@@ -372,7 +410,7 @@ impl Producer {
                 change = namespace_changes.recv(), if wants_namespace => {
                     match change {
                         Ok(change) => {
-                            self.apply_namespace_change(&mut subscribed_namespace, &mut known_namespaces, change)?;
+                            self.apply_namespace_change(&mut subscribed_namespace, &mut known_namespaces, change).await?;
                         }
                         Err(broadcast::error::RecvError::Lagged(skipped)) => {
                             // Recoverable: a full resync reconstructs the state the
@@ -381,7 +419,7 @@ impl Producer {
                             // visible before it shows up as latency.
                             metrics::counter!("moq_relay_change_channel_lagged_total", "channel" => "namespace")
                                 .increment(skipped);
-                            self.resync_namespaces(&mut subscribed_namespace, &mut known_namespaces)?;
+                            self.resync_namespaces(&mut subscribed_namespace, &mut known_namespaces).await?;
                         }
                         Err(broadcast::error::RecvError::Closed) => return Ok(()),
                     }
@@ -404,7 +442,12 @@ impl Producer {
         }
     }
 
-    fn send_namespace_snapshot(
+    /// Whether the peer may be told that `namespace` exists.
+    async fn may_announce(&self, namespace: &TrackNamespace) -> bool {
+        may_announce_namespace(self.auth.as_ref(), &self.context, namespace).await
+    }
+
+    async fn send_namespace_snapshot(
         &self,
         subscribed_namespace: &mut SubscribedNamespace,
         known: &mut HashSet<TrackNamespace>,
@@ -413,6 +456,9 @@ impl Producer {
             .locals
             .list_namespaces_matching(self.context.scope(), &subscribed_namespace.namespace_prefix)
         {
+            if !self.may_announce(&namespace).await {
+                continue;
+            }
             if known.insert(namespace.clone()) {
                 subscribed_namespace.namespace(&namespace)?;
             }
@@ -421,7 +467,7 @@ impl Producer {
         Ok(())
     }
 
-    fn apply_namespace_change(
+    async fn apply_namespace_change(
         &self,
         subscribed_namespace: &mut SubscribedNamespace,
         known: &mut HashSet<TrackNamespace>,
@@ -439,6 +485,9 @@ impl Producer {
         }
 
         if change.added {
+            if !self.may_announce(&change.namespace).await {
+                return Ok(());
+            }
             if known.insert(change.namespace.clone()) {
                 subscribed_namespace.namespace(&change.namespace)?;
             }
@@ -449,16 +498,20 @@ impl Producer {
         Ok(())
     }
 
-    fn resync_namespaces(
+    async fn resync_namespaces(
         &self,
         subscribed_namespace: &mut SubscribedNamespace,
         known: &mut HashSet<TrackNamespace>,
     ) -> Result<(), ServeError> {
-        let current: HashSet<_> = self
+        let mut current = HashSet::new();
+        for namespace in self
             .locals
             .list_namespaces_matching(self.context.scope(), &subscribed_namespace.namespace_prefix)
-            .into_iter()
-            .collect();
+        {
+            if self.may_announce(&namespace).await {
+                current.insert(namespace);
+            }
+        }
 
         for namespace in current.difference(known) {
             subscribed_namespace.namespace(namespace)?;
@@ -555,6 +608,43 @@ impl Producer {
             return Ok(());
         }
 
+        // SUBSCRIBE_NAMESPACE grants discovery of a prefix, not delivery of
+        // everything under it. This path pushes PUBLISH and then streams the
+        // track's objects, so it needs the same authorization a SUBSCRIBE for
+        // that track would: a token scoped to a prefix for discovery, or to a
+        // subset of track names, must not receive media outside that grant.
+        //
+        // A denial skips the track rather than failing the subscription: the
+        // peer asked for a prefix, not for this track, so the rest of the
+        // prefix is still legitimately theirs.
+        if let Err(reason) = may_serve_track_in_fanout(
+            self.auth.as_ref(),
+            &self.context,
+            &full_name,
+            subscribed_namespace.info.request_id,
+        )
+        .await
+        {
+            tracing::debug!(
+                namespace = %full_name.namespace,
+                track = %full_name.name,
+                reason = %reason,
+                "withholding track from SUBSCRIBE_NAMESPACE fan-out"
+            );
+            metrics::counter!("moq_relay_publish_errors_total", "phase" => "auth_fanout")
+                .increment(1);
+
+            // A policy denial is stable for the session, so record it and stop
+            // re-deciding on every change event. A hook *fault* is not: it says
+            // nothing about this track, so leave it out of `known` and let the
+            // next event retry rather than withholding the track for the life
+            // of the subscription over one transient failure.
+            if reason.is_policy_denial() {
+                known.insert(full_name);
+            }
+            return Ok(());
+        }
+
         let mut params = KeyValuePairs::default();
         if !subscribed_namespace.forward {
             params.set_forward(false);
@@ -605,6 +695,26 @@ impl Producer {
             namespace: track_status_requested.request_msg.track_namespace.clone(),
             name: track_status_requested.request_msg.track_name.clone(),
         };
+
+        // Authorize before the lookup: TRACK_STATUS is an existence oracle, so
+        // answering it for an unauthorized track leaks exactly what the token
+        // scope is meant to hide.
+        if let Err(reason) = authorize(
+            self.auth.as_ref(),
+            &self.context,
+            AuthzOperation::TrackStatus {
+                namespace: &full_name.namespace,
+                track: &full_name.name,
+            },
+            Some(track_status_requested.request_msg.id),
+        )
+        .await
+        {
+            metrics::counter!("moq_relay_track_status_errors_total", "phase" => "auth")
+                .increment(1);
+            track_status_requested.respond_error(reason.request_error_code(), "unauthorized")?;
+            return Err(anyhow::anyhow!("unauthorized track_status"));
+        }
 
         // Check actual local tracks first.
         if let Some(track) = self.locals.retrieve_track(self.context.scope(), &full_name) {
@@ -663,11 +773,249 @@ fn full_name_for_track(track: &TrackReader) -> FullTrackName {
     }
 }
 
+/// Whether a track may be delivered through the SUBSCRIBE_NAMESPACE fan-out.
+///
+/// That path pushes PUBLISH and then streams the track's objects, so it needs
+/// the authorization a SUBSCRIBE for the same track would: a prefix
+/// subscription grants discovery, not delivery of everything beneath it. A
+/// token scoped to a subset of track names must not receive the rest merely
+/// because it subscribed to the enclosing prefix.
+///
+/// A free function so the decision is testable without a live session, which
+/// `Producer` requires: a `Publisher` cannot be constructed outside
+/// `moq-transport`, so the gate could not otherwise be covered at all.
+///
+/// The tests therefore pin this decision and the operation it asks about, but
+/// not that the caller still consults it — removing the call site produces a
+/// dead-code warning rather than a failing test. Closing that would need an
+/// end-to-end session harness.
+async fn may_serve_track_in_fanout(
+    auth: Option<&SessionAuth>,
+    context: &SessionContext,
+    full_name: &FullTrackName,
+    request_id: u64,
+) -> Result<(), DenyReason> {
+    authorize(
+        auth,
+        context,
+        AuthzOperation::Subscribe {
+            namespace: &full_name.namespace,
+            track: &full_name.name,
+        },
+        Some(request_id),
+    )
+    .await
+}
+
+/// Whether the peer may be told that `namespace` exists.
+///
+/// A prefix subscription is not a grant over everything beneath it. The `nil`
+/// terminator makes the distinction concrete: a scope of
+/// `[exact("sports"), nil]` authorizes SUBSCRIBE_NAMESPACE for `sports` while
+/// denying every operation under `sports/football`, so announcing that
+/// namespace would disclose the existence of something the token cannot touch.
+/// The reasoning that gates the media fan-out applies to the metadata too.
+async fn may_announce_namespace(
+    auth: Option<&SessionAuth>,
+    context: &SessionContext,
+    namespace: &TrackNamespace,
+) -> bool {
+    // A concrete namespace viewed as the prefix naming exactly it.
+    let prefix = TrackNamespacePrefix {
+        fields: namespace.fields.clone(),
+    };
+
+    authorize(
+        auth,
+        context,
+        AuthzOperation::SubscribeNamespace { prefix: &prefix },
+        None,
+    )
+    .await
+    .is_ok()
+}
+
 #[cfg(test)]
 mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use async_trait::async_trait;
     use moq_transport::{serve::ServeError, session::SessionError};
 
-    use super::Producer;
+    use super::*;
+    use crate::auth::{AuthDecision, AuthError, AuthHook, AuthRequest, AuthToken, Principal};
+
+    /// Records every operation it is asked about, and answers from a script.
+    ///
+    /// Lets the fan-out gates be tested for the operation they construct, not
+    /// merely for their yes/no answer: authorizing the wrong thing would be as
+    /// much a bypass as authorizing nothing.
+    struct RecordingHook {
+        seen: Mutex<Vec<String>>,
+        decision: fn() -> Result<AuthDecision, AuthError>,
+    }
+
+    impl RecordingHook {
+        fn new(decision: fn() -> Result<AuthDecision, AuthError>) -> Arc<Self> {
+            Arc::new(Self {
+                seen: Mutex::new(Vec::new()),
+                decision,
+            })
+        }
+
+        fn seen(&self) -> Vec<String> {
+            self.seen.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl AuthHook for RecordingHook {
+        async fn on_setup(
+            &self,
+            _session: &SessionContext,
+            _tokens: &[AuthToken],
+        ) -> Result<AuthDecision, AuthError> {
+            (self.decision)()
+        }
+
+        async fn on_request(&self, request: &AuthRequest<'_>) -> Result<AuthDecision, AuthError> {
+            let detail = match &request.operation {
+                AuthzOperation::Subscribe { namespace, track } => format!(
+                    "subscribe {} {}",
+                    namespace.to_utf8_path(),
+                    track.to_string_lossy()
+                ),
+                AuthzOperation::SubscribeNamespace { prefix } => {
+                    format!("subscribe_namespace {}", prefix.to_utf8_path())
+                }
+                other => format!("other {}", other.label()),
+            };
+            self.seen.lock().unwrap().push(detail);
+            (self.decision)()
+        }
+    }
+
+    fn allow() -> Result<AuthDecision, AuthError> {
+        Ok(AuthDecision::allow(Principal::anonymous()))
+    }
+
+    fn deny() -> Result<AuthDecision, AuthError> {
+        Ok(AuthDecision::deny(DenyReason::ScopeMismatch))
+    }
+
+    fn fault() -> Result<AuthDecision, AuthError> {
+        Err(AuthError::Backend("backend unavailable".to_string()))
+    }
+
+    fn context() -> SessionContext {
+        SessionContext::public(Some("tenant".to_string()))
+    }
+
+    fn session_auth(hook: Arc<RecordingHook>) -> SessionAuth {
+        SessionAuth::new(hook, Principal::anonymous())
+    }
+
+    fn full_name() -> FullTrackName {
+        FullTrackName {
+            namespace: TrackNamespace::from_utf8_path("sports/football"),
+            name: "premium-4k".into(),
+        }
+    }
+
+    /// The fan-out streams media, so it must ask for SUBSCRIBE on the exact
+    /// track — not for the enclosing prefix, and not nothing at all.
+    #[tokio::test]
+    async fn fanout_authorizes_each_track_as_a_subscribe() {
+        let hook = RecordingHook::new(allow);
+        let auth = session_auth(hook.clone());
+
+        may_serve_track_in_fanout(Some(&auth), &context(), &full_name(), 7)
+            .await
+            .expect("allowed");
+
+        assert_eq!(hook.seen(), vec!["subscribe /sports/football premium-4k"]);
+    }
+
+    #[tokio::test]
+    async fn fanout_withholds_a_track_the_token_does_not_cover() {
+        let hook = RecordingHook::new(deny);
+        let auth = session_auth(hook.clone());
+
+        let result = may_serve_track_in_fanout(Some(&auth), &context(), &full_name(), 7).await;
+
+        assert!(result.is_err(), "a denied track must not be served");
+        assert_eq!(hook.seen().len(), 1, "the decision must actually be sought");
+    }
+
+    /// A hook fault is not a statement about this track, so it must not be
+    /// remembered as one; `publish_track_for_namespace` only caches denials
+    /// that are policy decisions.
+    #[tokio::test]
+    async fn fanout_distinguishes_a_fault_from_a_denial() {
+        let denied = may_serve_track_in_fanout(
+            Some(&session_auth(RecordingHook::new(deny))),
+            &context(),
+            &full_name(),
+            7,
+        )
+        .await
+        .expect_err("denied");
+        assert!(denied.is_policy_denial());
+
+        let faulted = may_serve_track_in_fanout(
+            Some(&session_auth(RecordingHook::new(fault))),
+            &context(),
+            &full_name(),
+            7,
+        )
+        .await
+        .expect_err("faulted");
+        assert!(
+            !faulted.is_policy_denial(),
+            "a fault must not be cached as a denial"
+        );
+    }
+
+    /// A session whose scope has no policy is unaffected.
+    #[tokio::test]
+    async fn fanout_permits_everything_when_no_policy_applies() {
+        assert!(may_serve_track_in_fanout(None, &context(), &full_name(), 7)
+            .await
+            .is_ok());
+        assert!(
+            may_announce_namespace(
+                None,
+                &context(),
+                &TrackNamespace::from_utf8_path("sports/football")
+            )
+            .await
+        );
+    }
+
+    /// Announcements disclose existence, so each concrete namespace is
+    /// authorized as the prefix naming exactly it.
+    #[tokio::test]
+    async fn announcements_are_authorized_per_namespace() {
+        let hook = RecordingHook::new(allow);
+        let auth = session_auth(hook.clone());
+        let namespace = TrackNamespace::from_utf8_path("sports/football");
+
+        assert!(may_announce_namespace(Some(&auth), &context(), &namespace).await);
+        assert_eq!(hook.seen(), vec!["subscribe_namespace /sports/football"]);
+    }
+
+    #[tokio::test]
+    async fn announcements_are_withheld_when_denied() {
+        let hook = RecordingHook::new(deny);
+        let auth = session_auth(hook.clone());
+        let namespace = TrackNamespace::from_utf8_path("sports/football");
+
+        assert!(
+            !may_announce_namespace(Some(&auth), &context(), &namespace).await,
+            "a namespace the token cannot touch must not be announced"
+        );
+        assert_eq!(hook.seen().len(), 1);
+    }
 
     #[test]
     fn expected_serve_shutdown_accepts_wrapped_session_errors() {

--- a/moq-relay-ietf/src/relay.rs
+++ b/moq-relay-ietf/src/relay.rs
@@ -10,6 +10,7 @@ use moq_native_ietf::quic::{self, Endpoint};
 use moq_transport::session::SessionConfig;
 use url::Url;
 
+use crate::auth::{decode_setup_tokens, ScopeAuthorizer, SessionAuth, SESSION_ERROR_UNAUTHORIZED};
 use crate::upstream_namespaces::{UpstreamNamespaces, UpstreamNamespacesRunner};
 use crate::{
     metrics::GaugeGuard, ConnectionMeta, ConnectionTagger, Consumer, Coordinator, Locals, Producer,
@@ -89,6 +90,145 @@ impl RelayConfig {
     }
 }
 
+/// Why a session was refused at setup.
+///
+/// Carries the QUIC application close code and a fixed reason phrase. The
+/// phrase is deliberately coarse: the peer learns that it was refused, not why
+/// validation failed.
+struct SessionRejection {
+    code: u32,
+    reason: &'static str,
+}
+
+/// Authorize an accepted session against its scope's policy.
+///
+/// Returns the session's authorization state, or `None` when the scope has no
+/// policy. Every failure path refuses the session: the relay never proceeds
+/// with a connection it could not positively authorize.
+async fn authorize_session(
+    authorizer: &ScopeAuthorizer,
+    context: &SessionContext,
+    session: &moq_transport::session::Session,
+) -> Result<Option<SessionAuth>, SessionRejection> {
+    // Decode before resolving the scope's policy. Draft-16 §9.2.2.1 makes
+    // rejecting a malformed Token structure, or an alias directive in
+    // CLIENT_SETUP, an unconditional obligation on the receiver -- it is not
+    // predicated on the receiver requiring authorization. Doing this after the
+    // policy lookup would skip both MUSTs for every scope that has no policy,
+    // which is the default.
+    let tokens = match decode_setup_tokens(session.setup_params()) {
+        Ok(tokens) => tokens,
+        Err(err) => {
+            // A wire-format violation, so the close code comes from the draft
+            // rather than being UNAUTHORIZED.
+            tracing::debug!(
+                scope = context.scope(),
+                error = %err,
+                "invalid AUTHORIZATION TOKEN parameter in CLIENT_SETUP"
+            );
+            metrics::counter!(
+                "moq_relay_auth_denied_total",
+                "phase" => "setup",
+                "operation" => "client_setup",
+                "reason" => err.metric_label(),
+            )
+            .increment(1);
+            return Err(SessionRejection {
+                code: err.session_error_code(),
+                reason: err.reason_phrase(),
+            });
+        }
+    };
+
+    let hook = match authorizer.resolve(context.scope()).await {
+        Ok(Some(hook)) => hook,
+        // The scope did not opt in to token authorization.
+        Ok(None) => return Ok(None),
+        Err(err) => {
+            // We could not learn whether this scope requires a token, so we
+            // must not assume it does not.
+            tracing::error!(
+                scope = context.scope(),
+                error = %err,
+                "could not determine the scope's authorization policy"
+            );
+            metrics::counter!("moq_relay_auth_errors_total", "stage" => "scope_config")
+                .increment(1);
+            return Err(SessionRejection {
+                code: SESSION_ERROR_UNAUTHORIZED,
+                reason: "authorization unavailable",
+            });
+        }
+    };
+
+    let decision = hook.on_setup(context, &tokens).await.map_err(|err| {
+        tracing::error!(
+            scope = context.scope(),
+            error = %err,
+            "authorization hook failed during setup"
+        );
+        metrics::counter!("moq_relay_auth_errors_total", "stage" => "setup").increment(1);
+        SessionRejection {
+            code: SESSION_ERROR_UNAUTHORIZED,
+            reason: "authorization unavailable",
+        }
+    })?;
+
+    match decision.into_principal() {
+        Ok(principal) => {
+            tracing::debug!(
+                scope = context.scope(),
+                subject = principal.subject(),
+                "session authorized"
+            );
+            Ok(Some(SessionAuth::new(hook, principal)))
+        }
+        Err(reason) => {
+            tracing::debug!(
+                scope = context.scope(),
+                reason = %reason,
+                "session authorization denied"
+            );
+            metrics::counter!(
+                "moq_relay_auth_denied_total",
+                "phase" => "setup",
+                "operation" => "client_setup",
+                "reason" => reason.label(),
+            )
+            .increment(1);
+            Err(SessionRejection {
+                code: SESSION_ERROR_UNAUTHORIZED,
+                reason: "unauthorized",
+            })
+        }
+    }
+}
+
+/// The scope identity used for this session's coordinator calls and media
+/// lookups.
+///
+/// An unscoped session and one whose `scope_id` is empty are the same thing,
+/// and are normalized to `None` here so that they stay the same thing
+/// everywhere downstream. [`Locals`] already collapses the two into one media
+/// bucket (it keys unscoped sessions under `""`), but [`ScopeAuthorizer`]
+/// caches by `Option<String>`, where `None` and `Some("")` are distinct keys.
+/// Left unnormalized, a coordinator that returned an empty `scope_id` could
+/// have its authorization policy looked up under one key while its media
+/// landed in the other's bucket — an unauthenticated session sharing tracks
+/// with an enforced one.
+///
+/// Not reachable through the in-tree coordinators, whose `scope_id` comes from
+/// a connection path that [`Session::normalize_connection_path`] never yields
+/// empty. It is reachable through a custom [`Coordinator`], which is reason
+/// enough to close it here rather than rely on every implementation not to.
+///
+/// [`Session::normalize_connection_path`]: moq_transport::session::Session::normalize_connection_path
+fn normalize_scope_id(scope_info: Option<&crate::ScopeInfo>) -> Option<String> {
+    scope_info
+        .map(|info| info.scope_id.clone())
+        .filter(|scope_id| !scope_id.is_empty())
+}
+
 /// MoQ Relay server.
 pub struct Relay {
     config: RelayConfig,
@@ -96,6 +236,10 @@ pub struct Relay {
     remotes: RemoteManager,
     upstream_namespaces: UpstreamNamespaces,
     upstream_namespaces_runner: UpstreamNamespacesRunner,
+
+    /// Per-scope authorization policy, resolved from the coordinator and
+    /// cached. Shared by every connection task.
+    authorizer: Arc<ScopeAuthorizer>,
 }
 
 impl Relay {
@@ -161,12 +305,15 @@ impl Relay {
         let (upstream_namespaces, upstream_namespaces_runner) =
             UpstreamNamespaces::new(locals.clone(), remotes.clone(), config.coordinator.clone());
 
+        let authorizer = Arc::new(ScopeAuthorizer::new(config.coordinator.clone()));
+
         Ok(Self {
             config,
             locals,
             remotes,
             upstream_namespaces,
             upstream_namespaces_runner,
+            authorizer,
         })
     }
 
@@ -178,6 +325,7 @@ impl Relay {
             remotes,
             upstream_namespaces,
             upstream_namespaces_runner,
+            authorizer,
         } = self;
 
         let RelayConfig {
@@ -244,8 +392,43 @@ impl Relay {
                 // Multi-scope forwarding (routing different incoming scopes to different
                 // upstream paths) would require per-scope forward connections.
                 let forward_scope = session.connection_path().map(|s| s.to_string());
-                let forward_context =
-                    SessionContext::internal(forward_scope, Some(RelayInfo::new(url.clone())));
+                // The forward link is bidirectional: the upstream can publish
+                // and subscribe back into this scope over it. Token
+                // authorization is not applied — the relay has no credential
+                // of its own to present, and the upstream is operator-chosen —
+                // so if the scope does require tokens, say so loudly rather
+                // than leaving an unauthenticated path into it undocumented at
+                // runtime.
+                match coordinator.get_scope_config(forward_scope.as_deref()).await {
+                    Ok(config) if config.auth.is_some() => {
+                        tracing::warn!(
+                            url = %url,
+                            scope = forward_scope.as_deref(),
+                            "--announce targets a scope that requires token authorization, but \
+                             the forward link is not authorized: the upstream relay can publish \
+                             and subscribe in this scope without presenting a token. Ensure the \
+                             announce target is trusted and reachable only over a trusted path."
+                        );
+                    }
+                    Ok(_) => {}
+                    Err(err) => {
+                        // Not fatal — the link is operator-configured either
+                        // way — but the warning above is the only signal that
+                        // this path exists, so its absence must not be silent.
+                        tracing::warn!(
+                            url = %url,
+                            scope = forward_scope.as_deref(),
+                            error = %err,
+                            "could not determine whether the --announce target's scope requires \
+                             token authorization; the forward link is unauthorized regardless"
+                        );
+                    }
+                }
+
+                let forward_context = SessionContext::internal(
+                    forward_scope,
+                    Some(RelayInfo::new(url.clone())),
+                );
 
                 let forward_coordinator = coordinator.clone();
                 let session = Session {
@@ -256,6 +439,8 @@ impl Relay {
                         remote_manager.clone(),
                         upstream_namespaces.clone(),
                         forward_context.clone(),
+                        // Operator-configured peer; see the warning above.
+                        None,
                     )),
                     consumer: Some(Consumer::new(
                         subscriber,
@@ -264,6 +449,7 @@ impl Relay {
                         remote_manager.clone(),
                         None,
                         forward_context.clone(),
+                        None,
                     )),
                     // Forward connections are always full read-write relay peers,
                     // so no reject loops needed.
@@ -346,6 +532,7 @@ impl Relay {
                         let coordinator = coordinator.clone();
                         let upstream_namespaces = upstream_namespaces.clone();
                         let connection_tagger = connection_tagger.clone();
+                        let authorizer = authorizer.clone();
 
                         // Spawn a new task to handle the connection
                         tasks.push(async move {
@@ -419,7 +606,7 @@ impl Relay {
                             // connection is treated as a public client. For connections
                             // classified internal, the peer relay identity is derived from
                             // the inbound socket address (see RelayInfo::from_socket_addr).
-                            let scope = scope_info.as_ref().map(|info| info.scope_id.clone());
+                            let scope = normalize_scope_id(scope_info.as_ref());
                             let context = match connection_tagger.as_ref() {
                                 Some(tagger) => {
                                     let meta = ConnectionMeta::new(
@@ -487,6 +674,35 @@ impl Relay {
                                 );
                             }
 
+                            // Authorize the session, if this scope requires it.
+                            //
+                            // resolve_scope() established *which* scope this
+                            // connection belongs to and its coarse permissions;
+                            // this establishes *who* the peer is, from the
+                            // AUTHORIZATION TOKEN in CLIENT_SETUP. It runs
+                            // before either session half is built so that an
+                            // unauthorized peer never gets one.
+                            let session_auth = match authorize_session(
+                                &authorizer,
+                                &context,
+                                &moq_session,
+                            ).await {
+                                Ok(auth) => auth,
+                                Err(rejection) => {
+                                    tracing::info!(
+                                        connection_path = moq_session.connection_path(),
+                                        scope = context.scope(),
+                                        code = rejection.code,
+                                        reason = rejection.reason,
+                                        "session authorization failed, closing"
+                                    );
+                                    raw_conn.close(rejection.code, rejection.reason);
+                                    metrics::counter!("moq_relay_connection_errors_total", "stage" => "auth_setup").increment(1);
+                                    metrics::counter!("moq_relay_connections_closed_total").increment(1);
+                                    return Ok(());
+                                }
+                            };
+
                             // Gate Producer/Consumer creation on permissions.
                             // Note the intentional inversion:
                             // - Producer serves SUBSCRIBEs → gated on can_subscribe
@@ -496,13 +712,13 @@ impl Relay {
                             // to the Session's reject fields so unauthorized messages get
                             // an explicit error response instead of being silently ignored.
                             let (producer, reject_subscribes) = if can_subscribe {
-                                (publisher.map(|publisher| Producer::new_with_upstream_namespaces(publisher, locals.clone(), remotes.clone(), upstream_namespaces, context.clone())), None)
+                                (publisher.map(|publisher| Producer::new_with_upstream_namespaces(publisher, locals.clone(), remotes.clone(), upstream_namespaces, context.clone(), session_auth.clone())), None)
                             } else {
                                 (None, publisher)
                             };
 
                             let (consumer, reject_publishes) = if can_publish {
-                                (subscriber.map(|subscriber| Consumer::new(subscriber, locals, coordinator, remotes.clone(), forward, context.clone())), None)
+                                (subscriber.map(|subscriber| Consumer::new(subscriber, locals, coordinator, remotes.clone(), forward, context.clone(), session_auth)), None)
                             } else {
                                 (None, subscriber)
                             };
@@ -544,5 +760,66 @@ impl Relay {
 
         remotes.shutdown().await;
         run_result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::{ScopeInfo, ScopePermissions};
+
+    fn scope_info(scope_id: &str) -> ScopeInfo {
+        ScopeInfo {
+            scope_id: scope_id.to_string(),
+            permissions: ScopePermissions::ReadWrite,
+        }
+    }
+
+    #[test]
+    fn a_named_scope_is_preserved() {
+        assert_eq!(
+            normalize_scope_id(Some(&scope_info("tenant"))),
+            Some("tenant".to_string())
+        );
+        // Including shapes that merely look empty.
+        assert_eq!(
+            normalize_scope_id(Some(&scope_info("/"))),
+            Some("/".to_string())
+        );
+        assert_eq!(
+            normalize_scope_id(Some(&scope_info(" "))),
+            Some(" ".to_string())
+        );
+    }
+
+    #[test]
+    fn an_unscoped_session_stays_unscoped() {
+        assert_eq!(normalize_scope_id(None), None);
+    }
+
+    /// The case this exists for: `Some("")` and `None` must not be distinct
+    /// keys, or a scope's authorization policy and its media could be looked
+    /// up under different ones.
+    #[test]
+    fn an_empty_scope_id_is_normalized_to_unscoped() {
+        assert_eq!(normalize_scope_id(Some(&scope_info(""))), None);
+        assert_eq!(
+            normalize_scope_id(Some(&scope_info(""))),
+            normalize_scope_id(None),
+            "an empty scope id and no scope must agree"
+        );
+    }
+
+    /// `Locals` keys unscoped media under `""`, so normalizing to `None` here
+    /// is what keeps the authorization key and the media key in agreement.
+    #[test]
+    fn normalization_agrees_with_the_locals_bucket() {
+        let normalized = normalize_scope_id(Some(&scope_info("")));
+        assert_eq!(normalized.as_deref().unwrap_or(""), "");
+        assert_eq!(
+            normalize_scope_id(None).as_deref().unwrap_or(""),
+            normalized.as_deref().unwrap_or(""),
+        );
     }
 }

--- a/moq-transport/src/coding/bounded_string.rs
+++ b/moq-transport/src/coding/bounded_string.rs
@@ -10,6 +10,34 @@ macro_rules! bounded_string {
 
         impl $name {
             pub const MAX_LEN: usize = $max_len;
+
+            /// Build from a string, truncating to [`MAX_LEN`](Self::MAX_LEN).
+            ///
+            /// [`Encode`] rejects anything longer, and an encode failure on
+            /// the control stream tears down the whole session — so for a
+            /// string the local application did not choose (an error's
+            /// `Display`, a caller-supplied reason phrase) a shortened value
+            /// is strictly better than the alternative. Prefer this over the
+            /// tuple constructor anywhere the length is not known statically.
+            ///
+            /// Truncation lands on a UTF-8 character boundary, so the result
+            /// is always a valid prefix of the input.
+            pub fn new(value: impl Into<String>) -> Self {
+                let mut value = value.into();
+
+                if value.len() > Self::MAX_LEN {
+                    // `is_char_boundary(0)` is always true, so this terminates
+                    // and cannot underflow; UTF-8 scalars are at most 4 bytes,
+                    // so it steps back at most 3 times.
+                    let mut end = Self::MAX_LEN;
+                    while !value.is_char_boundary(end) {
+                        end -= 1;
+                    }
+                    value.truncate(end);
+                }
+
+                Self(value)
+            }
         }
 
         impl Encode for $name {
@@ -94,5 +122,59 @@ mod tests {
             decoded.unwrap_err(),
             DecodeError::FieldBoundsExceeded(_)
         ));
+    }
+
+    #[test]
+    fn new_leaves_a_string_within_the_bound_untouched() {
+        assert_eq!(ReasonPhrase::new("unauthorized").0, "unauthorized");
+        assert_eq!(ReasonPhrase::new("").0, "");
+
+        let exact = "x".repeat(ReasonPhrase::MAX_LEN);
+        assert_eq!(ReasonPhrase::new(exact.clone()).0, exact);
+    }
+
+    /// Truncation must land on a character boundary, whatever width the
+    /// characters are and wherever the limit falls inside one.
+    #[test]
+    fn new_truncates_on_a_char_boundary() {
+        // 1, 2, 3 and 4 byte scalars, each padded so the limit lands at every
+        // offset within a character.
+        for filler in ["a", "\u{80}", "\u{800}", "\u{10000}", "\u{10FFFF}"] {
+            for pad in 0..8 {
+                let mut input = "p".repeat(pad);
+                while input.len() < ReasonPhrase::MAX_LEN * 2 {
+                    input.push_str(filler);
+                }
+
+                let bounded = ReasonPhrase::new(input.clone());
+
+                assert!(
+                    bounded.0.len() <= ReasonPhrase::MAX_LEN,
+                    "filler {filler:?} pad {pad}: {} bytes",
+                    bounded.0.len()
+                );
+                assert!(
+                    input.starts_with(&bounded.0),
+                    "filler {filler:?} pad {pad}: not a prefix"
+                );
+                // Backtracking is bounded by the widest UTF-8 scalar.
+                assert!(bounded.0.len() + 4 > ReasonPhrase::MAX_LEN);
+
+                // The point of the bound: it always encodes.
+                let mut buf = Vec::new();
+                bounded.encode(&mut buf).expect("must encode");
+            }
+        }
+    }
+
+    /// The bound is in bytes, matching what `Encode` checks and what
+    /// draft-16 §1.4.3 specifies.
+    #[test]
+    fn new_bounds_bytes_not_characters() {
+        let wide = "\u{10FFFF}".repeat(ReasonPhrase::MAX_LEN);
+        let bounded = ReasonPhrase::new(wide);
+
+        assert!(bounded.0.len() <= ReasonPhrase::MAX_LEN);
+        assert!(bounded.0.chars().count() < ReasonPhrase::MAX_LEN);
     }
 }

--- a/moq-transport/src/mlog/events.rs
+++ b/moq-transport/src/mlog/events.rs
@@ -171,11 +171,34 @@ pub struct LogLevelEvent {
     pub message: String,
 }
 
+/// Parameter type carrying an AUTHORIZATION TOKEN.
+///
+/// The same code point in both registries — draft-16 §9.3.1.5 for setup
+/// parameters and §9.2.2.1 for message parameters — so one rule covers both.
+const AUTHORIZATION_TOKEN_PARAM: u64 = 0x3;
+
 // Helper functions to create vector of string pairs from KVPs
 fn key_value_pairs_to_vec(kvps: &[coding::KeyValuePair]) -> Vec<(String, String)> {
     kvps.iter()
-        .map(|kvp| (kvp.key.to_string(), format!("{:?}", kvp.value)))
+        .map(|kvp| (kvp.key.to_string(), render_parameter(kvp)))
         .collect()
+}
+
+/// Render a parameter for the log, redacting bearer credentials.
+///
+/// `Value`'s `Debug` hex-dumps the first 16 bytes, which for an AUTHORIZATION
+/// TOKEN is a prefix of the credential itself. mlog files are written to disk
+/// with no expiry and are served over HTTP by the relay's `--mlog-serve`
+/// endpoint, so that prefix would outlive the session and cross a trust
+/// boundary. The length is kept because it is useful for debugging and
+/// discloses nothing.
+fn render_parameter(kvp: &coding::KeyValuePair) -> String {
+    match (&kvp.value, kvp.key) {
+        (coding::Value::BytesValue(bytes), AUTHORIZATION_TOKEN_PARAM) => {
+            format!("[REDACTED {} bytes]", bytes.len())
+        }
+        (value, _) => format!("{value:?}"),
+    }
 }
 
 fn create_control_message_event(
@@ -831,5 +854,31 @@ mod tests {
             "/example.com/meeting"
         );
         assert_eq!(data.message["subscribe_options"], "Both");
+    }
+
+    /// An AUTHORIZATION TOKEN must not reach the log. mlog files persist on
+    /// disk and are served over HTTP by `--mlog-serve`, so a credential
+    /// prefix written here outlives the session and crosses a trust boundary.
+    #[test]
+    fn authorization_tokens_are_redacted_in_logs() {
+        let secret = b"super-secret-bearer-token-value".to_vec();
+        let kvps = vec![
+            coding::KeyValuePair::new_bytes(0x3, secret.clone()),
+            coding::KeyValuePair::new_bytes(0x1, b"/tenant/live".to_vec()),
+            coding::KeyValuePair::new_int(0x2, 100),
+        ];
+
+        let rendered = key_value_pairs_to_vec(&kvps);
+
+        let token = &rendered[0].1;
+        assert_eq!(token, &format!("[REDACTED {} bytes]", secret.len()));
+        // No byte of the credential, in any rendering.
+        assert!(!token.contains("73"), "{token} looks like a hex dump");
+        assert!(!token.contains("super"), "{token}");
+
+        // Other parameters are untouched: PATH is not a credential and is
+        // needed for debugging.
+        assert!(rendered[1].1.contains("2F"), "path should still be dumped");
+        assert_eq!(rendered[2].1, "100");
     }
 }

--- a/moq-transport/src/session/mod.rs
+++ b/moq-transport/src/session/mod.rs
@@ -190,6 +190,15 @@ pub struct Session {
     /// Normally the QUIC connection ID hex, which the peer also observes and which names this
     /// connection's qlog and mlog files.
     session_id: SessionId,
+
+    /// Setup parameters the peer sent in CLIENT_SETUP.
+    ///
+    /// Retained verbatim so the application layer can read parameters the
+    /// transport does not interpret itself — notably AUTHORIZATION TOKEN
+    /// (draft-16 §9.3.1.5), which the relay's authorization hook decodes.
+    /// Empty for sessions created via `connect()`, which receive
+    /// SERVER_SETUP rather than sending CLIENT_SETUP.
+    setup_params: KeyValuePairs,
 }
 
 impl Session {
@@ -308,6 +317,26 @@ impl Session {
     /// files and matches what the peer observes.
     pub fn session_id(&self) -> &SessionId {
         &self.session_id
+    }
+
+    /// Returns the CLIENT_SETUP parameters sent by the peer.
+    ///
+    /// Only populated for server-side sessions created via [`accept`]; sessions
+    /// created via [`connect`] return an empty set. Parameters the transport
+    /// interprets itself (PATH, MAX_REQUEST_ID) are present here too, but the
+    /// primary consumer is the application layer reading parameters the
+    /// transport deliberately does not act on, such as AUTHORIZATION TOKEN
+    /// (draft-16 §9.3.1.5).
+    ///
+    /// The parameter list is returned as decoded, so repeated keys — which
+    /// AUTHORIZATION TOKEN explicitly permits (§9.2.2.1) — are all present.
+    /// Use direct iteration rather than [`KeyValuePairs::get`], which returns
+    /// only the first match.
+    ///
+    /// [`accept`]: Self::accept
+    /// [`connect`]: Self::connect
+    pub fn setup_params(&self) -> &KeyValuePairs {
+        &self.setup_params
     }
 
     /// Log a control message with structured fields for observability.
@@ -566,6 +595,8 @@ impl Session {
         }
     }
 
+    // Every argument is independent session state with no natural grouping;
+    // bundling them into a struct would only move the same list one level out.
     #[allow(clippy::too_many_arguments)]
     fn new(
         webtransport: web_transport::Session,
@@ -575,6 +606,7 @@ impl Session {
         mlog: Option<mlog::MlogWriter>,
         transport: Transport,
         connection_path: Option<String>,
+        setup_params: KeyValuePairs,
         request_id: RequestId,
     ) -> (Self, Option<Publisher>, Option<Subscriber>) {
         let outgoing = Queue::default().split();
@@ -615,6 +647,7 @@ impl Session {
             transport,
             connection_path,
             session_id,
+            setup_params,
         };
 
         (session, publisher, subscriber)
@@ -777,7 +810,17 @@ impl Session {
         let request_id =
             RequestId::new_with_session_id(session_id.clone(), 0, peer_max, our_max_request_id, 1);
         let session = Session::new(
-            session, session_id, sender, recver, mlog, transport, path, request_id,
+            session,
+            session_id,
+            sender,
+            recver,
+            mlog,
+            transport,
+            path,
+            // Outbound sessions send CLIENT_SETUP rather than receiving one,
+            // so there are no peer setup parameters to retain.
+            KeyValuePairs::default(),
+            request_id,
         );
         let publisher = session.1.ok_or(SessionError::Internal)?;
         let subscriber = session.2.ok_or(SessionError::Internal)?;
@@ -944,6 +987,7 @@ impl Session {
             mlog,
             transport,
             connection_path,
+            client.params,
             request_id,
         ))
     }

--- a/moq-transport/src/session/mod.rs
+++ b/moq-transport/src/session/mod.rs
@@ -45,7 +45,7 @@ use futures::{stream::FuturesUnordered, StreamExt};
 use request_id::max_request_id_from_params;
 use std::sync::{Arc, Mutex};
 
-use crate::coding::{KeyValuePairs, Value};
+use crate::coding::{KeyValuePair, KeyValuePairs, Value};
 use crate::message::Message;
 use crate::mlog;
 use crate::watch::Queue;
@@ -193,7 +193,7 @@ pub struct Session {
 
     /// Setup parameters the peer sent in CLIENT_SETUP.
     ///
-    /// Retained verbatim so the application layer can read parameters the
+    /// Retained in decoded form so the application layer can read parameters the
     /// transport does not interpret itself — notably AUTHORIZATION TOKEN
     /// (draft-16 §9.3.1.5), which the relay's authorization hook decodes.
     /// Empty for sessions created via `connect()`, which receive
@@ -695,6 +695,25 @@ impl Session {
         .await
     }
 
+    /// Create an outbound/client connection carrying authorization tokens in
+    /// CLIENT_SETUP.
+    pub async fn connect_with_tokens(
+        session: web_transport::Session,
+        mlog_path: Option<PathBuf>,
+        transport: Transport,
+        tokens: Vec<setup::AuthorizationToken>,
+    ) -> Result<(Session, Publisher, Subscriber), SessionError> {
+        Self::connect_with_config_and_session_id_and_tokens(
+            session,
+            SessionId::generate(),
+            mlog_path,
+            transport,
+            SessionConfig::default(),
+            tokens,
+        )
+        .await
+    }
+
     /// Create an outbound/client QUIC connection with explicit session configuration.
     ///
     /// Generates a local [`SessionId`] fallback. Use
@@ -708,12 +727,13 @@ impl Session {
     ) -> Result<(Session, Publisher, Subscriber), SessionError> {
         // TODO(itzmanish): When SessionId becomes mandatory in the next breaking API, make
         // `connect_with_config` accept it and remove `connect_with_config_and_session_id`.
-        Self::connect_with_config_and_session_id(
+        Self::connect_with_config_and_session_id_and_tokens(
             session,
             SessionId::generate(),
             mlog_path,
             transport,
             config,
+            Vec::new(),
         )
         .await
     }
@@ -727,6 +747,47 @@ impl Session {
         mlog_path: Option<PathBuf>,
         transport: Transport,
         config: SessionConfig,
+    ) -> Result<(Session, Publisher, Subscriber), SessionError> {
+        Self::connect_with_config_and_session_id_and_tokens(
+            session,
+            session_id,
+            mlog_path,
+            transport,
+            config,
+            Vec::new(),
+        )
+        .await
+    }
+
+    /// Create an outbound/client connection with explicit session
+    /// configuration and authorization tokens.
+    pub async fn connect_with_config_and_tokens(
+        session: web_transport::Session,
+        mlog_path: Option<PathBuf>,
+        transport: Transport,
+        config: SessionConfig,
+        tokens: Vec<setup::AuthorizationToken>,
+    ) -> Result<(Session, Publisher, Subscriber), SessionError> {
+        Self::connect_with_config_and_session_id_and_tokens(
+            session,
+            SessionId::generate(),
+            mlog_path,
+            transport,
+            config,
+            tokens,
+        )
+        .await
+    }
+
+    /// Create an outbound/client connection with explicit configuration,
+    /// correlation ID, and authorization tokens.
+    pub async fn connect_with_config_and_session_id_and_tokens(
+        session: web_transport::Session,
+        session_id: SessionId,
+        mlog_path: Option<PathBuf>,
+        transport: Transport,
+        config: SessionConfig,
+        tokens: Vec<setup::AuthorizationToken>,
     ) -> Result<(Session, Publisher, Subscriber), SessionError> {
         let url = session.url().clone();
         let url_path = url.path();
@@ -779,6 +840,13 @@ impl Session {
             setup::ParameterType::MaxRequestId.into(),
             our_max_request_id,
         );
+
+        for token in tokens {
+            params.0.push(KeyValuePair::new_bytes(
+                setup::ParameterType::AuthorizationToken.into(),
+                token.encode_value()?,
+            ));
+        }
 
         let client = setup::Client { params };
 

--- a/moq-transport/src/session/published_namespace.rs
+++ b/moq-transport/src/session/published_namespace.rs
@@ -29,6 +29,12 @@ pub struct PublishedNamespace {
 
     ok: bool,
     error: Option<ServeError>,
+
+    /// REQUEST_ERROR code to send on drop when the publish was never accepted.
+    /// `None` falls back to UNINTERESTED, the default for a relay that simply
+    /// declined the namespace. Set by [`reject`](Self::reject) so callers can
+    /// state a specific reason such as UNAUTHORIZED.
+    error_code: Option<u64>,
 }
 
 impl PublishedNamespace {
@@ -48,6 +54,7 @@ impl PublishedNamespace {
             info,
             ok: false,
             error: None,
+            error_code: None,
             state: send,
         };
         let recv = PublishedNamespaceRecv {
@@ -91,8 +98,34 @@ impl PublishedNamespace {
     }
 
     /// Reject the PUBLISH_NAMESPACE; the error is sent on drop.
+    ///
+    /// The REQUEST_ERROR carries UNINTERESTED. Use [`reject`](Self::reject) to
+    /// send a specific error code such as UNAUTHORIZED.
     pub fn close(mut self, err: ServeError) -> Result<(), ServeError> {
         self.error = Some(err);
+        Ok(())
+    }
+
+    /// Reject the PUBLISH_NAMESPACE with an explicit REQUEST_ERROR code
+    /// (draft-16 §9.8); the error is sent on drop.
+    ///
+    /// Mirrors [`SubscribedNamespace::reject`], letting a caller distinguish
+    /// "not interested" from "not permitted". Once the publish has been
+    /// accepted with [`ok`](Self::ok) the code is ignored: acceptance is
+    /// revoked with PUBLISH_NAMESPACE_CANCEL, which carries the error code
+    /// derived from `reason` instead.
+    ///
+    /// [`SubscribedNamespace::reject`]: super::SubscribedNamespace::reject
+    pub fn reject(mut self, error_code: u64, reason: &str) -> Result<(), ServeError> {
+        self.error = Some(ServeError::Closed(error_code));
+        self.error_code = Some(error_code);
+        tracing::debug!(
+            namespace = %self.info.namespace,
+            request_id = self.info.request_id,
+            error_code,
+            reason,
+            "rejecting PUBLISH_NAMESPACE"
+        );
         Ok(())
     }
 }
@@ -127,7 +160,9 @@ impl Drop for PublishedNamespace {
                 "publish_namespace",
                 message::RequestError {
                     id: self.info.request_id,
-                    error_code: RequestErrorCode::Uninterested as u64,
+                    error_code: self
+                        .error_code
+                        .unwrap_or(RequestErrorCode::Uninterested as u64),
                     retry_interval: 0,
                     reason: ReasonPhrase(err.to_string()),
                 },

--- a/moq-transport/src/session/published_namespace.rs
+++ b/moq-transport/src/session/published_namespace.rs
@@ -35,6 +35,13 @@ pub struct PublishedNamespace {
     /// declined the namespace. Set by [`reject`](Self::reject) so callers can
     /// state a specific reason such as UNAUTHORIZED.
     error_code: Option<u64>,
+
+    /// Reason phrase to send on drop, when the caller supplied one.
+    ///
+    /// Without this the peer receives the `Display` of the internal
+    /// [`ServeError`] — for a coded rejection that renders as
+    /// `"closed, code=N"`, which restates the code and tells the peer nothing.
+    reason: Option<String>,
 }
 
 impl PublishedNamespace {
@@ -55,6 +62,7 @@ impl PublishedNamespace {
             ok: false,
             error: None,
             error_code: None,
+            reason: None,
             state: send,
         };
         let recv = PublishedNamespaceRecv {
@@ -110,15 +118,25 @@ impl PublishedNamespace {
     /// (draft-16 §9.8); the error is sent on drop.
     ///
     /// Mirrors [`SubscribedNamespace::reject`], letting a caller distinguish
-    /// "not interested" from "not permitted". Once the publish has been
-    /// accepted with [`ok`](Self::ok) the code is ignored: acceptance is
-    /// revoked with PUBLISH_NAMESPACE_CANCEL, which carries the error code
-    /// derived from `reason` instead.
+    /// "not interested" from "not permitted".
+    ///
+    /// `reason` is sent to the peer in the Reason Phrase, so it must describe
+    /// the rejection without disclosing anything the peer is not entitled to
+    /// know. It is truncated to [`ReasonPhrase::MAX_LEN`], since a longer
+    /// phrase fails to encode and would take the whole message with it.
+    ///
+    /// Calling this after [`ok`](Self::ok) is permitted and revokes the
+    /// acceptance: the peer receives PUBLISH_NAMESPACE_CANCEL (§9.24) instead
+    /// of REQUEST_ERROR, carrying this same code and reason. §9.24 draws its
+    /// codes from the same registry as REQUEST_ERROR, and expiry of
+    /// authorization is one of the reasons the draft names for a cancel, so
+    /// UNAUTHORIZED is meaningful there.
     ///
     /// [`SubscribedNamespace::reject`]: super::SubscribedNamespace::reject
     pub fn reject(mut self, error_code: u64, reason: &str) -> Result<(), ServeError> {
         self.error = Some(ServeError::Closed(error_code));
         self.error_code = Some(error_code);
+        self.reason = Some(reason.to_string());
         tracing::debug!(
             namespace = %self.info.namespace,
             request_id = self.info.request_id,
@@ -142,29 +160,50 @@ impl Drop for PublishedNamespace {
     fn drop(&mut self) {
         let err = self.error.clone().unwrap_or(ServeError::Done);
 
-        if self.state.lock().done {
-            return;
-        }
+        // A caller-supplied reason wins over the error's own `Display`, which
+        // for a coded rejection is only `"closed, code=N"` and so tells the
+        // peer nothing the code did not already.
+        let reason = self.reason.clone().unwrap_or_else(|| err.to_string());
+
+        // An explicit `reject` code wins; otherwise the namespace is simply no
+        // longer wanted. Deriving the default from `err` would make a clean
+        // teardown report INTERNAL_ERROR, since that is code 0 and what
+        // `ServeError::Done` renders as.
+        let error_code = self
+            .error_code
+            .unwrap_or(RequestErrorCode::Uninterested as u64);
 
         if self.ok {
+            // Already answered with REQUEST_OK, so what is owed now is a
+            // revocation of that acceptance — and only if there is still
+            // something to revoke. A peer that has sent PUBLISH_NAMESPACE_DONE
+            // has withdrawn already.
+            if self.state.lock().done {
+                return;
+            }
+
             // Accepted: send PUBLISH_NAMESPACE_CANCEL to revoke acceptance
             // (draft-16 §9.24).  Carries Request ID, not the namespace.
             self.session.send_message(message::PublishNamespaceCancel {
                 id: self.info.request_id,
-                error_code: err.code(),
-                reason_phrase: ReasonPhrase(err.to_string()),
+                error_code,
+                reason_phrase: ReasonPhrase::new(reason),
             });
         } else {
-            // Never accepted: send REQUEST_ERROR (draft-16 §9.8).
+            // Never answered. Draft-16 §6.2: "A subscriber MUST send exactly
+            // one REQUEST_OK or REQUEST_ERROR in response to a
+            // PUBLISH_NAMESPACE." A peer withdrawing does not discharge that,
+            // so this is sent even once PUBLISH_NAMESPACE_DONE has arrived —
+            // otherwise a publisher that pipelines DONE behind its
+            // PUBLISH_NAMESPACE, which it may do while the relay is still
+            // awaiting authorization, gets no response at all.
             self.session.send_request_error(
                 "publish_namespace",
                 message::RequestError {
                     id: self.info.request_id,
-                    error_code: self
-                        .error_code
-                        .unwrap_or(RequestErrorCode::Uninterested as u64),
+                    error_code,
                     retry_interval: 0,
-                    reason: ReasonPhrase(err.to_string()),
+                    reason: ReasonPhrase::new(reason),
                 },
             );
         }
@@ -192,6 +231,252 @@ impl PublishedNamespaceRecv {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use crate::coding::{Decode, Encode, TrackNamespace};
+    use crate::session::{PendingRequests, RequestId, Subscriber};
+    use crate::watch::Queue;
+
+    /// Build a `PublishedNamespace` wired to a queue the test can drain, so
+    /// the bytes destined for the peer are observable.
+    ///
+    /// The returned handle is a *clone* of the sending half rather than the
+    /// receiving half: `Queue::close` needs `lock_mut`, which stops working
+    /// once every drop guard is gone, and the guard the `Subscriber` holds
+    /// dies with the `PublishedNamespace` whose `Drop` we are trying to
+    /// observe. Cloning shares the guard, so the queue stays readable
+    /// afterwards.
+    fn published() -> (PublishedNamespace, Queue<message::Message>) {
+        let (send, _recv, observer) = published_with_recv();
+        (send, observer)
+    }
+
+    /// As [`published`], but also yields the receive half so a test can
+    /// simulate the peer sending PUBLISH_NAMESPACE_DONE.
+    fn published_with_recv() -> (
+        PublishedNamespace,
+        PublishedNamespaceRecv,
+        Queue<message::Message>,
+    ) {
+        let outgoing = Queue::<message::Message>::default();
+        let observer = outgoing.clone();
+        let namespace_open = Queue::default().split();
+
+        let subscriber = Subscriber::new(
+            outgoing,
+            namespace_open.0,
+            None,
+            RequestId::new(0, 100, 100, 1),
+            PendingRequests::default(),
+        );
+
+        let (send, recv) =
+            PublishedNamespace::new(subscriber, 42, TrackNamespace::from_utf8_path("sports"));
+
+        (send, recv, observer)
+    }
+
+    /// The rejection the peer receives, as (error_code, reason_phrase).
+    fn sent_request_error(outgoing: Queue<message::Message>) -> (u64, String) {
+        let sent = outgoing.close();
+        let error = sent
+            .into_iter()
+            .find_map(|msg| match msg {
+                message::Message::RequestError(err) => Some(err),
+                _ => None,
+            })
+            .expect("a REQUEST_ERROR should have been sent");
+
+        (error.error_code, error.reason.0)
+    }
+
+    /// The revocation the peer receives, as (error_code, reason_phrase).
+    ///
+    /// A separate matcher because PUBLISH_NAMESPACE_CANCEL is a different
+    /// message type; `sent_request_error` is structurally unable to see it,
+    /// which is how the accepted-then-revoked branch went untested.
+    fn sent_cancel(outgoing: Queue<message::Message>) -> (u64, String) {
+        let sent = outgoing.close();
+        let cancel = sent
+            .into_iter()
+            .find_map(|msg| match msg {
+                message::Message::PublishNamespaceCancel(cancel) => Some(cancel),
+                _ => None,
+            })
+            .expect("a PUBLISH_NAMESPACE_CANCEL should have been sent");
+
+        (cancel.error_code, cancel.reason_phrase.0)
+    }
+
+    /// Whatever was sent, decoded from its encoded bytes.
+    ///
+    /// The queue assertions stop at the in-memory message; this confirms the
+    /// reason survives encoding, which is what actually reaches the peer.
+    fn round_trip(outgoing: Queue<message::Message>) -> message::RequestError {
+        let sent = outgoing.close();
+        let error = sent
+            .into_iter()
+            .find_map(|msg| match msg {
+                message::Message::RequestError(err) => Some(err),
+                _ => None,
+            })
+            .expect("a REQUEST_ERROR should have been sent");
+
+        let mut buf = Vec::new();
+        error.encode(&mut buf).expect("must encode");
+
+        let mut cursor = &buf[..];
+        message::RequestError::decode(&mut cursor).expect("must decode")
+    }
+
+    /// The reason has to reach the peer, not just the local log. Without this
+    /// the phrase is the `Display` of `ServeError::Closed`, i.e.
+    /// `"closed, code=1"`, which merely restates the code.
+    #[test]
+    fn reject_sends_the_reason_to_the_peer() {
+        let (published, outgoing) = published();
+        published.reject(0x1, "unauthorized").unwrap();
+
+        let (code, reason) = sent_request_error(outgoing);
+        assert_eq!(code, 0x1);
+        assert_eq!(reason, "unauthorized");
+    }
+
+    /// The queue holds a struct; the peer receives bytes. Confirm the reason
+    /// survives the encode/decode round trip.
+    #[test]
+    fn the_reason_survives_encoding() {
+        let (published, outgoing) = published();
+        published.reject(0x1, "unauthorized").unwrap();
+
+        let decoded = round_trip(outgoing);
+        assert_eq!(decoded.id, 42);
+        assert_eq!(decoded.error_code, 0x1);
+        assert_eq!(decoded.reason.0, "unauthorized");
+    }
+
+    /// Rejecting an already-accepted namespace revokes it with
+    /// PUBLISH_NAMESPACE_CANCEL, carrying the same code and reason. §9.24
+    /// draws its codes from the REQUEST_ERROR registry, so UNAUTHORIZED is
+    /// meaningful here.
+    #[test]
+    fn rejecting_after_accepting_revokes_with_the_same_code_and_reason() {
+        let (mut published, outgoing) = published();
+        published.ok().unwrap();
+        published.reject(0x1, "unauthorized").unwrap();
+
+        let (code, reason) = sent_cancel(outgoing);
+        assert_eq!(code, 0x1);
+        assert_eq!(reason, "unauthorized");
+    }
+
+    /// A clean teardown of an accepted namespace is not an internal error.
+    /// Deriving the code from `ServeError::Done` would send 0x0, which
+    /// §13.4.2 defines as INTERNAL_ERROR.
+    #[test]
+    fn a_clean_teardown_does_not_report_an_internal_error() {
+        let (mut published, outgoing) = published();
+        published.ok().unwrap();
+        drop(published);
+
+        let (code, _) = sent_cancel(outgoing);
+        assert_ne!(code, 0x0, "0x0 is INTERNAL_ERROR");
+        assert_eq!(code, RequestErrorCode::Uninterested as u64);
+    }
+
+    /// Draft-16 §6.2: "A subscriber MUST send exactly one REQUEST_OK or
+    /// REQUEST_ERROR in response to a PUBLISH_NAMESPACE."
+    ///
+    /// A publisher may pipeline PUBLISH_NAMESPACE_DONE behind its
+    /// PUBLISH_NAMESPACE, and the relay awaits authorization before
+    /// answering — so the withdrawal can land first. It does not discharge
+    /// the obligation to answer.
+    #[test]
+    fn a_withdrawal_before_the_response_does_not_suppress_it() {
+        let (published, recv, outgoing) = published_with_recv();
+
+        // The peer withdraws before we have answered.
+        recv.recv_done().unwrap();
+        published.reject(0x1, "unauthorized").unwrap();
+
+        let (code, reason) = sent_request_error(outgoing);
+        assert_eq!(code, 0x1);
+        assert_eq!(reason, "unauthorized");
+    }
+
+    /// Once accepted, a withdrawal *does* settle it: the response was already
+    /// sent, and there is nothing left to revoke.
+    #[test]
+    fn a_withdrawal_after_accepting_suppresses_the_cancel() {
+        let (mut published, recv, outgoing) = published_with_recv();
+        published.ok().unwrap();
+        recv.recv_done().unwrap();
+        drop(published);
+
+        let sent = outgoing.close();
+        assert!(
+            !sent
+                .iter()
+                .any(|msg| matches!(msg, message::Message::PublishNamespaceCancel(_))),
+            "nothing to revoke once the peer has withdrawn"
+        );
+    }
+
+    /// `close` has no reason of its own, so it keeps falling back to the
+    /// error's own rendering and to UNINTERESTED.
+    #[test]
+    fn close_falls_back_to_the_error_rendering() {
+        let (published, outgoing) = published();
+        published.close(ServeError::NotFound).unwrap();
+
+        let (code, reason) = sent_request_error(outgoing);
+        assert_eq!(code, RequestErrorCode::Uninterested as u64);
+        assert_eq!(reason, ServeError::NotFound.to_string());
+    }
+
+    /// Dropping without a verdict still tells the peer something.
+    #[test]
+    fn plain_drop_still_sends_an_error() {
+        let (published, outgoing) = published();
+        drop(published);
+
+        let (code, _) = sent_request_error(outgoing);
+        assert_eq!(code, RequestErrorCode::Uninterested as u64);
+    }
+
+    /// A phrase longer than `ReasonPhrase::MAX_LEN` fails to encode, which
+    /// would drop the whole REQUEST_ERROR and leave the peer with nothing.
+    #[test]
+    fn an_oversized_reason_is_truncated_rather_than_dropped() {
+        let (published, outgoing) = published();
+        published
+            .reject(0x1, &"x".repeat(ReasonPhrase::MAX_LEN * 2))
+            .unwrap();
+
+        let (_, reason) = sent_request_error(outgoing);
+        assert_eq!(reason.len(), ReasonPhrase::MAX_LEN);
+
+        // And it still encodes, which is the point of the bound.
+        let mut buf = Vec::new();
+        ReasonPhrase(reason).encode(&mut buf).expect("must encode");
+    }
+
+    /// An over-long *fallback* reason must be bounded too. `close` takes a
+    /// `ServeError`, whose `Internal`/`NotImplemented` variants carry an
+    /// arbitrary `String`, and an unencodable phrase on the control stream
+    /// tears down the session rather than merely losing the message.
+    #[test]
+    fn an_oversized_fallback_reason_is_also_bounded() {
+        let (published, outgoing) = published();
+        published
+            .close(ServeError::Internal("y".repeat(ReasonPhrase::MAX_LEN * 4)))
+            .unwrap();
+
+        let (_, reason) = sent_request_error(outgoing);
+        assert!(reason.len() <= ReasonPhrase::MAX_LEN);
+
+        let mut buf = Vec::new();
+        ReasonPhrase(reason).encode(&mut buf).expect("must encode");
+    }
 
     #[test]
     fn recv_done_marks_namespace_done_before_drop() {

--- a/moq-transport/src/session/published_namespace.rs
+++ b/moq-transport/src/session/published_namespace.rs
@@ -107,8 +107,10 @@ impl PublishedNamespace {
 
     /// Reject the PUBLISH_NAMESPACE; the error is sent on drop.
     ///
-    /// The REQUEST_ERROR carries UNINTERESTED. Use [`reject`](Self::reject) to
-    /// send a specific error code such as UNAUTHORIZED.
+    /// Before [`ok`](Self::ok), the peer receives REQUEST_ERROR with
+    /// UNINTERESTED. After `ok`, it receives PUBLISH_NAMESPACE_CANCEL with the
+    /// same code. Use [`reject`](Self::reject) to send a specific error code
+    /// such as UNAUTHORIZED.
     pub fn close(mut self, err: ServeError) -> Result<(), ServeError> {
         self.error = Some(err);
         Ok(())
@@ -233,7 +235,7 @@ mod tests {
     use super::*;
 
     use crate::coding::{Decode, Encode, TrackNamespace};
-    use crate::session::{PendingRequests, RequestId, Subscriber};
+    use crate::session::{PendingRequests, RequestId, SessionId, Subscriber};
     use crate::watch::Queue;
 
     /// Build a `PublishedNamespace` wired to a queue the test can drain, so
@@ -267,6 +269,7 @@ mod tests {
             None,
             RequestId::new(0, 100, 100, 1),
             PendingRequests::default(),
+            SessionId::generate(),
         );
 
         let (send, recv) =

--- a/moq-transport/src/session/publisher.rs
+++ b/moq-transport/src/session/publisher.rs
@@ -245,6 +245,36 @@ impl Publisher {
         Self::connect_with_session_id(session, SessionId::generate(), transport).await
     }
 
+    /// Connect while presenting authorization tokens in CLIENT_SETUP.
+    pub async fn connect_with_tokens(
+        session: web_transport::Session,
+        transport: super::Transport,
+        tokens: Vec<crate::setup::AuthorizationToken>,
+    ) -> Result<(Session, Publisher), SessionError> {
+        let (session, publisher, _) =
+            Session::connect_with_tokens(session, None, transport, tokens).await?;
+        Ok((session, publisher))
+    }
+
+    /// Connect with a peer-observed correlation ID while presenting authorization tokens.
+    pub async fn connect_with_session_id_and_tokens(
+        session: web_transport::Session,
+        session_id: SessionId,
+        transport: super::Transport,
+        tokens: Vec<crate::setup::AuthorizationToken>,
+    ) -> Result<(Session, Publisher), SessionError> {
+        let (session, publisher, _) = Session::connect_with_config_and_session_id_and_tokens(
+            session,
+            session_id,
+            None,
+            transport,
+            SessionConfig::default(),
+            tokens,
+        )
+        .await?;
+        Ok((session, publisher))
+    }
+
     /// Create a configured publisher session using a generated local correlation ID.
     ///
     /// Use [`Self::connect_with_config_and_session_id`] when a peer-observed QUIC connection ID is

--- a/moq-transport/src/session/subscribed.rs
+++ b/moq-transport/src/session/subscribed.rs
@@ -438,7 +438,7 @@ impl Drop for Subscribed {
                 id: self.info.id,
                 status_code: Self::publish_done_code(&err),
                 stream_count,
-                reason: ReasonPhrase(err.to_string()),
+                reason: ReasonPhrase::new(err.to_string()),
             });
         } else {
             // Draft-16 §9.8: subscription rejection uses REQUEST_ERROR, not the
@@ -449,7 +449,7 @@ impl Drop for Subscribed {
                     id: self.info.id,
                     error_code: Self::request_error_code(&err),
                     retry_interval: 0,
-                    reason: ReasonPhrase(err.to_string()),
+                    reason: ReasonPhrase::new(err.to_string()),
                 },
             );
             self.forwarder.publisher.drop_subscribe(self.info.id);

--- a/moq-transport/src/session/subscribed_namespace.rs
+++ b/moq-transport/src/session/subscribed_namespace.rs
@@ -379,7 +379,7 @@ fn request_error(id: u64, error_code: u64, reason: &str) -> Message {
         id,
         error_code,
         retry_interval: 0,
-        reason: ReasonPhrase(reason.to_string()),
+        reason: ReasonPhrase::new(reason),
     }
     .into()
 }

--- a/moq-transport/src/session/subscriber.rs
+++ b/moq-transport/src/session/subscriber.rs
@@ -333,6 +333,36 @@ impl Subscriber {
         Self::connect_with_session_id(session, SessionId::generate(), transport).await
     }
 
+    /// Connect while presenting authorization tokens in CLIENT_SETUP.
+    pub async fn connect_with_tokens(
+        session: web_transport::Session,
+        transport: super::Transport,
+        tokens: Vec<crate::setup::AuthorizationToken>,
+    ) -> Result<(Session, Self), SessionError> {
+        let (session, _, subscriber) =
+            Session::connect_with_tokens(session, None, transport, tokens).await?;
+        Ok((session, subscriber))
+    }
+
+    /// Connect with a peer-observed correlation ID while presenting authorization tokens.
+    pub async fn connect_with_session_id_and_tokens(
+        session: web_transport::Session,
+        session_id: SessionId,
+        transport: super::Transport,
+        tokens: Vec<crate::setup::AuthorizationToken>,
+    ) -> Result<(Session, Self), SessionError> {
+        let (session, _, subscriber) = Session::connect_with_config_and_session_id_and_tokens(
+            session,
+            session_id,
+            None,
+            transport,
+            SessionConfig::default(),
+            tokens,
+        )
+        .await?;
+        Ok((session, subscriber))
+    }
+
     /// Create a configured subscriber session using a generated local correlation ID.
     ///
     /// Use [`Self::connect_with_config_and_session_id`] when a peer-observed QUIC connection ID is

--- a/moq-transport/src/session/track_status_requested.rs
+++ b/moq-transport/src/session/track_status_requested.rs
@@ -32,7 +32,7 @@ impl TrackStatusRequested {
                 id: self.request_msg.id,
                 error_code,
                 retry_interval: 0,
-                reason: ReasonPhrase(error_message.to_string()),
+                reason: ReasonPhrase::new(error_message),
             },
         );
         Ok(())

--- a/moq-transport/src/setup/authorization_token.rs
+++ b/moq-transport/src/setup/authorization_token.rs
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2026 Cloudflare Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::fmt;
+
+use crate::coding::{BoundsExceeded, Encode, EncodeError, VarInt};
+
+/// An opaque authorization token sent inline during session setup.
+///
+/// The token type identifies how the receiver interprets `value`; this type
+/// deliberately has no knowledge of CAT or any other token format.
+pub struct AuthorizationToken {
+    token_type: VarInt,
+    value: Vec<u8>,
+}
+
+impl AuthorizationToken {
+    /// Create a token with a MoQT token type and opaque value.
+    pub fn new(token_type: u64, value: Vec<u8>) -> Result<Self, BoundsExceeded> {
+        Ok(Self {
+            token_type: token_type.try_into()?,
+            value,
+        })
+    }
+
+    pub(crate) fn encode_value(&self) -> Result<Vec<u8>, EncodeError> {
+        let mut encoded = Vec::new();
+        VarInt::from(3u8).encode(&mut encoded)?; // USE_VALUE
+        self.token_type.encode(&mut encoded)?;
+        encoded.extend_from_slice(&self.value);
+        Ok(encoded)
+    }
+}
+
+impl fmt::Debug for AuthorizationToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AuthorizationToken")
+            .field("token_type", &self.token_type)
+            .field(
+                "value",
+                &format_args!("<redacted, {} bytes>", self.value.len()),
+            )
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encodes_an_inline_token_without_a_value_length() {
+        let token = AuthorizationToken::new(1, vec![0xaa, 0xbb]).unwrap();
+
+        assert_eq!(token.encode_value().unwrap(), [0x03, 0x01, 0xaa, 0xbb]);
+    }
+
+    #[test]
+    fn debug_redacts_the_token_value() {
+        let token = AuthorizationToken::new(1, b"secret".to_vec()).unwrap();
+        let debug = format!("{token:?}");
+
+        assert!(debug.contains("<redacted, 6 bytes>"));
+        assert!(!debug.contains("secret"));
+    }
+}

--- a/moq-transport/src/setup/client.rs
+++ b/moq-transport/src/setup/client.rs
@@ -10,16 +10,41 @@
 
 use crate::coding::{Decode, DecodeError, Encode, EncodeError, KeyValuePairs};
 use bytes::Buf as _;
+use std::fmt;
 
 /// Sent by the client to set up the session.
 ///
 /// Message Type = 0x20 (unchanged from draft-11+).
 /// The payload contains only setup parameters; version is agreed via ALPN.
-#[derive(Debug)]
 pub struct Client {
     /// Setup parameters (PATH, AUTHORITY, MAX_REQUEST_ID,
     /// MAX_AUTH_TOKEN_CACHE_SIZE, AUTHORIZATION_TOKEN, MOQT_IMPLEMENTATION, …).
     pub params: KeyValuePairs,
+}
+
+impl fmt::Debug for Client {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        struct Params<'a>(&'a KeyValuePairs);
+
+        impl fmt::Debug for Params<'_> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                let mut list = f.debug_list();
+                let Params(params) = self;
+                for param in &params.0 {
+                    if param.key == u64::from(super::ParameterType::AuthorizationToken) {
+                        list.entry(&format_args!("{{{}: <redacted>}}", param.key));
+                    } else {
+                        list.entry(param);
+                    }
+                }
+                list.finish()
+            }
+        }
+
+        f.debug_struct("Client")
+            .field("params", &Params(&self.params))
+            .finish()
+    }
 }
 
 impl Decode for Client {
@@ -63,7 +88,10 @@ impl Encode for Client {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::setup::{ParameterType, Version};
+    use crate::{
+        coding::KeyValuePair,
+        setup::{AuthorizationToken, ParameterType, Version},
+    };
     use bytes::BytesMut;
 
     #[test]
@@ -96,6 +124,42 @@ mod tests {
 
         let decoded = Client::decode(&mut buf).unwrap();
         assert_eq!(decoded.params, client.params);
+    }
+
+    #[test]
+    fn repeated_authorization_tokens_round_trip_and_are_redacted() {
+        let mut params = KeyValuePairs::default();
+        params.set_bytesvalue(ParameterType::Path.into(), b"clock".to_vec());
+        params.set_intvalue(ParameterType::MaxRequestId.into(), 100);
+        for token in [
+            AuthorizationToken::new(1, b"first-secret".to_vec()).unwrap(),
+            AuthorizationToken::new(0x63346d, b"second-secret".to_vec()).unwrap(),
+        ] {
+            params.0.push(KeyValuePair::new_bytes(
+                ParameterType::AuthorizationToken.into(),
+                token.encode_value().unwrap(),
+            ));
+        }
+        let client = Client { params };
+        let debug = format!("{client:?}");
+        assert!(!debug.contains("first-secret"));
+        assert!(!debug.contains("second-secret"));
+        assert_eq!(debug.matches("<redacted>").count(), 2);
+
+        let mut buf = BytesMut::new();
+        client.encode(&mut buf).unwrap();
+        let decoded = Client::decode(&mut buf).unwrap();
+
+        assert_eq!(decoded.params, client.params);
+        assert_eq!(
+            decoded
+                .params
+                .0
+                .iter()
+                .filter(|param| param.key == u64::from(ParameterType::AuthorizationToken))
+                .count(),
+            2
+        );
     }
 
     #[test]

--- a/moq-transport/src/setup/mod.rs
+++ b/moq-transport/src/setup/mod.rs
@@ -8,11 +8,13 @@
 //! The client sends the [Client] message and the server responds with the [Server] message.
 //! Both sides negotate the [Version] and [Role].
 
+mod authorization_token;
 mod client;
 mod param_types;
 mod server;
 mod version;
 
+pub use authorization_token::*;
 pub use client::*;
 pub use param_types::*;
 pub use server::*;

--- a/moq-transport/src/watch/queue.rs
+++ b/moq-transport/src/watch/queue.rs
@@ -10,6 +10,14 @@ pub struct Queue<T> {
     state: State<VecDeque<(T, Option<oneshot::Sender<()>>)>>, // store optional notifier per item
 }
 
+/// The queue was closed before the operation could complete.
+///
+/// A named type rather than `()` so a caller can tell from the signature what
+/// went wrong, and so the reason is not lost when the error is propagated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("queue closed")]
+pub struct QueueClosed;
+
 impl<T> Queue<T> {
     /// Push an item onto the queue. Returns Err(item) if the queue has been closed.
     pub fn push(&mut self, item: T) -> Result<(), T> {
@@ -76,23 +84,23 @@ impl<T> Queue<T> {
     }
 
     /// Push an item and wait until it is popped.
-    /// Returns Ok(()) if the item was successfully popped.
-    /// Returns Err(()) if the queue was closed before the item could be confirmed popped.
-    #[allow(clippy::result_unit_err)]
-    pub async fn push_and_wait_until_popped(&mut self, item: T) -> Result<(), ()> {
+    ///
+    /// Returns [`QueueClosed`] if the queue was closed either before the push
+    /// or while waiting for the item to be taken.
+    pub async fn push_and_wait_until_popped(&mut self, item: T) -> Result<(), QueueClosed> {
         // Create a oneshot channel
         let (tx, rx) = oneshot::channel();
 
         // Push the item along with the sender
         match self.state.lock_mut() {
             Some(mut state) => state.push_back((item, Some(tx))),
-            None => return Err(()), // Queue already closed before push
+            None => return Err(QueueClosed), // Queue already closed before push
         }
 
         // Wait until the item is popped.
         // If we receive Canceled, it means the sender was dropped without sending,
         // which indicates the queue was closed while we were waiting.
-        rx.await.map_err(|_| ())
+        rx.await.map_err(|_| QueueClosed)
     }
 
     /// Split the queue into two handles that share the same underlying state.


### PR DESCRIPTION
## Summary

Add scope-configured Common Access Token (CAT) bearer authorization to `moq-relay-ietf`.

- Add a generic `AuthHook` boundary with setup-time authentication and request-time authorization.
- Load independent issuers, audiences, ES256 public-key sets, clock-skew tolerances, and cache lifetimes from each scope's coordinator configuration.
- Authorize CLIENT_SETUP, PUBLISH_NAMESPACE, PUBLISH, SUBSCRIBE, SUBSCRIBE_NAMESPACE, and TRACK_STATUS before lookup, registration, or metadata disclosure.
- Apply authorization to namespace advertisements and per-track SUBSCRIBE_NAMESPACE fan-out.
- Retain decoded CLIENT_SETUP parameters in `moq-transport` and support explicit PUBLISH_NAMESPACE rejection.
- Add generic outbound CLIENT_SETUP token presentation and a repeatable `moq-clock-ietf --auth-token TYPE:BASE64URL` test option.

Scopes without authorization configuration retain their current behavior. Scopes that opt in fail closed if configuration, token decoding, signature validation, or claim evaluation fails.

## Security Model

Signatures are verified once during setup. The established principal is retained for request-time claim evaluation, with expiry checked for each new request. Token values and principal claims are redacted from debug and mlog output, and the relay-owned credential copy is zeroized on drop.

The CAT implementation rejects unsupported or malformed restrictions, duplicate claims, sender-constrained bearer tokens, implausible validity windows, and tokens requiring unsupported mid-session revalidation. Setup signature work is bounded across presented tokens and configured keys.

CAT support is behind the off-by-default `auth-cat` feature. The hook, wire decoder, and enforcement points compile without the feature so an auth-configured scope still fails closed rather than silently running unauthenticated.

## Draft Status

This is a draft because `cat-token` is pinned to commit `df4905bad7ba24a2713746ed9907691eae7bc61b` pending a published release, and the implementation must be updated for the final `moqt` claim shape from [CAT-4-MOQT PR #48](https://github.com/moq-wg/CAT-4-MOQT/pull/48) before landing.

Known limitations:

- Tokens are session-level only; per-request token parameters are not yet plumbed through the transport API.
- Existing subscriptions are not terminated when a token expires; expiry gates admission of new requests.
- Outbound relay-to-relay sessions do not yet present credentials, so protected relay meshes need additional credential plumbing.
- `moq-clock-ietf` exposes bearer values in process arguments and is intended only for testing.

## Testing

- `cargo test --verbose`
- `cargo test -p moq-relay-ietf --features auth-cat`
- `cargo clippy --no-deps`
- `cargo clippy --no-deps --all-targets -p moq-relay-ietf --features auth-cat`
- `cargo fmt --all -- --check`
- `cargo machete`
